### PR TITLE
fix(ci): add missing files to syntax check and run unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,19 @@ jobs:
       # Syntax check all server JS files
       - name: Syntax check
         run: |
-          for f in server/server.js \
-                   server/blackboard-server.js \
-                   server/management.js \
-                   server/process-review.js \
-                   server/retro.js \
-                   server/runtime-openclaw.js \
-                   server/runtime-codex.js \
-                   server/runtime-claude.js \
-                   server/runtime-edda.js; do
+          for f in server/*.js; do
             echo "Checking $f..."
             node --check "$f"
           done
+
+      # Standalone unit tests (no server needed)
+      - name: Unit tests
+        run: |
+          node server/test-vault.js
+          node server/test-runtime-claude-api.js
+          node server/test-usage.js
+          node server/test-gateway.js
+          node server/test-instance-manager.js
 
       # Create initial board.json (gitignored, needed for server to start)
       - name: Seed board


### PR DESCRIPTION
## Summary
- Replace hardcoded 9-file syntax check with `server/*.js` glob, covering all 31 server JS files (22 were previously unchecked)
- Add a new "Unit tests" step that runs 5 standalone test suites (~199 tests) before server-dependent integration tests
- No changes to any server code -- only `.github/workflows/ci.yml` is modified

## Test plan
- [x] All 31 `server/*.js` files pass `node --check` locally
- [x] All 5 unit test suites pass locally (vault: 10, runtime-claude-api: 94, usage: 40, gateway: 45, instance-manager: 10)
- [x] No port conflicts (unit tests use 13460/14000+, integration uses 3461)
- [ ] CI pipeline passes on this PR

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)