### PR TITLE
feat(server): instance manager — multi-tenant process lifecycle (#33)

### DIFF
--- a/server/blackboard-server.js
+++ b/server/blackboard-server.js
@@ -214,13 +214,27 @@ function createServer(ctx, routeHandler) {
       return res.end();
     }
 
+    // Parse URL for route matching (supports query params)
+    const pathname = new URL(req.url, 'http://localhost').pathname;
+
+    // Health check (before auth — instance manager needs unauthenticated access)
+    if (req.method === 'GET' && pathname === '/health') {
+      const mem = process.memoryUsage();
+      return json(res, 200, {
+        status: 'ok',
+        uptime: Math.floor(process.uptime()),
+        pid: process.pid,
+        port: ctx.port,
+        memoryMB: Math.round(mem.rss / 1024 / 1024),
+        boardType: ctx.boardType,
+        instanceId: process.env.INSTANCE_ID || null,
+      });
+    }
+
     // Auth gate
     if (!checkAuth(ctx, req)) {
       return json(res, 401, { error: 'unauthorized' });
     }
-
-    // Parse URL for route matching (supports query params)
-    const pathname = new URL(req.url, 'http://localhost').pathname;
 
     // Built-in routes
     if (req.method === 'GET' && pathname === '/api/events') {

--- a/server/instance-manager.js
+++ b/server/instance-manager.js
@@ -1,0 +1,410 @@
+#!/usr/bin/env node
+/**
+ * instance-manager.js — Multi-tenant instance lifecycle manager
+ *
+ * Manages per-user Karvi server processes for the paid SaaS version.
+ * Each user gets an isolated process with its own port, data directory,
+ * and board.json.
+ *
+ * Designed as an embedded module (Approach B) — imported by Gateway,
+ * no separate HTTP server.
+ *
+ * Usage:
+ *   const mgr = require('./instance-manager');
+ *   mgr.init({ dataRoot: '/data' });
+ *   const inst = await mgr.createInstance({ userId: 'user-1' });
+ *   // inst = { instanceId, userId, port, pid, status, ... }
+ */
+const { spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+
+// --- Configuration ---
+const PORT_MIN = Number(process.env.KARVI_PORT_MIN || 4000);
+const PORT_MAX = Number(process.env.KARVI_PORT_MAX || 4999);
+const SERVER_SCRIPT = path.join(__dirname, 'server.js');
+const DEFAULT_MEMORY_LIMIT_MB = 128;
+const HEALTH_CHECK_INTERVAL_MS = 30000;
+const MAX_RESTARTS_PER_HOUR = 3;
+const SHUTDOWN_TIMEOUT_MS = 5000;
+const STARTUP_TIMEOUT_MS = 10000;
+
+// --- State ---
+let registry = { meta: {}, instances: {} };
+let dataRoot = null;
+let healthCheckTimer = null;
+const childProcesses = new Map(); // instanceId → ChildProcess
+
+// --- Helpers ---
+
+function isProcessAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+function httpGet(url, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, { timeout: timeoutMs }, (res) => {
+      let body = '';
+      res.on('data', d => (body += d));
+      res.on('end', () => {
+        try { resolve(JSON.parse(body)); }
+        catch { reject(new Error('Invalid JSON from ' + url)); }
+      });
+    });
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('Timeout')); });
+  });
+}
+
+function httpPost(url, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const req = http.request({
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.pathname,
+      method: 'POST',
+      timeout: timeoutMs,
+    }, (res) => {
+      let body = '';
+      res.on('data', d => (body += d));
+      res.on('end', () => resolve(body));
+    });
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('Timeout')); });
+    req.end();
+  });
+}
+
+function waitForExit(instanceId, timeoutMs = SHUTDOWN_TIMEOUT_MS) {
+  return new Promise((resolve) => {
+    const child = childProcesses.get(instanceId);
+    if (!child) return resolve();
+    const timer = setTimeout(() => resolve(), timeoutMs);
+    child.once('exit', () => { clearTimeout(timer); resolve(); });
+  });
+}
+
+function waitForReady(child, timeoutMs = STARTUP_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Startup timeout')), timeoutMs);
+    let buf = '';
+    const onData = (chunk) => {
+      buf += chunk.toString();
+      if (buf.includes('running at')) {
+        clearTimeout(timer);
+        child.stdout.removeListener('data', onData);
+        resolve();
+      }
+    };
+    child.stdout.on('data', onData);
+    child.once('exit', (code) => {
+      clearTimeout(timer);
+      child.stdout.removeListener('data', onData);
+      reject(new Error(`Process exited during startup (code=${code})`));
+    });
+  });
+}
+
+// --- Registry I/O ---
+
+function registryPath() {
+  return path.join(dataRoot, 'instance-registry.json');
+}
+
+function loadRegistry() {
+  const regPath = registryPath();
+  try {
+    registry = JSON.parse(fs.readFileSync(regPath, 'utf8'));
+  } catch {
+    registry = { meta: {}, instances: {} };
+  }
+  // Verify PIDs — clean stale entries
+  for (const inst of Object.values(registry.instances)) {
+    if (inst.pid && !isProcessAlive(inst.pid)) {
+      inst.status = 'stopped';
+      inst.pid = null;
+    }
+  }
+  saveRegistry();
+}
+
+function saveRegistry() {
+  registry.meta.updatedAt = new Date().toISOString();
+  const regPath = registryPath();
+  const tmpPath = regPath + '.tmp';
+  fs.mkdirSync(path.dirname(regPath), { recursive: true });
+  fs.writeFileSync(tmpPath, JSON.stringify(registry, null, 2));
+  fs.renameSync(tmpPath, regPath);
+}
+
+// --- Port Allocation ---
+
+function allocatePort() {
+  const usedPorts = new Set(
+    Object.values(registry.instances)
+      .filter(i => i.status !== 'stopped' && i.status !== 'failed')
+      .map(i => i.port)
+  );
+  for (let p = PORT_MIN; p <= PORT_MAX; p++) {
+    if (!usedPorts.has(p)) return p;
+  }
+  throw new Error(`No available ports in range ${PORT_MIN}-${PORT_MAX}`);
+}
+
+function freePort(port) {
+  // Port is freed implicitly when instance status changes to stopped/failed.
+  // This function exists for explicit port management if needed.
+  void port;
+}
+
+// --- Instance Lifecycle ---
+
+function init({ dataRoot: root }) {
+  dataRoot = root;
+  fs.mkdirSync(dataRoot, { recursive: true });
+  loadRegistry();
+}
+
+async function createInstance({ userId, memoryLimitMB = DEFAULT_MEMORY_LIMIT_MB }) {
+  if (!dataRoot) throw new Error('Instance manager not initialized. Call init() first.');
+  if (getInstanceByUserId(userId)) {
+    throw new Error(`Instance already exists for user ${userId}`);
+  }
+
+  const port = allocatePort();
+  const instanceId = `inst-${userId}`;
+  const userDataDir = path.join(dataRoot, 'users', userId);
+  fs.mkdirSync(path.join(userDataDir, 'briefs'), { recursive: true });
+
+  const child = spawn(process.execPath, [
+    `--max-old-space-size=${memoryLimitMB}`,
+    SERVER_SCRIPT,
+  ], {
+    env: {
+      ...process.env,
+      PORT: String(port),
+      DATA_DIR: userDataDir,
+      INSTANCE_ID: instanceId,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+    detached: false,
+  });
+
+  const instance = {
+    instanceId,
+    userId,
+    port,
+    pid: child.pid,
+    status: 'starting',
+    dataDir: userDataDir,
+    memoryLimitMB,
+    createdAt: new Date().toISOString(),
+    lastHealthCheck: null,
+    healthFailCount: 0,
+    restartHistory: [],
+  };
+
+  registry.instances[instanceId] = instance;
+  childProcesses.set(instanceId, child);
+
+  // Crash detection
+  child.on('exit', (code, signal) => {
+    handleInstanceExit(instanceId, code, signal);
+  });
+
+  // Capture stderr for debugging
+  child.stderr.on('data', (d) => {
+    const msg = d.toString().trim();
+    if (msg) console.error(`[${instanceId}] ${msg}`);
+  });
+
+  saveRegistry();
+
+  // Wait for readiness
+  try {
+    await waitForReady(child);
+    instance.status = 'running';
+    saveRegistry();
+  } catch (err) {
+    console.error(`[instance-manager] ${instanceId} failed to start: ${err.message}`);
+    instance.status = 'failed';
+    saveRegistry();
+  }
+
+  return instance;
+}
+
+async function destroyInstance(instanceId, { graceful = true } = {}) {
+  const instance = registry.instances[instanceId];
+  if (!instance) throw new Error(`Instance ${instanceId} not found`);
+
+  if (instance.status === 'stopped') return { ok: true };
+
+  // Mark as stopping to prevent auto-restart race condition
+  instance.status = 'stopping';
+  saveRegistry();
+
+  if (graceful && instance.port) {
+    try {
+      await httpPost(`http://localhost:${instance.port}/api/shutdown`);
+      await waitForExit(instanceId, SHUTDOWN_TIMEOUT_MS);
+    } catch {
+      // HTTP shutdown failed, force kill
+    }
+  }
+
+  // Force kill if still alive
+  const child = childProcesses.get(instanceId);
+  if (child) {
+    try { child.kill(); } catch {}
+    childProcesses.delete(instanceId);
+  }
+
+  instance.status = 'stopped';
+  instance.pid = null;
+  saveRegistry();
+
+  return { ok: true };
+}
+
+async function restartInstance(instanceId) {
+  const instance = registry.instances[instanceId];
+  if (!instance) throw new Error(`Instance ${instanceId} not found`);
+
+  const { userId, memoryLimitMB } = instance;
+  await destroyInstance(instanceId);
+
+  // Remove old entry so createInstance doesn't throw "already exists"
+  delete registry.instances[instanceId];
+  saveRegistry();
+
+  return createInstance({ userId, memoryLimitMB });
+}
+
+// --- Query ---
+
+function getInstance(instanceId) {
+  return registry.instances[instanceId] || null;
+}
+
+function getInstanceByUserId(userId) {
+  return Object.values(registry.instances).find(
+    i => i.userId === userId && i.status !== 'stopped' && i.status !== 'failed'
+  ) || null;
+}
+
+function listInstances() {
+  return Object.values(registry.instances);
+}
+
+// --- Health Checker ---
+
+function startHealthChecker({ intervalMs = HEALTH_CHECK_INTERVAL_MS } = {}) {
+  if (healthCheckTimer) return;
+  healthCheckTimer = setInterval(() => {
+    for (const inst of Object.values(registry.instances)) {
+      if (inst.status !== 'running') continue;
+      checkInstanceHealth(inst);
+    }
+  }, intervalMs);
+}
+
+function stopHealthChecker() {
+  if (healthCheckTimer) {
+    clearInterval(healthCheckTimer);
+    healthCheckTimer = null;
+  }
+}
+
+async function checkInstanceHealth(instance) {
+  try {
+    const data = await httpGet(`http://localhost:${instance.port}/health`, 5000);
+    instance.lastHealthCheck = new Date().toISOString();
+    instance.healthFailCount = 0;
+    instance.memoryUsageMB = data.memoryMB;
+
+    if (data.memoryMB > instance.memoryLimitMB * 1.5) {
+      console.warn(`[instance-manager] ${instance.instanceId} memory ${data.memoryMB}MB exceeds 1.5x limit ${instance.memoryLimitMB}MB`);
+    }
+    saveRegistry();
+  } catch {
+    instance.healthFailCount = (instance.healthFailCount || 0) + 1;
+    if (instance.healthFailCount >= 3) {
+      console.warn(`[instance-manager] ${instance.instanceId} failed ${instance.healthFailCount} health checks, restarting`);
+      instance.healthFailCount = 0;
+      autoRestart(instance.instanceId);
+    }
+  }
+}
+
+// --- Auto-Restart ---
+
+function handleInstanceExit(instanceId, code, signal) {
+  const instance = registry.instances[instanceId];
+  if (!instance) return;
+  if (instance.status === 'stopped' || instance.status === 'stopping') return; // Expected shutdown
+
+  console.warn(`[instance-manager] ${instanceId} exited unexpectedly (code=${code}, signal=${signal})`);
+  childProcesses.delete(instanceId);
+  instance.pid = null;
+
+  autoRestart(instanceId);
+}
+
+async function autoRestart(instanceId) {
+  const instance = registry.instances[instanceId];
+  if (!instance) return;
+
+  const now = Date.now();
+  const oneHourAgo = now - 3600000;
+  const recentRestarts = (instance.restartHistory || []).filter(t => t > oneHourAgo);
+
+  if (recentRestarts.length >= MAX_RESTARTS_PER_HOUR) {
+    instance.status = 'failed';
+    console.error(`[instance-manager] ${instanceId} exceeded ${MAX_RESTARTS_PER_HOUR} restarts/hour, marking as failed`);
+    saveRegistry();
+    return;
+  }
+
+  instance.restartHistory = [...recentRestarts, now];
+  saveRegistry();
+
+  try {
+    await restartInstance(instanceId);
+    console.log(`[instance-manager] ${instanceId} restarted successfully`);
+  } catch (err) {
+    console.error(`[instance-manager] ${instanceId} restart failed: ${err.message}`);
+    instance.status = 'failed';
+    saveRegistry();
+  }
+}
+
+// --- Shutdown all ---
+
+async function destroyAll() {
+  stopHealthChecker();
+  const ids = Object.keys(registry.instances).filter(
+    id => registry.instances[id].status === 'running' || registry.instances[id].status === 'starting'
+  );
+  await Promise.all(ids.map(id => destroyInstance(id).catch(() => {})));
+}
+
+module.exports = {
+  init,
+  createInstance,
+  destroyInstance,
+  restartInstance,
+  getInstance,
+  getInstanceByUserId,
+  listInstances,
+  startHealthChecker,
+  stopHealthChecker,
+  allocatePort,
+  freePort,
+  loadRegistry,
+  saveRegistry,
+  destroyAll,
+};

--- a/server/server.js
+++ b/server/server.js
@@ -28,11 +28,12 @@ function getRuntime(hint) {
 
 const DIR = __dirname;
 const ROOT = path.resolve(DIR, '..');
+const DATA_DIR = process.env.DATA_DIR || DIR;
 
 const ctx = bb.createContext({
   dir: ROOT,
-  boardPath: path.join(DIR, 'board.json'),
-  logPath: path.join(DIR, 'task-log.jsonl'),
+  boardPath: path.join(DATA_DIR, 'board.json'),
+  logPath: path.join(DATA_DIR, 'task-log.jsonl'),
   port: Number(process.env.PORT || 3461),
   boardType: 'task-engine',
 });
@@ -46,7 +47,7 @@ const broadcastSSE = (ev, d) => bb.broadcastSSE(ctx, ev, d);
 const processing = new Map();
 
 // --- S8: Scoped Boards (briefs) ---
-const BRIEFS_DIR = path.join(DIR, 'briefs');
+const BRIEFS_DIR = path.join(DATA_DIR, 'briefs');
 const SKILLS_NEEDING_BRIEF = new Set(['conversapix-storyboard']);
 
 function ensureBriefsDir() {
@@ -2227,6 +2228,13 @@ const server = bb.createServer(ctx, (req, res, helpers) => {
     return;
   }
 
+  // POST /api/shutdown — graceful shutdown (critical for Windows where SIGTERM kills immediately)
+  if (req.method === 'POST' && req.url === '/api/shutdown') {
+    json(res, 200, { ok: true, message: 'shutting down' });
+    setImmediate(gracefulShutdown);
+    return;
+  }
+
   return false; // fall through to bb static file serving
 });
 
@@ -2256,5 +2264,14 @@ if (!Array.isArray(initBoard.signals)) { initBoard.signals = []; dirty = true; }
 if (!Array.isArray(initBoard.insights)) { initBoard.insights = []; dirty = true; }
 if (!Array.isArray(initBoard.lessons)) { initBoard.lessons = []; dirty = true; }
 if (dirty) writeBoard(initBoard);
+
+// --- Graceful Shutdown ---
+function gracefulShutdown() {
+  console.log('[server] shutting down...');
+  server.close(() => process.exit(0));
+  setTimeout(() => process.exit(1), 5000);
+}
+process.on('SIGTERM', gracefulShutdown);
+process.on('SIGINT', gracefulShutdown);
 
 bb.listen(server, ctx);

--- a/server/smoke-test.js
+++ b/server/smoke-test.js
@@ -161,7 +161,20 @@ async function runSuite(target) {
     } catch (e) { fail(`GET ${domainRoute} (domain)`, e.message); }
   }
 
-  // 6. CORS headers
+  // 6. GET /health
+  try {
+    const r = await get(port, '/health', { token: null }); // health is pre-auth
+    if (r.status !== 200) throw new Error(`status ${r.status}`);
+    const health = JSON.parse(r.body);
+    if (health.status !== 'ok') throw new Error(`health status: ${health.status}`);
+    if (typeof health.uptime !== 'number') throw new Error('missing uptime');
+    if (typeof health.pid !== 'number') throw new Error('missing pid');
+    if (typeof health.port !== 'number') throw new Error('missing port');
+    if (typeof health.memoryMB !== 'number') throw new Error('missing memoryMB');
+    ok('GET /health → 200 + valid health response');
+  } catch (e) { fail('GET /health', e.message); }
+
+  // 7. CORS headers
   try {
     const r = await get(port, '/api/board');
     const cors = r.headers['access-control-allow-origin'];
@@ -171,7 +184,7 @@ async function runSuite(target) {
     ok('CORS → Access-Control-Allow-Origin: * + Authorization header');
   } catch (e) { fail('CORS', e.message); }
 
-  // 7. Vault API (task-engine only, graceful when disabled)
+  // 8. Vault API (task-engine only, graceful when disabled)
   if (port === 3461) {
     try {
       const statusR = await get(port, '/api/vault/status');
@@ -208,7 +221,7 @@ async function runSuite(target) {
     } catch (e) { fail('Vault API', e.message); }
   }
 
-  // 8-11. Evolution API checks (task-engine only)
+  // 9-12. Evolution API checks (task-engine only)
   if (port === 3461) {
     try {
       const r = await get(port, '/api/signals');

--- a/server/test-instance-manager.js
+++ b/server/test-instance-manager.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * test-instance-manager.js — Integration test for instance manager
+ *
+ * Tests: create, health check, data isolation, port allocation,
+ *        destroy, port reuse, registry persistence, list instances.
+ *
+ * Usage:
+ *   node server/test-instance-manager.js
+ */
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const http = require('http');
+const mgr = require('./instance-manager');
+
+const TEST_DATA_ROOT = path.join(os.tmpdir(), `karvi-test-im-${Date.now()}`);
+let passed = 0;
+let failed = 0;
+
+function ok(name) { passed++; console.log(`  ✅ ${name}`); }
+function fail(name, err) { failed++; console.log(`  ❌ ${name}: ${err}`); }
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'Assertion failed');
+}
+
+function httpGet(url, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, { timeout: timeoutMs }, (res) => {
+      let body = '';
+      res.on('data', d => (body += d));
+      res.on('end', () => {
+        try { resolve(JSON.parse(body)); }
+        catch { reject(new Error('Invalid JSON')); }
+      });
+    });
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('Timeout')); });
+  });
+}
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+function cleanTestData() {
+  try { fs.rmSync(TEST_DATA_ROOT, { recursive: true, force: true }); } catch {}
+}
+
+async function main() {
+  console.log('\n━━━ Instance Manager Integration Test ━━━\n');
+  console.log(`  Data root: ${TEST_DATA_ROOT}`);
+
+  cleanTestData();
+  mgr.init({ dataRoot: TEST_DATA_ROOT });
+
+  // Test 1: Create instance
+  let inst1;
+  try {
+    inst1 = await mgr.createInstance({ userId: 'test-user-1' });
+    assert(inst1.port >= 4000 && inst1.port <= 4999, `port ${inst1.port} out of range`);
+    assert(inst1.status === 'running', `status should be running, got ${inst1.status}`);
+    assert(inst1.instanceId === 'inst-test-user-1', `bad instanceId: ${inst1.instanceId}`);
+    assert(inst1.pid > 0, 'pid should be positive');
+    ok('Create instance (port in range, status running, has pid)');
+  } catch (e) { fail('Create instance', e.message); }
+
+  // Test 2: Health check responds
+  try {
+    const health = await httpGet(`http://localhost:${inst1.port}/health`);
+    assert(health.status === 'ok', `health status: ${health.status}`);
+    assert(health.pid === inst1.pid, `health pid mismatch: ${health.pid} vs ${inst1.pid}`);
+    assert(health.instanceId === inst1.instanceId, `instanceId mismatch`);
+    ok('Health check responds with correct PID and instanceId');
+  } catch (e) { fail('Health check', e.message); }
+
+  // Test 3: User data isolation
+  try {
+    const boardPath = path.join(TEST_DATA_ROOT, 'users', 'test-user-1', 'board.json');
+    assert(fs.existsSync(boardPath), 'board.json not created in user dir');
+    const briefsDir = path.join(TEST_DATA_ROOT, 'users', 'test-user-1', 'briefs');
+    assert(fs.existsSync(briefsDir), 'briefs/ not created in user dir');
+    ok('User data directory created and isolated');
+  } catch (e) { fail('User data isolation', e.message); }
+
+  // Test 4: Second instance gets different port
+  let inst2;
+  try {
+    inst2 = await mgr.createInstance({ userId: 'test-user-2' });
+    assert(inst2.port !== inst1.port, `ports should differ: ${inst2.port} === ${inst1.port}`);
+    assert(inst2.status === 'running', `status should be running, got ${inst2.status}`);
+    ok(`Second instance gets different port (${inst1.port} vs ${inst2.port})`);
+  } catch (e) { fail('Second instance port', e.message); }
+
+  // Test 5: Duplicate user rejected
+  try {
+    await mgr.createInstance({ userId: 'test-user-1' });
+    fail('Duplicate user rejected', 'should have thrown');
+  } catch (e) {
+    assert(e.message.includes('already exists'), `wrong error: ${e.message}`);
+    ok('Duplicate user creation rejected');
+  }
+
+  // Test 6: List instances
+  try {
+    const all = mgr.listInstances();
+    assert(all.length === 2, `expected 2 instances, got ${all.length}`);
+    ok('List instances returns correct count');
+  } catch (e) { fail('List instances', e.message); }
+
+  // Test 7: getInstance and getInstanceByUserId
+  try {
+    const byId = mgr.getInstance('inst-test-user-1');
+    assert(byId !== null, 'getInstance returned null');
+    assert(byId.userId === 'test-user-1', 'wrong userId');
+
+    const byUser = mgr.getInstanceByUserId('test-user-2');
+    assert(byUser !== null, 'getInstanceByUserId returned null');
+    assert(byUser.instanceId === 'inst-test-user-2', 'wrong instanceId');
+
+    const notFound = mgr.getInstance('nonexistent');
+    assert(notFound === null, 'should return null for nonexistent');
+
+    ok('getInstance and getInstanceByUserId work correctly');
+  } catch (e) { fail('getInstance / getInstanceByUserId', e.message); }
+
+  // Test 8: Destroy instance
+  try {
+    const result = await mgr.destroyInstance('inst-test-user-1');
+    assert(result.ok === true, 'destroy should return ok');
+    await sleep(500); // Wait for process to exit
+    const inst = mgr.getInstance('inst-test-user-1');
+    assert(inst.status === 'stopped', `status should be stopped, got ${inst.status}`);
+    assert(inst.pid === null, 'pid should be null after destroy');
+    ok('Destroy instance (status stopped, pid null)');
+  } catch (e) { fail('Destroy instance', e.message); }
+
+  // Test 9: Port reuse after destroy
+  try {
+    const inst3 = await mgr.createInstance({ userId: 'test-user-3' });
+    assert(inst3.port === inst1.port, `should reuse freed port ${inst1.port}, got ${inst3.port}`);
+    ok(`Port reused after destroy (port ${inst3.port})`);
+    await mgr.destroyInstance(inst3.instanceId);
+  } catch (e) { fail('Port reuse', e.message); }
+
+  // Test 10: Registry persistence
+  try {
+    const regPath = path.join(TEST_DATA_ROOT, 'instance-registry.json');
+    assert(fs.existsSync(regPath), 'registry file should exist');
+    const loaded = JSON.parse(fs.readFileSync(regPath, 'utf8'));
+    assert(loaded.meta && loaded.meta.updatedAt, 'registry should have meta.updatedAt');
+    assert(Object.keys(loaded.instances).length >= 2, 'registry should have instances');
+    ok('Registry persisted to disk');
+  } catch (e) { fail('Registry persistence', e.message); }
+
+  // Cleanup
+  console.log('\n  Cleaning up...');
+  await mgr.destroyAll();
+  await sleep(1000); // Give processes time to exit
+  cleanTestData();
+
+  console.log(`\n  ── ${passed} passed, ${failed} failed ──\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error('Test runner error:', err);
+  mgr.destroyAll().then(() => {
+    cleanTestData();
+    process.exit(1);
+  });
+});


### PR DESCRIPTION
## Summary

Split from PR #58 (which mixed vault + instance-manager changes).

- Add `DATA_DIR` env var to `server.js` for configurable data directories (backward compatible)
- Add `GET /health` endpoint to `blackboard-server.js` (pre-auth, for instance manager health checks)
- Add `POST /api/shutdown` + SIGTERM/SIGINT handlers for cross-platform graceful shutdown
- Add `server/instance-manager.js` — embedded module for per-user Karvi server process management
- Add `server/test-instance-manager.js` — 10 integration test cases

### Instance Manager Features
- **createInstance**: allocate port (4000-4999), spawn process with isolated DATA_DIR, wait for readiness
- **destroyInstance**: HTTP graceful shutdown (Windows compatible) + force kill fallback
- **restartInstance**: destroy + re-create with same config
- **Health checker**: 30s interval polling `/health`, auto-restart after 3 consecutive failures
- **Crash loop protection**: max 3 restarts/hour per instance, then marks as 'failed'
- **Registry persistence**: atomic JSON write (tmp + rename), PID verification on load
- **Port allocation**: registry-based scan in configurable range

## Test plan

- [x] Smoke test passes (6/6) — `/health` endpoint verified
- [x] Instance manager integration test passes (10/10)
- [x] Syntax check passes on all 5 modified files
- [x] No vault code included (split to separate PR)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)