### PR TITLE
fix: address PR #12 review findings in runtime-claude.js

### DIFF
--- a/server/runtime-claude.js
+++ b/server/runtime-claude.js
@@ -23,19 +23,24 @@ function dispatch(plan) {
     // Claude-specific extras (passthrough if present on plan)
     if (plan.maxBudgetUsd) args.push('--max-budget-usd', String(plan.maxBudgetUsd));
     if (plan.allowedTools && plan.allowedTools.length) {
-      args.push('--allowedTools', plan.allowedTools.join(' '));
+      args.push('--allowedTools', ...plan.allowedTools);
     }
     if (plan.effort) args.push('--effort', plan.effort);
     if (plan.systemPrompt) args.push('--append-system-prompt', plan.systemPrompt);
-    if (plan.fullAuto) args.push('--dangerously-skip-permissions');
 
     // The prompt
     args.push(plan.message);
 
-    const child = spawn(CLAUDE_CMD, args, {
-      cwd: plan.workingDir || path.resolve(DIR, '..'),
+    const workDir = plan.workingDir || path.resolve(DIR, '..');
+    const spawnCmd = process.platform === 'win32' ? 'cmd.exe' : CLAUDE_CMD;
+    const spawnArgs = process.platform === 'win32'
+      ? ['/d', '/s', '/c', CLAUDE_CMD, ...args]
+      : args;
+
+    const child = spawn(spawnCmd, spawnArgs, {
+      cwd: workDir,
       windowsHide: true,
-      shell: process.platform === 'win32',
+      shell: false,
       timeout: (plan.timeoutSec || 300) * 1000,
     });
 


### PR DESCRIPTION
## Summary

- Use `cmd.exe /d /s /c` spawn pattern on Windows (matches openclaw/edda convention per CLAUDE.md)
- Remove `plan.fullAuto` dead code (`fullAuto` field doesn't exist on DispatchPlan)
- Fix `--allowedTools` to pass each tool as separate arg instead of space-joined string

Fixes findings from [PR #12 review](https://github.com/fagemx/karvi/pull/12#issuecomment-3974878752).

## Test plan

- [x] `node -c server/runtime-claude.js` — syntax OK
- [x] Module exports verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)