### PR TITLE
feat(storage): board storage abstraction layer (#37)

### DIFF
--- a/server/blackboard-server.js
+++ b/server/blackboard-server.js
@@ -33,6 +33,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const storage = require('./storage');
 
 const MIME = {
   '.html': 'text/html; charset=utf-8',
@@ -105,7 +106,7 @@ function checkAuth(ctx, req) {
 }
 
 function readBoard(ctx) {
-  return JSON.parse(fs.readFileSync(ctx.boardPath, 'utf8'));
+  return storage.readBoard(ctx.boardPath);
 }
 
 function writeBoard(ctx, board) {
@@ -113,12 +114,12 @@ function writeBoard(ctx, board) {
   board.meta.updatedAt = nowIso();
   if (ctx.boardType) board.meta.boardType = ctx.boardType;
   if (board.meta.version === undefined) board.meta.version = 1;
-  fs.writeFileSync(ctx.boardPath, JSON.stringify(board, null, 2), 'utf8');
+  storage.writeBoard(ctx.boardPath, board);
   broadcastSSE(ctx, 'board', board);
 }
 
 function appendLog(ctx, entry) {
-  try { fs.appendFileSync(ctx.logPath, JSON.stringify(entry) + '\n', 'utf8'); } catch {}
+  storage.appendLog(ctx.logPath, entry);
 }
 
 function broadcastSSE(ctx, event, data) {
@@ -261,16 +262,14 @@ function createServer(ctx, routeHandler) {
 }
 
 function ensureBoardExists(ctx, defaultBoard) {
-  if (!fs.existsSync(ctx.boardPath)) {
+  if (!storage.boardExists(ctx.boardPath)) {
     console.log(`[bb] board not found at ${ctx.boardPath}, creating default...`);
     writeBoard(ctx, defaultBoard);
   }
 }
 
 function listen(server, ctx) {
-  if (!fs.existsSync(ctx.logPath)) {
-    try { fs.writeFileSync(ctx.logPath, '', 'utf8'); } catch {}
-  }
+  storage.ensureLogFile(ctx.logPath);
   server.listen(ctx.port, () => {
     console.log(`Blackboard server running at http://localhost:${ctx.port}`);
   });
@@ -294,4 +293,5 @@ module.exports = {
   listen,
   checkAuth,
   tokenMatch,
+  storage,
 };

--- a/server/process-review.js
+++ b/server/process-review.js
@@ -13,6 +13,7 @@
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const storageBackend = require('./storage');
 
 const DIR = __dirname;
 const DEFAULT_BOARD = path.join(DIR, 'board.json');
@@ -56,7 +57,7 @@ function uid(prefix) {
 }
 
 function appendLog(entry) {
-  try { fs.appendFileSync(LOG_PATH, JSON.stringify(entry) + '\n', 'utf8'); } catch {}
+  storageBackend.appendLog(LOG_PATH, entry);
 }
 
 function emitSignal(signal) {
@@ -332,12 +333,12 @@ function main() {
   const args = parseArgs();
   const boardPath = args.board || DEFAULT_BOARD;
 
-  if (!fs.existsSync(boardPath)) {
+  if (!storageBackend.boardExists(boardPath)) {
     console.error(`Board not found: ${boardPath}`);
     process.exit(1);
   }
 
-  const board = JSON.parse(fs.readFileSync(boardPath, 'utf8'));
+  const board = storageBackend.readBoard(boardPath);
   const controls = { ...DEFAULT_CONTROLS, ...(board.controls || {}) };
   const threshold = args.threshold || controls.quality_threshold;
 
@@ -469,7 +470,7 @@ function main() {
       id: uid('msg'), ts: nowIso(), type: 'system', from: 'system', to: 'human',
       text: `【${task.id} 審查中】第 ${task.reviewAttempts}/${controls.max_review_attempts} 次`,
     });
-    fs.writeFileSync(boardPath, JSON.stringify(board, null, 2), 'utf8');
+    storageBackend.writeBoard(boardPath, board);
 
     let replyText;
     try {
@@ -586,7 +587,7 @@ function main() {
   if (!args.dryRun && processed > 0) {
     board.meta = board.meta || {};
     board.meta.updatedAt = nowIso();
-    fs.writeFileSync(boardPath, JSON.stringify(board, null, 2), 'utf8');
+    storageBackend.writeBoard(boardPath, board);
     console.log(`\nBoard updated. ${processed} task(s) processed.`);
   } else if (args.dryRun) {
     console.log(`\nDRY RUN complete. ${processed} task(s) would be processed.`);

--- a/server/retro.js
+++ b/server/retro.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const http = require('http');
+const storage = require('./storage');
 
 const DIR = __dirname;
 const DEFAULT_BOARD = path.join(DIR, 'board.json');
@@ -298,13 +299,13 @@ async function main() {
   const boardPath = args.board || DEFAULT_BOARD;
   const port = args.port || DEFAULT_PORT;
 
-  if (!fs.existsSync(boardPath)) {
+  if (!storage.boardExists(boardPath)) {
     console.error(`[retro] Board not found: ${boardPath}`);
     console.error('[retro] Start the server first: npm start');
     process.exit(1);
   }
 
-  const board = JSON.parse(fs.readFileSync(boardPath, 'utf8'));
+  const board = storage.readBoard(boardPath);
 
   console.log(`[retro] board: ${boardPath}`);
   console.log(`[retro] signals: ${(board.signals || []).length}`);

--- a/server/storage-json.js
+++ b/server/storage-json.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * storage-json.js — JSON file storage backend
+ *
+ * Implements the storage interface for board.json + task-log.jsonl
+ * using atomic writes (write to .tmp then rename) for crash safety.
+ *
+ * Interface:
+ *   readBoard(boardPath) → object
+ *   writeBoard(boardPath, board) → void
+ *   appendLog(logPath, entry) → void
+ *   boardExists(boardPath) → boolean
+ *   ensureLogFile(logPath) → void
+ */
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function readBoard(boardPath) {
+  return JSON.parse(fs.readFileSync(boardPath, 'utf8'));
+}
+
+function writeBoard(boardPath, board) {
+  const dir = path.dirname(boardPath);
+  const tmpPath = path.join(dir, `.board-${process.pid}-${Date.now()}.tmp`);
+  const data = JSON.stringify(board, null, 2);
+  fs.writeFileSync(tmpPath, data, 'utf8');
+  fs.renameSync(tmpPath, boardPath);
+}
+
+function appendLog(logPath, entry) {
+  try {
+    fs.appendFileSync(logPath, JSON.stringify(entry) + '\n', 'utf8');
+  } catch {
+    // best-effort: log append failure is non-fatal
+  }
+}
+
+function boardExists(boardPath) {
+  return fs.existsSync(boardPath);
+}
+
+function ensureLogFile(logPath) {
+  if (!fs.existsSync(logPath)) {
+    try { fs.writeFileSync(logPath, '', 'utf8'); } catch {}
+  }
+}
+
+module.exports = {
+  name: 'json',
+  readBoard,
+  writeBoard,
+  appendLog,
+  boardExists,
+  ensureLogFile,
+};

--- a/server/storage-sqlite.js
+++ b/server/storage-sqlite.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * storage-sqlite.js — SQLite storage backend (stub)
+ *
+ * Placeholder for future SQLite-based storage.
+ * All methods throw a clear error directing users to use the JSON backend
+ * or implement the SQLite backend when needed.
+ *
+ * Future implementation will use Node.js 22+ built-in SQLite support
+ * (node:sqlite) to maintain the zero-dependency constraint.
+ */
+
+const NOT_IMPLEMENTED = 'SQLite storage backend is not yet implemented. '
+  + 'Set KARVI_STORAGE=json (default) or implement storage-sqlite.js. '
+  + 'See issue #37 for roadmap.';
+
+function readBoard(/* boardPath */) {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+function writeBoard(/* boardPath, board */) {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+function appendLog(/* logPath, entry */) {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+function boardExists(/* boardPath */) {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+function ensureLogFile(/* logPath */) {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+module.exports = {
+  name: 'sqlite',
+  readBoard,
+  writeBoard,
+  appendLog,
+  boardExists,
+  ensureLogFile,
+};

--- a/server/storage.js
+++ b/server/storage.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * storage.js — Storage backend factory
+ *
+ * Returns the configured storage backend based on KARVI_STORAGE env var.
+ * Defaults to 'json' (file-based). Supports lazy require to avoid loading
+ * unused backends.
+ *
+ * Usage:
+ *   const storage = require('./storage');
+ *   const board = storage.readBoard('/path/to/board.json');
+ *   storage.writeBoard('/path/to/board.json', board);
+ *   storage.appendLog('/path/to/log.jsonl', entry);
+ *
+ * Environment:
+ *   KARVI_STORAGE=json    (default) — JSON file backend with atomic writes
+ *   KARVI_STORAGE=sqlite  (stub)    — future SQLite backend
+ */
+
+const BACKEND = (process.env.KARVI_STORAGE || 'json').toLowerCase();
+
+const BACKENDS = {
+  json: () => require('./storage-json'),
+  sqlite: () => require('./storage-sqlite'),
+};
+
+const factory = BACKENDS[BACKEND];
+if (!factory) {
+  throw new Error(
+    `Unknown storage backend: "${BACKEND}". `
+    + `Supported: ${Object.keys(BACKENDS).join(', ')}. `
+    + 'Set KARVI_STORAGE=json (default) or KARVI_STORAGE=sqlite.'
+  );
+}
+
+module.exports = factory();


### PR DESCRIPTION
## Summary

- **Add pluggable storage backend** so board.json I/O can be swapped from JSON files to SQLite (or other backends) without touching `server.js` or any of its 100+ call sites
- **Atomic writes** via tmp file + rename for crash safety (replaces raw `fs.writeFileSync`)
- **SQLite stub** with clear error message for future implementation when scaling past 1000 users

## New files

| File | Lines | Purpose |
|------|-------|---------|
| `server/storage.js` | ~30 | Factory — reads `KARVI_STORAGE` env, defaults to `json`, lazy-requires backend |
| `server/storage-json.js` | ~55 | JSON file backend — `readBoard`, `writeBoard` (atomic), `appendLog`, `boardExists`, `ensureLogFile` |
| `server/storage-sqlite.js` | ~35 | Stub — all methods throw clear "not implemented" error with guidance |

## Modified files

| File | Change |
|------|--------|
| `server/blackboard-server.js` | Delegates `readBoard`/`writeBoard`/`appendLog`/`ensureBoardExists`/`listen` to storage backend; exports `storage` |
| `server/retro.js` | Uses `storage.readBoard()`/`boardExists()` instead of raw `fs` |
| `server/process-review.js` | Uses `storageBackend` for read/write/append/exists |

## Key constraints preserved

- Zero external dependencies
- `server.js` has **ZERO changes** — all call sites (`readBoard()`, `writeBoard()`, `appendLog()`) work unchanged
- Backward compatible — existing `board.json` files work as-is
- Configurable via `KARVI_STORAGE` env var (default: `json`)

## Test plan

- [x] `npm test` — full evolution loop integration test passes
- [x] `node -e "require('./server/storage')"` — module loads, reports `json` backend
- [x] `KARVI_STORAGE=sqlite` — selects sqlite backend correctly
- [x] `KARVI_STORAGE=invalid` — throws clear error with supported backends list
- [x] Atomic write/read cycle verified manually
- [x] `retro.js` and `process-review.js` load and use storage correctly

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)