### PR TITLE
feat(app): environment-based API URL + default indicator

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,0 +1,7 @@
+# Karvi App — Environment Variables
+# Copy this file to .env and fill in your values.
+
+# Default API server URL (baked into the app at build time).
+# If set, the app will auto-connect on launch without manual URL input.
+# Users can still override this in Settings.
+EXPO_PUBLIC_API_URL=http://192.168.1.100:3461

--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,0 +1,10 @@
+import { ExpoConfig, ConfigContext } from 'expo/config';
+
+export default ({ config }: ConfigContext): ExpoConfig => ({
+  ...config,
+  name: 'Karvi',
+  slug: 'karvi',
+  extra: {
+    apiUrl: process.env.EXPO_PUBLIC_API_URL || '',
+  },
+});

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -16,10 +16,15 @@ export default function SettingsScreen() {
   const apiToken = useBoardStore((s) => s.apiToken);
   const setApiToken = useBoardStore((s) => s.setApiToken);
   const connectionStatus = useBoardStore((s) => s.connectionStatus);
+  const defaultApiUrl = useBoardStore((s) => s.defaultApiUrl);
+  const resetServerUrl = useBoardStore((s) => s.resetServerUrl);
   const [draft, setDraft] = useState(serverUrl);
   const [draftToken, setDraftToken] = useState(apiToken);
   const [testing, setTesting] = useState(false);
   const t = useTheme();
+
+  const isUsingDefault = defaultApiUrl !== '' && draft === defaultApiUrl;
+  const hasOverridden = defaultApiUrl !== '' && draft !== defaultApiUrl;
 
   const handleSave = () => {
     const url = draft.replace(/\/+$/, '');
@@ -77,13 +82,29 @@ export default function SettingsScreen() {
               style={[styles.input, { color: t.text }]}
               value={draft}
               onChangeText={setDraft}
-              placeholder="http://192.168.1.100:3461"
+              placeholder={defaultApiUrl || 'http://192.168.1.100:3461'}
               placeholderTextColor={t.placeholder}
               autoCapitalize="none"
               autoCorrect={false}
               keyboardType="url"
             />
           </View>
+          {isUsingDefault && (
+            <Text style={[styles.defaultHint, { color: t.success }]}>
+              Using default: {defaultApiUrl}
+            </Text>
+          )}
+          {hasOverridden && (
+            <Button
+              label="Reset to default"
+              variant="secondary"
+              onPress={() => {
+                resetServerUrl();
+                setDraft(defaultApiUrl);
+              }}
+              style={styles.resetBtn}
+            />
+          )}
           <Text style={[styles.inputLabel, { color: t.textSecondary }]}>API Token</Text>
           <View style={[styles.inputBox, { backgroundColor: t.bgSubtle, borderColor: t.border }]}>
             <Ionicons name="key-outline" size={16} color={t.textTertiary} />
@@ -181,6 +202,10 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   input: { flex: 1, fontSize: 15, padding: 0 },
+
+  // Default URL hint + reset
+  defaultHint: { fontSize: 12, marginBottom: 12, fontStyle: 'italic' },
+  resetBtn: { marginBottom: 12 },
 
   // Buttons
   btnRow: { flexDirection: 'row', gap: 10 },

--- a/app/hooks/useBoardStore.ts
+++ b/app/hooks/useBoardStore.ts
@@ -2,6 +2,9 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { Board } from '../../shared/types';
+import { getDefaultApiUrl } from '../lib/config';
+
+const DEFAULT_API_URL = getDefaultApiUrl();
 
 export type ConnectionStatus = 'connected' | 'polling' | 'reconnecting' | 'disconnected';
 
@@ -9,29 +12,42 @@ interface BoardStore {
   board: Board | null;
   serverUrl: string;
   apiToken: string;
+  defaultApiUrl: string;
   connectionStatus: ConnectionStatus;
   setBoard: (board: Board) => void;
   setServerUrl: (url: string) => void;
   setApiToken: (token: string) => void;
   setConnectionStatus: (s: ConnectionStatus) => void;
+  resetServerUrl: () => void;
 }
 
 export const useBoardStore = create<BoardStore>()(
   persist(
     (set) => ({
       board: null,
-      serverUrl: '',
+      serverUrl: DEFAULT_API_URL,
       apiToken: '',
+      defaultApiUrl: DEFAULT_API_URL,
       connectionStatus: 'disconnected',
       setBoard: (board) => set({ board }),
       setServerUrl: (serverUrl) => set({ serverUrl }),
       setApiToken: (apiToken) => set({ apiToken }),
       setConnectionStatus: (connectionStatus) => set({ connectionStatus }),
+      resetServerUrl: () => set({ serverUrl: DEFAULT_API_URL }),
     }),
     {
       name: 'karvi-board',
       storage: createJSONStorage(() => AsyncStorage),
       partialize: (state) => ({ board: state.board, serverUrl: state.serverUrl, apiToken: state.apiToken }),
+      merge: (persisted, current) => {
+        const p = persisted as Partial<BoardStore> | undefined;
+        return {
+          ...current,
+          ...p,
+          // 若已持久化的 serverUrl 為空且有環境預設值，使用預設值
+          serverUrl: (p?.serverUrl || '') === '' ? DEFAULT_API_URL : p!.serverUrl,
+        };
+      },
     }
   )
 );

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -1,0 +1,9 @@
+import Constants from 'expo-constants';
+
+/**
+ * 從 app.config.ts extra 讀取環境預設 API URL。
+ * 由 EXPO_PUBLIC_API_URL 環境變數注入，build-time 解析。
+ */
+export function getDefaultApiUrl(): string {
+  return Constants.expoConfig?.extra?.apiUrl || '';
+}


### PR DESCRIPTION
## Summary

- Add `app/app.config.ts` to read `EXPO_PUBLIC_API_URL` env var and expose it via `extra.apiUrl`
- Add `app/lib/config.ts` helper (`getDefaultApiUrl()`) to read the env value at runtime via `expo-constants`
- Update `useBoardStore` to initialize `serverUrl` from the env default, with `merge` function to upgrade existing users who have an empty persisted URL
- Update Settings screen to show "Using default: ..." indicator and "Reset to default" button
- Add `app/.env.example` documenting the env var for contributors and self-hosters

## What was already done (PR #55/#56)

Token management (`apiToken` in store, `Authorization: Bearer` headers, SSE `?token=xxx`, Settings token input) was fully implemented in prior PRs. This PR completes the remaining ~15% of issue #21: the environment-based default URL feature.

## Test plan

- [ ] Fresh install **without** `EXPO_PUBLIC_API_URL` — `serverUrl` is `''`, no "Using default" hint, backward compatible
- [ ] Fresh install **with** `EXPO_PUBLIC_API_URL` set — app auto-connects on launch, "Using default" shown in Settings
- [ ] User overrides URL in Settings — "Reset to default" button appears, override persists across restarts
- [ ] User taps "Reset to default" — URL reverts to env value, "Using default" reappears
- [ ] Existing user with empty persisted URL + new env var — `merge` function fills in the default
- [ ] No env var = identical behavior to current app (backward compat)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)