### PR TITLE
feat(server): Jira webhook receiver — auto-create tasks from tickets

### DIFF
--- a/server/integration-jira.js
+++ b/server/integration-jira.js
@@ -67,6 +67,108 @@ function jiraRequest(method, apiPath, body) {
 }
 
 // ---------------------------------------------------------------------------
+// ADF (Atlassian Document Format) → plain text
+// ---------------------------------------------------------------------------
+
+/**
+ * adfToPlainText(node) — recursively extract plain text from Jira ADF JSON.
+ * Unknown node types gracefully return empty string.
+ *
+ * @param {object|string|null} node — ADF node or raw string
+ * @returns {string}
+ */
+function adfToPlainText(node) {
+  if (!node) return '';
+  if (typeof node === 'string') return node;
+  if (node.type === 'text') return node.text || '';
+  if (node.type === 'hardBreak') return '\n';
+  if (!Array.isArray(node.content)) return '';
+  const parts = node.content.map(child => adfToPlainText(child));
+  // Add newline after block-level nodes (paragraph, heading, listItem, etc.)
+  const blockTypes = new Set(['paragraph', 'heading', 'bulletList', 'orderedList', 'listItem', 'blockquote', 'codeBlock', 'table', 'tableRow', 'tableCell']);
+  if (blockTypes.has(node.type)) {
+    return parts.join('') + '\n';
+  }
+  return parts.join('');
+}
+
+// ---------------------------------------------------------------------------
+// Priority mapping (Jira → Karvi P0-P4)
+// ---------------------------------------------------------------------------
+
+const JIRA_PRIORITY_MAP = {
+  'Highest':  'P0',
+  'Blocker':  'P0',
+  'Critical': 'P0',
+  'High':     'P1',
+  'Medium':   'P2',
+  'Normal':   'P2',
+  'Low':      'P3',
+  'Minor':    'P3',
+  'Lowest':   'P4',
+  'Trivial':  'P4',
+};
+
+/**
+ * mapJiraPriority(name) — map Jira priority name to P0-P4.
+ * Returns 'P2' (Medium) as default for unknown priorities.
+ */
+function mapJiraPriority(name) {
+  if (!name) return 'P2';
+  return JIRA_PRIORITY_MAP[name] || 'P2';
+}
+
+// ---------------------------------------------------------------------------
+// Build Karvi task from Jira issue
+// ---------------------------------------------------------------------------
+
+/**
+ * buildTaskFromIssue(issue, config)
+ *
+ * @param {object} issue — Jira issue object from webhook payload
+ * @param {object} config — board.integrations.jira config
+ * @returns {object} Karvi task object
+ */
+function buildTaskFromIssue(issue, config) {
+  const fields = issue.fields || {};
+  const key = issue.key || '';
+  const host = process.env.JIRA_HOST || '';
+  const jiraUrl = host ? `https://${host}/browse/${key}` : '';
+
+  // Extract description — could be ADF object or plain string
+  let description = '';
+  if (fields.description) {
+    if (typeof fields.description === 'string') {
+      description = fields.description;
+    } else {
+      description = adfToPlainText(fields.description).trim();
+    }
+  }
+  // Truncate to 2000 chars
+  const MAX_DESC = 2000;
+  if (description.length > MAX_DESC) {
+    description = description.slice(0, MAX_DESC) + '... (truncated)';
+  }
+
+  const priority = mapJiraPriority(fields.priority?.name);
+  const assignee = fields.assignee?.displayName || null;
+
+  return {
+    id: key,
+    title: fields.summary || key,
+    description,
+    status: 'pending',
+    jiraKey: key,
+    jiraUrl,
+    source: 'jira',
+    priority,
+    assignee: assignee,
+    depends: [],
+    history: [{ ts: new Date().toISOString(), status: 'created', by: 'jira-webhook' }],
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Status mapping
 // ---------------------------------------------------------------------------
 
@@ -126,6 +228,29 @@ function handleWebhook(board, payload, url) {
 
   // 2. Parse event
   const event = payload.webhookEvent;
+
+  // --- Handle issue_created: build new task ---
+  if (event === 'jira:issue_created') {
+    const issue = payload.issue;
+    if (!issue?.key) {
+      return { action: 'skipped', error: 'No issue key in payload' };
+    }
+
+    // Dedup: skip if task with same jiraKey already exists
+    const tasks = board.taskPlan?.tasks || [];
+    if (tasks.some(t => t.jiraKey === issue.key)) {
+      return { action: 'skipped', error: `Task already exists for ${issue.key}` };
+    }
+
+    const task = buildTaskFromIssue(issue, config);
+    return {
+      action: 'create_task',
+      task,
+      issueKey: issue.key,
+    };
+  }
+
+  // --- Handle issue_updated: existing logic ---
   if (event !== 'jira:issue_updated') {
     return { action: 'skipped', error: `Unsupported event: ${event}` };
   }
@@ -308,4 +433,140 @@ module.exports = {
   // exposed for testing
   jiraRequest,
   verifyWebhookToken,
+  adfToPlainText,
+  mapJiraPriority,
+  buildTaskFromIssue,
 };
+
+// ---------------------------------------------------------------------------
+// Self-tests (run via: node server/integration-jira.js)
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  let passed = 0;
+  let failed = 0;
+  function ok(name) { passed++; console.log(`  OK: ${name}`); }
+  function fail(name, err) { failed++; console.log(`  FAIL: ${name}: ${err}`); }
+
+  console.log('integration-jira.js self-tests\n');
+
+  // --- adfToPlainText ---
+  try {
+    const adf = {
+      type: 'doc', version: 1,
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'Hello' }, { type: 'text', text: ' World' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Second paragraph' }] },
+      ],
+    };
+    const result = adfToPlainText(adf);
+    if (!result.includes('Hello World')) throw new Error(`missing "Hello World" in: ${result}`);
+    if (!result.includes('Second paragraph')) throw new Error(`missing "Second paragraph" in: ${result}`);
+    ok('adfToPlainText: nested paragraphs');
+  } catch (e) { fail('adfToPlainText: nested paragraphs', e.message); }
+
+  try {
+    if (adfToPlainText(null) !== '') throw new Error('null should return empty');
+    if (adfToPlainText('plain') !== 'plain') throw new Error('string should pass through');
+    if (adfToPlainText({}) !== '') throw new Error('empty object should return empty');
+    ok('adfToPlainText: edge cases (null, string, empty)');
+  } catch (e) { fail('adfToPlainText: edge cases', e.message); }
+
+  // --- mapJiraPriority ---
+  try {
+    if (mapJiraPriority('Highest') !== 'P0') throw new Error('Highest should be P0');
+    if (mapJiraPriority('High') !== 'P1') throw new Error('High should be P1');
+    if (mapJiraPriority('Medium') !== 'P2') throw new Error('Medium should be P2');
+    if (mapJiraPriority('Low') !== 'P3') throw new Error('Low should be P3');
+    if (mapJiraPriority('Lowest') !== 'P4') throw new Error('Lowest should be P4');
+    if (mapJiraPriority(null) !== 'P2') throw new Error('null should default to P2');
+    if (mapJiraPriority('UnknownPriority') !== 'P2') throw new Error('unknown should default to P2');
+    ok('mapJiraPriority: all mappings');
+  } catch (e) { fail('mapJiraPriority', e.message); }
+
+  // --- buildTaskFromIssue ---
+  try {
+    process.env.JIRA_HOST = 'test.atlassian.net';
+    const issue = {
+      key: 'TEST-42',
+      fields: {
+        summary: 'Fix login bug',
+        description: { type: 'doc', version: 1, content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'Users cannot log in' }] },
+        ]},
+        priority: { name: 'Critical' },
+        assignee: { displayName: 'Alice' },
+      },
+    };
+    const task = buildTaskFromIssue(issue, {});
+    if (task.id !== 'TEST-42') throw new Error(`id: ${task.id}`);
+    if (task.jiraKey !== 'TEST-42') throw new Error(`jiraKey: ${task.jiraKey}`);
+    if (task.jiraUrl !== 'https://test.atlassian.net/browse/TEST-42') throw new Error(`jiraUrl: ${task.jiraUrl}`);
+    if (task.source !== 'jira') throw new Error(`source: ${task.source}`);
+    if (task.priority !== 'P0') throw new Error(`priority: ${task.priority}`);
+    if (task.status !== 'pending') throw new Error(`status: ${task.status}`);
+    if (!task.description.includes('Users cannot log in')) throw new Error(`description: ${task.description}`);
+    if (task.assignee !== 'Alice') throw new Error(`assignee: ${task.assignee}`);
+    ok('buildTaskFromIssue: full field mapping');
+    delete process.env.JIRA_HOST;
+  } catch (e) { fail('buildTaskFromIssue', e.message); delete process.env.JIRA_HOST; }
+
+  // --- handleWebhook: issue_created ---
+  try {
+    const board = {
+      integrations: { jira: { enabled: true } },
+      taskPlan: { tasks: [] },
+    };
+    const payload = {
+      webhookEvent: 'jira:issue_created',
+      issue: {
+        key: 'PROJ-1',
+        fields: { summary: 'New feature', priority: { name: 'Medium' } },
+      },
+    };
+    const result = handleWebhook(board, payload, 'http://localhost/api/webhooks/jira');
+    if (result.action !== 'create_task') throw new Error(`action: ${result.action}`);
+    if (result.task.id !== 'PROJ-1') throw new Error(`task.id: ${result.task.id}`);
+    if (result.issueKey !== 'PROJ-1') throw new Error(`issueKey: ${result.issueKey}`);
+    ok('handleWebhook: issue_created → create_task');
+  } catch (e) { fail('handleWebhook: issue_created', e.message); }
+
+  // --- handleWebhook: dedup ---
+  try {
+    const board = {
+      integrations: { jira: { enabled: true } },
+      taskPlan: { tasks: [{ id: 'PROJ-1', jiraKey: 'PROJ-1', title: 'Existing' }] },
+    };
+    const payload = {
+      webhookEvent: 'jira:issue_created',
+      issue: {
+        key: 'PROJ-1',
+        fields: { summary: 'Duplicate' },
+      },
+    };
+    const result = handleWebhook(board, payload, 'http://localhost/api/webhooks/jira');
+    if (result.action !== 'skipped') throw new Error(`action: ${result.action}`);
+    if (!result.error.includes('already exists')) throw new Error(`error: ${result.error}`);
+    ok('handleWebhook: dedup → skipped');
+  } catch (e) { fail('handleWebhook: dedup', e.message); }
+
+  // --- handleWebhook: issue_updated still works (regression check) ---
+  try {
+    const board = {
+      integrations: { jira: { enabled: true, statusMapping: { 'Done': 'completed' } } },
+      taskPlan: { tasks: [{ id: 'REG-1', jiraKey: 'REG-1', title: 'Regression test', status: 'in_progress' }] },
+    };
+    const payload = {
+      webhookEvent: 'jira:issue_updated',
+      issue: { key: 'REG-1' },
+      changelog: { items: [{ field: 'status', toString: 'Done' }] },
+    };
+    const result = handleWebhook(board, payload, 'http://localhost/api/webhooks/jira');
+    if (result.action !== 'status_change') throw new Error(`action: ${result.action}`);
+    if (result.karviStatus !== 'completed') throw new Error(`karviStatus: ${result.karviStatus}`);
+    ok('handleWebhook: issue_updated regression → status_change');
+  } catch (e) { fail('handleWebhook: issue_updated regression', e.message); }
+
+  console.log(`\n  ${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+}

--- a/server/server.js
+++ b/server/server.js
@@ -2140,6 +2140,40 @@ const server = bb.createServer(ctx, (req, res, helpers) => {
           json(res, 200, { ok: true, skipped: true, reason: result.error });
           return;
         }
+
+        // --- Handle create_task: append new task from Jira issue_created ---
+        if (result.action === 'create_task' && result.task) {
+          board.taskPlan = board.taskPlan || { tasks: [] };
+          board.taskPlan.tasks = board.taskPlan.tasks || [];
+          board.taskPlan.tasks.push(result.task);
+          writeBoard(board);
+          appendLog({ ts: nowIso(), event: 'jira_task_created', taskId: result.task.id, jiraKey: result.issueKey, source: 'jira-webhook' });
+
+          // Optional auto-dispatch via internal HTTP loopback (when config flag is set)
+          const jiraConfig = board.integrations?.jira || {};
+          if (jiraConfig.autoDispatchOnCreate) {
+            const taskId = result.task.id;
+            setImmediate(() => {
+              const http = require('http');
+              const authToken = process.env.KARVI_API_TOKEN;
+              const headers = {};
+              if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+              const dreq = http.request({
+                hostname: 'localhost',
+                port: ctx.port,
+                path: `/api/tasks/${encodeURIComponent(taskId)}/dispatch`,
+                method: 'POST',
+                headers,
+              });
+              dreq.on('error', err => console.error(`[jira-webhook] auto-dispatch failed for ${taskId}:`, err.message));
+              dreq.end();
+            });
+          }
+
+          json(res, 201, { ok: true, action: 'create_task', taskId: result.task.id, jiraKey: result.issueKey });
+          return;
+        }
+
         if (result.action === 'dispatch' && result.task) {
           result.task.status = 'dispatched';
           result.task.history = result.task.history || [];

--- a/server/smoke-test.js
+++ b/server/smoke-test.js
@@ -262,6 +262,79 @@ async function runSuite(target) {
     } catch (e) { fail('POST + GET /api/lessons', e.message); }
   }
 
+  // 13-16. Jira Webhook tests (task-engine only)
+  if (port === 3461) {
+    // 13. POST /api/webhooks/jira with issue_created → 201 + task created
+    try {
+      const jiraPayload = {
+        webhookEvent: 'jira:issue_created',
+        issue: {
+          key: 'SMOKE-9999',
+          fields: {
+            summary: 'Smoke test Jira ticket',
+            description: { type: 'doc', version: 1, content: [
+              { type: 'paragraph', content: [{ type: 'text', text: 'Smoke test description from Jira' }] },
+            ]},
+            priority: { name: 'High' },
+            assignee: { displayName: 'SmokeBot' },
+          },
+        },
+      };
+      const r = await post(port, '/api/webhooks/jira', jiraPayload);
+      if (r.status !== 201) throw new Error(`expected 201, got ${r.status}: ${r.body}`);
+      const body = JSON.parse(r.body);
+      if (body.action !== 'create_task') throw new Error(`expected action create_task, got ${body.action}`);
+      if (body.jiraKey !== 'SMOKE-9999') throw new Error(`expected jiraKey SMOKE-9999, got ${body.jiraKey}`);
+
+      // Verify task exists in board with correct fields
+      const boardR = await get(port, '/api/board');
+      const board = JSON.parse(boardR.body);
+      const task = (board.taskPlan?.tasks || []).find(t => t.jiraKey === 'SMOKE-9999');
+      if (!task) throw new Error('task not found in board');
+      if (task.source !== 'jira') throw new Error(`expected source jira, got ${task.source}`);
+      if (task.priority !== 'P1') throw new Error(`expected priority P1, got ${task.priority}`);
+      if (!task.jiraUrl) throw new Error('missing jiraUrl');
+      if (!task.description) throw new Error('missing description');
+      ok('POST /api/webhooks/jira (issue_created) → 201 + task in board');
+    } catch (e) { fail('POST /api/webhooks/jira (issue_created)', e.message); }
+
+    // 14. Duplicate issue_created → 200 with skipped
+    try {
+      const dupPayload = {
+        webhookEvent: 'jira:issue_created',
+        issue: {
+          key: 'SMOKE-9999',
+          fields: { summary: 'Duplicate ticket' },
+        },
+      };
+      const r = await post(port, '/api/webhooks/jira', dupPayload);
+      if (r.status !== 200) throw new Error(`expected 200, got ${r.status}`);
+      const body = JSON.parse(r.body);
+      if (!body.skipped) throw new Error('expected skipped: true');
+      ok('POST /api/webhooks/jira (duplicate) → 200 skipped');
+    } catch (e) { fail('POST /api/webhooks/jira (duplicate)', e.message); }
+
+    // 15. Invalid/unsupported event → 200 with skipped
+    try {
+      const r = await post(port, '/api/webhooks/jira', { webhookEvent: 'jira:unknown_event' });
+      if (r.status !== 200) throw new Error(`expected 200, got ${r.status}`);
+      const body = JSON.parse(r.body);
+      if (!body.skipped) throw new Error('expected skipped: true');
+      ok('POST /api/webhooks/jira (unsupported event) → 200 skipped');
+    } catch (e) { fail('POST /api/webhooks/jira (unsupported event)', e.message); }
+
+    // 16. Clean up: remove smoke test task from board
+    try {
+      const boardR = await get(port, '/api/board');
+      const board = JSON.parse(boardR.body);
+      if (board.taskPlan?.tasks) {
+        board.taskPlan.tasks = board.taskPlan.tasks.filter(t => t.jiraKey !== 'SMOKE-9999');
+        await post(port, '/api/board', board);
+      }
+      ok('Jira webhook cleanup → smoke task removed');
+    } catch (e) { fail('Jira webhook cleanup', e.message); }
+  }
+
   // Auth-specific tests (only when --token is provided)
   if (authToken) {
     console.log('\n  ── Auth tests ──');

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -124,6 +124,9 @@ export interface Task {
   blocker?: { reason: string; askedAt: string } | null;
   history?: HistoryEntry[];
   jiraKey?: string;
+  jiraUrl?: string;
+  source?: string;
+  priority?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -288,6 +291,7 @@ export interface JiraConfig {
   statusMapping: Record<string, TaskStatus>;
   reverseMapping: Record<string, string>;
   triggerStatus?: string;
+  autoDispatchOnCreate?: boolean;
   humanGate: {
     enabled: boolean;
     mergeRequiresHuman: boolean;


### PR DESCRIPTION
## Summary

Closes #24

- Add `jira:issue_created` webhook handling to `handleWebhook()` in `integration-jira.js`, extending the existing `jira:issue_updated` flow
- Server.js handles the new `create_task` action: appends task to `board.taskPlan.tasks[]`, writes board (triggers SSE broadcast), logs event
- Jira issue key used as task ID for human readability; dedup via `jiraKey` field prevents duplicate tasks on webhook replay
- ADF (Atlassian Document Format) descriptions recursively extracted to plain text (~20 lines, zero deps)
- Jira priority mapped to P0-P4 (Highest/Critical->P0, High->P1, Medium->P2, Low->P3, Lowest->P4)
- Optional `autoDispatchOnCreate` config flag for auto-dispatch via internal HTTP loopback
- `shared/types.ts` updated with `jiraUrl`, `source`, `priority` on Task and `autoDispatchOnCreate` on JiraConfig

## Files changed

| File | Lines | What |
|------|-------|------|
| `server/integration-jira.js` | +238 | `adfToPlainText`, `mapJiraPriority`, `buildTaskFromIssue`, `handleWebhook` issue_created branch, 7 self-tests |
| `server/server.js` | +34 | `create_task` action handler in webhook route (201 response + appendLog + optional auto-dispatch) |
| `shared/types.ts` | +4 | New optional fields: `jiraUrl`, `source`, `priority`, `autoDispatchOnCreate` |
| `server/smoke-test.js` | +73 | 4 webhook smoke tests (create, dedup, unsupported event, cleanup) |

## Acceptance criteria checklist

- [x] Jira `issue.created` webhook -> Karvi auto-create pending task
- [x] Task includes Jira ticket URL, key, summary, description
- [x] Duplicate webhook does not create duplicate task (jiraKey dedup)
- [x] Webhook secret verification failure returns 401 (existing, unchanged)
- [x] SSE real-time push to all clients (via `writeBoard()`)
- [x] Existing `issue_updated` handling unchanged (regression self-test)

## Test plan

- [x] `node server/integration-jira.js` -- 7/7 self-tests pass (adfToPlainText, mapJiraPriority, buildTaskFromIssue, handleWebhook create/dedup/regression)
- [x] `node -c server/server.js` -- syntax OK
- [x] `npm test` -- evolution loop integration test passes
- [ ] `node server/smoke-test.js 3461` -- webhook smoke tests (requires running server with Jira integration enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)