### PR TITLE
feat(server): L1 confidence engine — 6-dimension signal computation (#52)

### DIFF
--- a/server/confidence-engine.js
+++ b/server/confidence-engine.js
@@ -1,0 +1,369 @@
+/**
+ * confidence-engine.js — L1 Confidence Signal Computation (#52)
+ *
+ * 任務完成後計算 6 維信心燈號，純數值/規則運算，不需要 LLM。
+ * 模式參考 digest-task.js — 獨立模組、注入依賴、同步觸發。
+ *
+ * 6 維信號:
+ *   tests        — 測試結果 (review issues 關鍵字)
+ *   quality      — 審查分數 (review.score)
+ *   scope        — 變更範圍 (diff files/lines)
+ *   requirements — AC 達成度 (description checkbox)
+ *   preflight    — lessons/policy 命中 (management.matchLessonsForTask)
+ *   agent        — agent 歷史成功率 (signals review_result)
+ *
+ * 零外部依賴 — 僅使用 Node.js 內建模組。
+ *
+ * @module confidence-engine
+ */
+
+const mgmt = require('./management');
+
+// --- Constants ---
+
+const SIGNAL_KEYS = ['tests', 'quality', 'scope', 'requirements', 'preflight', 'agent'];
+
+// Thresholds
+const QUALITY_GREEN = 70;
+const QUALITY_YELLOW = 50;
+const SCOPE_GREEN_FILES = 5;
+const SCOPE_YELLOW_FILES = 15;
+const AGENT_GREEN_RATE = 80;
+const AGENT_YELLOW_RATE = 50;
+const AGENT_MIN_REVIEWS = 3;
+const MAX_WARNINGS = 3;
+
+// --- Individual Signal Computers ---
+
+/**
+ * tests 信號: 從 review issues 中偵測測試相關關鍵字。
+ * @param {object} task
+ * @returns {{ key: string, state: string, label: string } | null}
+ */
+function computeTestsSignal(task) {
+  const review = task.review;
+  if (!review) return null;
+
+  const issues = review.issues || [];
+  const issueText = issues.map(i => typeof i === 'string' ? i : JSON.stringify(i)).join(' ');
+
+  // Check for test failures
+  if (/test.*fail|fail.*test|tests?\s+failed/i.test(issueText)) {
+    return { key: 'tests', state: 'red', label: 'Tests fail' };
+  }
+
+  // Check for flaky tests
+  if (/flaky|intermittent/i.test(issueText)) {
+    return { key: 'tests', state: 'yellow', label: 'Flaky tests' };
+  }
+
+  // Deterministic-only review with high score = green
+  if (review.source === 'deterministic-only' && (review.score || 0) >= 90) {
+    return { key: 'tests', state: 'green', label: 'Checks pass' };
+  }
+
+  // Review exists with no test issues
+  if (review.score != null) {
+    return { key: 'tests', state: 'green', label: 'No test issues' };
+  }
+
+  return null;
+}
+
+/**
+ * quality 信號: 直接映射 review.score。
+ * @param {object} task
+ * @returns {{ key: string, state: string, label: string } | null}
+ */
+function computeQualitySignal(task) {
+  const score = task.review?.score;
+  if (score == null) return null;
+
+  if (score >= QUALITY_GREEN) {
+    return { key: 'quality', state: 'green', label: `${score}/100` };
+  }
+  if (score >= QUALITY_YELLOW) {
+    return { key: 'quality', state: 'yellow', label: `${score}/100` };
+  }
+  return { key: 'quality', state: 'red', label: `${score}/100` };
+}
+
+/**
+ * scope 信號: 從 lastReply 或 review.report 解析檔案數/行數。
+ * @param {object} task
+ * @returns {{ key: string, state: string, label: string } | null}
+ */
+function computeScopeSignal(task) {
+  // Multi-source extraction with fallback chain
+  const sources = [
+    task.lastReply || '',
+    task.review?.report || '',
+    (task.review?.issues || []).join(' '),
+  ];
+
+  let files = null;
+  let lines = null;
+
+  for (const src of sources) {
+    if (files !== null) break;
+
+    // Try to extract file count
+    const fileMatch = src.match(/(\d+)\s*(?:files?|檔案)\s*(?:changed|modified|created|affected|touched)?/i);
+    if (fileMatch) {
+      files = parseInt(fileMatch[1], 10);
+    }
+
+    // Try to extract line count
+    const lineMatch = src.match(/[+](\d+)\s*(?:lines?|行)/i);
+    if (lineMatch) {
+      lines = parseInt(lineMatch[1], 10);
+    }
+  }
+
+  if (files === null) return null;
+
+  const label = lines != null ? `${files} files +${lines}` : `${files} files`;
+
+  if (files <= SCOPE_GREEN_FILES) {
+    return { key: 'scope', state: 'green', label };
+  }
+  if (files <= SCOPE_YELLOW_FILES) {
+    return { key: 'scope', state: 'yellow', label };
+  }
+  return { key: 'scope', state: 'red', label };
+}
+
+/**
+ * requirements 信號: 解析 task.description 中的 markdown checkbox。
+ * @param {object} task
+ * @returns {{ key: string, state: string, label: string } | null}
+ */
+function computeRequirementsSignal(task) {
+  const desc = task.description || '';
+  const checkboxes = desc.match(/- \[(x| )\]/gi);
+  if (!checkboxes || checkboxes.length === 0) return null;
+
+  const total = checkboxes.length;
+  const checked = checkboxes.filter(c => /\[x\]/i.test(c)).length;
+
+  if (checked === total) {
+    return { key: 'requirements', state: 'green', label: `AC ${checked}/${total}` };
+  }
+  if (checked >= total * 0.5) {
+    return { key: 'requirements', state: 'yellow', label: `AC ${checked}/${total}` };
+  }
+  return { key: 'requirements', state: 'red', label: `AC ${checked}/${total}` };
+}
+
+/**
+ * preflight 信號: 檢查 lessons/policy 命中數。
+ * @param {object} board
+ * @param {object} task
+ * @returns {{ key: string, state: string, label: string } | null}
+ */
+function computePreflightSignal(board, task) {
+  let lessonResult;
+  try {
+    lessonResult = mgmt.matchLessonsForTask(board, task);
+  } catch {
+    return null;
+  }
+
+  const matched = lessonResult.matched || [];
+  if (matched.length === 0) {
+    return { key: 'preflight', state: 'green', label: 'No hits' };
+  }
+
+  // 3+ matches = red
+  if (matched.length >= 3) {
+    return { key: 'preflight', state: 'red', label: `${matched.length} warnings` };
+  }
+
+  // Agent-specific matches = yellow
+  if (matched.some(l => l.relevance === 'agent')) {
+    return { key: 'preflight', state: 'yellow', label: `Hit ${matched.length}` };
+  }
+
+  return { key: 'preflight', state: 'yellow', label: `Hit ${matched.length}` };
+}
+
+/**
+ * agent 信號: 計算 agent 歷史成功率。
+ * @param {object} board
+ * @param {object} task
+ * @returns {{ key: string, state: string, label: string } | null}
+ */
+function computeAgentSignal(board, task) {
+  const assignee = task.assignee;
+  if (!assignee) return null;
+
+  const signals = board.signals || [];
+  const reviewSignals = signals.filter(
+    s => s.type === 'review_result' && s.data?.assignee === assignee
+  );
+
+  if (reviewSignals.length < AGENT_MIN_REVIEWS) return null;
+
+  const total = reviewSignals.length;
+  const approved = reviewSignals.filter(s => s.data?.result === 'approved').length;
+  const successRate = Math.round((approved / total) * 100);
+
+  if (successRate >= AGENT_GREEN_RATE) {
+    return { key: 'agent', state: 'green', label: `Rate ${successRate}%` };
+  }
+  if (successRate >= AGENT_YELLOW_RATE) {
+    return { key: 'agent', state: 'yellow', label: `Rate ${successRate}%` };
+  }
+  return { key: 'agent', state: 'red', label: `Rate ${successRate}%` };
+}
+
+// --- Warning Generation ---
+
+/**
+ * 從非綠信號產生警告文字 (最多 MAX_WARNINGS 條)。
+ * @param {Array} signals - 非 null 信號列表
+ * @param {object} board
+ * @param {object} task
+ * @returns {string[]}
+ */
+function generateWarnings(signals, board, task) {
+  const warnings = [];
+
+  // Collect non-green signals, prioritize red over yellow
+  const redSignals = signals.filter(s => s.state === 'red');
+  const yellowSignals = signals.filter(s => s.state === 'yellow');
+
+  const warningCandidates = [...redSignals, ...yellowSignals];
+
+  for (const signal of warningCandidates) {
+    if (warnings.length >= MAX_WARNINGS) break;
+
+    switch (signal.key) {
+      case 'tests':
+        warnings.push(`tests: ${signal.label}`);
+        break;
+      case 'quality':
+        warnings.push(`quality score ${signal.label}`);
+        break;
+      case 'scope':
+        warnings.push(`scope: ${signal.label}`);
+        break;
+      case 'requirements':
+        warnings.push(`requirements: ${signal.label}`);
+        break;
+      case 'preflight':
+        warnings.push(`preflight: ${signal.label}`);
+        break;
+      case 'agent': {
+        // Try to add lesson context for agent warnings
+        let agentWarning = `agent: ${signal.label}`;
+        try {
+          const lessonResult = mgmt.matchLessonsForTask(board, task);
+          const agentLessons = (lessonResult.matched || [])
+            .filter(l => l.relevance === 'agent');
+          if (agentLessons.length > 0) {
+            agentWarning = agentLessons[0].rule.slice(0, 50);
+          }
+        } catch { /* ignore */ }
+        warnings.push(agentWarning);
+        break;
+      }
+      default:
+        warnings.push(`${signal.key}: ${signal.label}`);
+    }
+  }
+
+  return warnings;
+}
+
+// --- Main Computation ---
+
+/**
+ * 計算 6 維信心燈號。純同步運算，不需要 LLM。
+ * @param {object} board - 完整 board 物件
+ * @param {object} task - 要計算的 task
+ * @returns {{ signals: Array, warnings: string[], overall: number, computedAt: string }}
+ */
+function computeConfidence(board, task) {
+  const allSignals = [
+    computeTestsSignal(task),
+    computeQualitySignal(task),
+    computeScopeSignal(task),
+    computeRequirementsSignal(task),
+    computePreflightSignal(board, task),
+    computeAgentSignal(board, task),
+  ];
+
+  // Filter out null signals
+  const signals = allSignals.filter(Boolean);
+  const overall = signals.filter(s => s.state === 'green').length;
+  const warnings = generateWarnings(signals, board, task);
+
+  return {
+    signals,
+    warnings,
+    overall,
+    computedAt: new Date().toISOString(),
+  };
+}
+
+// --- Trigger Function ---
+
+/**
+ * 觸發信心計算。從 server.js 呼叫，同步執行。
+ *
+ * @param {string} taskId
+ * @param {string} event - 觸發事件 ('review_completed', 'approved', 'manual')
+ * @param {object} deps - { readBoard, writeBoard, broadcastSSE, appendLog }
+ */
+function triggerConfidence(taskId, event, { readBoard, writeBoard, broadcastSSE, appendLog }) {
+  const board = readBoard();
+  const task = (board.taskPlan?.tasks || []).find(t => t.id === taskId);
+  if (!task) {
+    console.warn(`[confidence:${taskId}] task not found, skipping`);
+    return;
+  }
+
+  const confidence = computeConfidence(board, task);
+
+  // Write confidence to task on the same board we just read
+  task.confidence = confidence;
+  writeBoard(board);
+  {
+    broadcastSSE('task.confidence_updated', { taskId, confidence });
+    appendLog({
+      ts: new Date().toISOString(),
+      event: 'confidence_computed',
+      taskId,
+      trigger: event,
+      overall: confidence.overall,
+      signalCount: confidence.signals.length,
+    });
+    console.log(`[confidence:${taskId}] computed (trigger: ${event}, overall: ${confidence.overall}/${confidence.signals.length})`);
+  }
+}
+
+// --- Exports ---
+
+module.exports = {
+  computeConfidence,
+  triggerConfidence,
+  _internal: {
+    SIGNAL_KEYS,
+    computeTestsSignal,
+    computeQualitySignal,
+    computeScopeSignal,
+    computeRequirementsSignal,
+    computePreflightSignal,
+    computeAgentSignal,
+    generateWarnings,
+    QUALITY_GREEN,
+    QUALITY_YELLOW,
+    SCOPE_GREEN_FILES,
+    SCOPE_YELLOW_FILES,
+    AGENT_GREEN_RATE,
+    AGENT_YELLOW_RATE,
+    AGENT_MIN_REVIEWS,
+    MAX_WARNINGS,
+  },
+};

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -411,7 +411,7 @@ function summarizeBriefAsSignal(taskId, helpers, DIR) {
 }
 
 module.exports = function tasksRoutes(req, res, helpers, deps) {
-  const { mgmt, runtime, push, usage, ctx, jiraIntegration, digestTask, timelineTask, PUSH_TOKENS_PATH, DIR, DATA_DIR } = deps;
+  const { mgmt, runtime, push, usage, ctx, jiraIntegration, digestTask, timelineTask, confidenceEngine, PUSH_TOKENS_PATH, DIR, DATA_DIR } = deps;
 
   // --- Manual review trigger ---
 
@@ -646,6 +646,15 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
                   console.log(`[review:${taskId}] auto-redispatch triggered`);
                   setImmediate(() => redispatchTask(updatedBoard, t, deps, helpers));
                 }
+                // L1 Confidence: compute before digest so confidence feeds into L2
+                if (confidenceEngine) {
+                  try {
+                    confidenceEngine.triggerConfidence(taskId, 'review_completed', {
+                      readBoard: helpers.readBoard, writeBoard: helpers.writeBoard,
+                      broadcastSSE: helpers.broadcastSSE, appendLog: helpers.appendLog,
+                    });
+                  } catch (err) { console.error(`[confidence:${taskId}] error:`, err.message); }
+                }
                 // L2 Digest: trigger after review completion
                 if (digestTask?.isDigestEnabled()) {
                   setImmediate(() => {
@@ -662,6 +671,15 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
           }));
         }
 
+        // L1 Confidence: trigger after task approved
+        if (payload.status === 'approved' && confidenceEngine) {
+          try {
+            confidenceEngine.triggerConfidence(taskId, 'approved', {
+              readBoard: helpers.readBoard, writeBoard: helpers.writeBoard,
+              broadcastSSE: helpers.broadcastSSE, appendLog: helpers.appendLog,
+            });
+          } catch (err) { console.error(`[confidence:${taskId}] error:`, err.message); }
+        }
         // L2 Digest: trigger after task approved
         if (payload.status === 'approved' && digestTask?.isDigestEnabled()) {
           setImmediate(() => {
@@ -857,6 +875,15 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
                 ) {
                   console.log(`[review:${taskId}] auto-redispatch triggered`);
                   setImmediate(() => redispatchTask(updatedBoard, t, deps, helpers));
+                }
+                // L1 Confidence: compute before digest so confidence feeds into L2
+                if (confidenceEngine) {
+                  try {
+                    confidenceEngine.triggerConfidence(taskId, 'review_completed', {
+                      readBoard: helpers.readBoard, writeBoard: helpers.writeBoard,
+                      broadcastSSE: helpers.broadcastSSE, appendLog: helpers.appendLog,
+                    });
+                  } catch (err) { console.error(`[confidence:${taskId}] error:`, err.message); }
                 }
                 // L2 Digest: trigger after review completion
                 if (digestTask?.isDigestEnabled()) {
@@ -1233,6 +1260,34 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
     }).then(() => json(res, 200, { ok: true, taskId }))
       .catch(err => json(res, 500, { error: err.message }));
     return;
+  }
+
+  // --- L1 Confidence API ---
+
+  const confidenceMatch = req.url.match(/^\/api\/tasks\/([^/]+)\/confidence$/);
+  if (req.method === 'GET' && confidenceMatch) {
+    const taskId = decodeURIComponent(confidenceMatch[1]);
+    const board = helpers.readBoard();
+    const task = (board.taskPlan?.tasks || []).find(t => t.id === taskId);
+    if (!task) return json(res, 404, { error: 'Task not found' });
+    if (!task.confidence) return json(res, 404, { error: 'No confidence data available' });
+    return json(res, 200, task.confidence);
+  }
+
+  if (req.method === 'POST' && confidenceMatch) {
+    const taskId = decodeURIComponent(confidenceMatch[1]);
+    if (!confidenceEngine) return json(res, 503, { error: 'Confidence engine not available' });
+    try {
+      confidenceEngine.triggerConfidence(taskId, 'manual', {
+        readBoard: helpers.readBoard, writeBoard: helpers.writeBoard,
+        broadcastSSE: helpers.broadcastSSE, appendLog: helpers.appendLog,
+      });
+      const board = helpers.readBoard();
+      const task = (board.taskPlan?.tasks || []).find(t => t.id === taskId);
+      return json(res, 200, { ok: true, taskId, confidence: task?.confidence || null });
+    } catch (err) {
+      return json(res, 500, { error: err.message });
+    }
   }
 
   // --- L3 Timeline API ---

--- a/server/server.js
+++ b/server/server.js
@@ -26,6 +26,9 @@ try { digestTask = require('./digest-task'); } catch { /* digest-task not availa
 let timelineTask = null;
 try { timelineTask = require('./timeline-task'); } catch { /* timeline-task not available, skip */ }
 
+let confidenceEngine = null;
+try { confidenceEngine = require('./confidence-engine'); } catch { /* confidence-engine not available, skip */ }
+
 const telemetry = require('./telemetry');
 const push = require('./push');
 const githubApi = require('./github-api');
@@ -75,6 +78,7 @@ const deps = {
   jiraIntegration,
   digestTask,
   timelineTask,
+  confidenceEngine,
 
   // Config / paths
   ctx,

--- a/server/smoke-test.js
+++ b/server/smoke-test.js
@@ -778,6 +778,31 @@ async function runSuite(target) {
     // It calls gracefulShutdown() which terminates the server process,
     // preventing remaining tests from running. The endpoint is trivial
     // (respond 200 then shutdown) and is better covered by lifecycle tests.
+
+    // ── L1 Confidence API ──
+    // GET /api/tasks/:id/confidence → 404 (no confidence on nonexistent task)
+    try {
+      const r = await get(port, '/api/tasks/SMOKE-NOEXIST/confidence');
+      if (r.status === 404) {
+        const body = JSON.parse(r.body);
+        if (!body.error) throw new Error('missing error message');
+        ok(`GET /api/tasks/:id/confidence (no task) → 404`);
+      } else {
+        throw new Error(`expected 404, got ${r.status}`);
+      }
+    } catch (e) { fail('GET /api/tasks/:id/confidence', e.message); }
+
+    // POST /api/tasks/:id/confidence → 404 (no task) or 503 (engine unavailable)
+    try {
+      const r = await post(port, '/api/tasks/SMOKE-NOEXIST/confidence', {});
+      if (r.status === 404 || r.status === 503) {
+        const body = JSON.parse(r.body);
+        if (!body.error) throw new Error('missing error message');
+        ok(`POST /api/tasks/:id/confidence → ${r.status} (expected without task)`);
+      } else {
+        throw new Error(`expected 404 or 503, got ${r.status}`);
+      }
+    } catch (e) { fail('POST /api/tasks/:id/confidence', e.message); }
   }
 
   // Auth-specific tests (only when --token is provided)

--- a/server/test-confidence-engine.js
+++ b/server/test-confidence-engine.js
@@ -1,0 +1,490 @@
+#!/usr/bin/env node
+/**
+ * test-confidence-engine.js — Unit tests for confidence-engine.js (#52)
+ *
+ * Tests all 6 signal dimensions, warning generation, overall computation,
+ * trigger flow, and graceful fallbacks.
+ * No external dependencies, no real API calls.
+ *
+ * Usage:
+ *   node server/test-confidence-engine.js
+ */
+
+const engine = require('./confidence-engine');
+const {
+  computeTestsSignal,
+  computeQualitySignal,
+  computeScopeSignal,
+  computeRequirementsSignal,
+  computePreflightSignal,
+  computeAgentSignal,
+  generateWarnings,
+  QUALITY_GREEN,
+  QUALITY_YELLOW,
+  SCOPE_GREEN_FILES,
+  SCOPE_YELLOW_FILES,
+  AGENT_GREEN_RATE,
+  AGENT_YELLOW_RATE,
+  AGENT_MIN_REVIEWS,
+  MAX_WARNINGS,
+} = engine._internal;
+
+let passed = 0;
+let failed = 0;
+
+function ok(name) { passed++; console.log(`  OK  ${name}`); }
+function fail(name, err) { failed++; console.log(`  FAIL  ${name}: ${err || '(unknown)'}`); }
+
+function assert(condition, name, detail) {
+  if (condition) ok(name);
+  else fail(name, detail || 'assertion failed');
+}
+
+// --- Test data ---
+
+function makeBoard(overrides = {}) {
+  return {
+    taskPlan: { tasks: [] },
+    lessons: [],
+    insights: [],
+    signals: [],
+    ...overrides,
+  };
+}
+
+function makeTask(overrides = {}) {
+  return {
+    id: 'T1',
+    title: 'Test task',
+    description: '',
+    status: 'completed',
+    assignee: 'eng_1',
+    review: null,
+    lastReply: '',
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+console.log('\n=== confidence-engine.js tests ===\n');
+
+// --- computeTestsSignal ---
+console.log('-- computeTestsSignal --');
+
+assert(
+  computeTestsSignal(makeTask()) === null,
+  'no review → null'
+);
+
+assert(
+  computeTestsSignal(makeTask({ review: { score: 85, issues: ['Missing error boundary'] } })).state === 'green',
+  'review with no test issues → green'
+);
+
+assert(
+  computeTestsSignal(makeTask({ review: { score: 85, issues: ['test failed in auth module'] } })).state === 'red',
+  'review with test failure → red'
+);
+
+assert(
+  computeTestsSignal(makeTask({ review: { score: 85, issues: ['Tests fail on CI'] } })).state === 'red',
+  'review with "Tests fail" → red'
+);
+
+assert(
+  computeTestsSignal(makeTask({ review: { score: 85, issues: ['flaky timeout in integration'] } })).state === 'yellow',
+  'review with flaky → yellow'
+);
+
+assert(
+  computeTestsSignal(makeTask({ review: { score: 95, source: 'deterministic-only', issues: [] } })).state === 'green',
+  'deterministic review 95 → green'
+);
+
+assert(
+  computeTestsSignal(makeTask({ review: { score: 95, source: 'deterministic-only', issues: [] } })).label === 'Checks pass',
+  'deterministic review label = "Checks pass"'
+);
+
+// --- computeQualitySignal ---
+console.log('\n-- computeQualitySignal --');
+
+assert(
+  computeQualitySignal(makeTask()) === null,
+  'no review → null'
+);
+
+assert(
+  computeQualitySignal(makeTask({ review: { score: null } })) === null,
+  'score null → null'
+);
+
+const q90 = computeQualitySignal(makeTask({ review: { score: 90 } }));
+assert(q90.state === 'green', 'score 90 → green');
+assert(q90.label === '90/100', 'score 90 label = "90/100"');
+
+const q60 = computeQualitySignal(makeTask({ review: { score: 60 } }));
+assert(q60.state === 'yellow', 'score 60 → yellow');
+
+const q30 = computeQualitySignal(makeTask({ review: { score: 30 } }));
+assert(q30.state === 'red', 'score 30 → red');
+
+const q70 = computeQualitySignal(makeTask({ review: { score: 70 } }));
+assert(q70.state === 'green', 'score 70 (boundary) → green');
+
+const q50 = computeQualitySignal(makeTask({ review: { score: 50 } }));
+assert(q50.state === 'yellow', 'score 50 (boundary) → yellow');
+
+const q49 = computeQualitySignal(makeTask({ review: { score: 49 } }));
+assert(q49.state === 'red', 'score 49 → red');
+
+// --- computeScopeSignal ---
+console.log('\n-- computeScopeSignal --');
+
+assert(
+  computeScopeSignal(makeTask()) === null,
+  'no reply → null'
+);
+
+const s3 = computeScopeSignal(makeTask({ lastReply: 'Changed 3 files, +80 lines' }));
+assert(s3 !== null, '3 files found');
+assert(s3.state === 'green', '3 files → green');
+assert(s3.label.includes('3 files'), 'label includes "3 files"');
+assert(s3.label.includes('+80'), 'label includes "+80"');
+
+const s10 = computeScopeSignal(makeTask({ lastReply: 'Modified 10 files' }));
+assert(s10.state === 'yellow', '10 files → yellow');
+
+const s20 = computeScopeSignal(makeTask({ lastReply: '20 files changed' }));
+assert(s20.state === 'red', '20 files → red');
+
+const s5 = computeScopeSignal(makeTask({ lastReply: '5 files modified' }));
+assert(s5.state === 'green', '5 files (boundary) → green');
+
+const s15 = computeScopeSignal(makeTask({ lastReply: '15 files changed' }));
+assert(s15.state === 'yellow', '15 files (boundary) → yellow');
+
+const s16 = computeScopeSignal(makeTask({ lastReply: '16 files changed' }));
+assert(s16.state === 'red', '16 files → red');
+
+// Fallback to review report
+const sReport = computeScopeSignal(makeTask({
+  lastReply: '',
+  review: { score: 80, report: 'Reviewed 4 files' },
+}));
+assert(sReport !== null && sReport.state === 'green', 'fallback to review report → green');
+
+// Chinese file count
+const sChinese = computeScopeSignal(makeTask({ lastReply: '修改了 3 檔案' }));
+assert(sChinese !== null && sChinese.state === 'green', 'Chinese 檔案 → green');
+
+// --- computeRequirementsSignal ---
+console.log('\n-- computeRequirementsSignal --');
+
+assert(
+  computeRequirementsSignal(makeTask()) === null,
+  'no description → null'
+);
+
+assert(
+  computeRequirementsSignal(makeTask({ description: 'Just a plain description' })) === null,
+  'no checkboxes → null'
+);
+
+const rAll = computeRequirementsSignal(makeTask({ description: '- [x] Item 1\n- [x] Item 2\n- [x] Item 3' }));
+assert(rAll.state === 'green', 'all checked → green');
+assert(rAll.label === 'AC 3/3', 'label = "AC 3/3"');
+
+const rPartial = computeRequirementsSignal(makeTask({ description: '- [x] Item 1\n- [ ] Item 2\n- [x] Item 3' }));
+assert(rPartial.state === 'yellow', '2/3 checked → yellow');
+assert(rPartial.label === 'AC 2/3', 'label = "AC 2/3"');
+
+const rNone = computeRequirementsSignal(makeTask({ description: '- [ ] Item 1\n- [ ] Item 2\n- [ ] Item 3' }));
+assert(rNone.state === 'red', '0/3 checked → red');
+
+const rHalf = computeRequirementsSignal(makeTask({ description: '- [x] A\n- [ ] B' }));
+assert(rHalf.state === 'yellow', '1/2 checked (50%) → yellow');
+
+const rBelow = computeRequirementsSignal(makeTask({ description: '- [x] A\n- [ ] B\n- [ ] C\n- [ ] D' }));
+assert(rBelow.state === 'red', '1/4 checked (25%) → red');
+
+// --- computePreflightSignal ---
+console.log('\n-- computePreflightSignal --');
+
+const pfNone = computePreflightSignal(makeBoard(), makeTask());
+assert(pfNone.state === 'green', 'no lessons → green');
+assert(pfNone.label === 'No hits', 'label = "No hits"');
+
+const pfBoard = makeBoard({
+  lessons: [
+    { id: 'l1', status: 'active', rule: 'Always validate input', fromInsight: 'i1' },
+  ],
+  insights: [
+    { id: 'i1', data: { agent: 'eng_1' } },
+  ],
+});
+const pfAgent = computePreflightSignal(pfBoard, makeTask({ assignee: 'eng_1' }));
+assert(pfAgent.state === 'yellow', 'agent-specific lesson → yellow');
+
+const pfMany = makeBoard({
+  lessons: [
+    { id: 'l1', status: 'validated', rule: 'Rule 1' },
+    { id: 'l2', status: 'validated', rule: 'Rule 2' },
+    { id: 'l3', status: 'validated', rule: 'Rule 3' },
+  ],
+});
+const pfRed = computePreflightSignal(pfMany, makeTask());
+assert(pfRed.state === 'red', '3+ validated lessons → red');
+
+// --- computeAgentSignal ---
+console.log('\n-- computeAgentSignal --');
+
+assert(
+  computeAgentSignal(makeBoard(), makeTask()) === null,
+  'no signals → null'
+);
+
+assert(
+  computeAgentSignal(makeBoard(), makeTask({ assignee: null })) === null,
+  'no assignee → null'
+);
+
+// < 3 reviews → null
+const agFew = makeBoard({
+  signals: [
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+  ],
+});
+assert(computeAgentSignal(agFew, makeTask()) === null, '<3 reviews → null');
+
+// 4/5 approved = 80% → green
+const agGreen = makeBoard({
+  signals: [
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'rejected' } },
+  ],
+});
+const agGreenSig = computeAgentSignal(agGreen, makeTask());
+assert(agGreenSig.state === 'green', '80% → green');
+assert(agGreenSig.label === 'Rate 80%', 'label = "Rate 80%"');
+
+// 3/5 = 60% → yellow
+const agYellow = makeBoard({
+  signals: [
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'rejected' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'rejected' } },
+  ],
+});
+assert(computeAgentSignal(agYellow, makeTask()).state === 'yellow', '60% → yellow');
+
+// 1/4 = 25% → red
+const agRed = makeBoard({
+  signals: [
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'rejected' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'rejected' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'rejected' } },
+  ],
+});
+assert(computeAgentSignal(agRed, makeTask()).state === 'red', '25% → red');
+
+// Agent isolation: different agent signals not counted
+const agIso = makeBoard({
+  signals: [
+    { type: 'review_result', data: { assignee: 'eng_2', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_2', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_2', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'rejected' } },
+  ],
+});
+assert(computeAgentSignal(agIso, makeTask({ assignee: 'eng_1' })) === null, 'different agent → only 1 review → null');
+
+// --- generateWarnings ---
+console.log('\n-- generateWarnings --');
+
+const warnSignals = [
+  { key: 'tests', state: 'red', label: 'Tests fail' },
+  { key: 'quality', state: 'yellow', label: '55/100' },
+  { key: 'scope', state: 'red', label: '20 files' },
+  { key: 'agent', state: 'yellow', label: 'Rate 60%' },
+];
+const warns = generateWarnings(warnSignals, makeBoard(), makeTask());
+assert(warns.length <= MAX_WARNINGS, `max ${MAX_WARNINGS} warnings`);
+assert(warns.length === 3, `got ${warns.length} warnings (cap at 3)`);
+// Red signals prioritized
+assert(warns[0].includes('tests'), 'first warning is red (tests)');
+assert(warns[1].includes('scope'), 'second warning is red (scope)');
+
+// No warnings when all green
+const greenSignals = [
+  { key: 'tests', state: 'green', label: 'All pass' },
+  { key: 'quality', state: 'green', label: '90/100' },
+];
+const noWarns = generateWarnings(greenSignals, makeBoard(), makeTask());
+assert(noWarns.length === 0, 'all green → 0 warnings');
+
+// --- computeConfidence (integration) ---
+console.log('\n-- computeConfidence (integration) --');
+
+const fullTask = makeTask({
+  review: { score: 85, issues: ['Minor style issues'] },
+  lastReply: 'Modified 3 files, +120 lines',
+  description: '- [x] Login form\n- [x] JWT tokens\n- [x] Error handling',
+});
+const fullBoard = makeBoard({
+  signals: [
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+    { type: 'review_result', data: { assignee: 'eng_1', result: 'approved' } },
+  ],
+});
+
+const conf = engine.computeConfidence(fullBoard, fullTask);
+assert(conf.signals.length > 0, 'signals not empty');
+assert(typeof conf.overall === 'number', 'overall is number');
+assert(typeof conf.computedAt === 'string', 'computedAt is string');
+assert(Array.isArray(conf.warnings), 'warnings is array');
+
+// All signals should be green in this scenario
+const allGreen = conf.signals.every(s => s.state === 'green');
+assert(allGreen, 'full task → all green');
+assert(conf.overall === conf.signals.length, 'overall = signal count when all green');
+
+// --- computeConfidence with mixed signals ---
+console.log('\n-- computeConfidence (mixed signals) --');
+
+const mixedTask = makeTask({
+  review: { score: 45, issues: ['test failed in auth'] },
+  lastReply: 'Modified 20 files',
+  description: '- [x] Login\n- [ ] Logout',
+});
+const mixedConf = engine.computeConfidence(makeBoard(), mixedTask);
+assert(mixedConf.signals.length > 0, 'mixed signals not empty');
+
+const redCount = mixedConf.signals.filter(s => s.state === 'red').length;
+assert(redCount >= 2, `at least 2 red signals (got ${redCount})`);
+assert(mixedConf.warnings.length > 0, 'mixed signals produce warnings');
+assert(mixedConf.overall < mixedConf.signals.length, 'overall < total when not all green');
+
+// --- computeConfidence with all null signals ---
+console.log('\n-- computeConfidence (all null) --');
+
+const emptyTask = makeTask({
+  review: null,
+  lastReply: '',
+  description: '',
+  assignee: null,
+});
+const emptyConf = engine.computeConfidence(makeBoard(), emptyTask);
+assert(emptyConf.signals.length === 0 || emptyConf.signals.every(s => s !== null), 'no null signals in output');
+assert(emptyConf.overall === 0 || emptyConf.signals.filter(s => s.state === 'green').length === emptyConf.overall, 'overall correct for empty');
+assert(emptyConf.warnings.length === 0, 'no warnings for empty task');
+
+// --- triggerConfidence ---
+console.log('\n-- triggerConfidence --');
+
+function testTrigger() {
+  let boardState = JSON.parse(JSON.stringify({
+    taskPlan: {
+      tasks: [
+        makeTask({
+          review: { score: 85, issues: [] },
+          lastReply: 'Modified 2 files',
+        }),
+      ],
+    },
+    lessons: [],
+    insights: [],
+    signals: [],
+  }));
+
+  let sseBroadcasts = [];
+  let logEntries = [];
+
+  const mockDeps = {
+    readBoard: () => JSON.parse(JSON.stringify(boardState)),
+    writeBoard: (b) => { boardState = b; },
+    broadcastSSE: (ev, data) => { sseBroadcasts.push({ ev, data }); },
+    appendLog: (entry) => { logEntries.push(entry); },
+  };
+
+  engine.triggerConfidence('T1', 'review_completed', mockDeps);
+
+  const updatedTask = (boardState.taskPlan?.tasks || []).find(t => t.id === 'T1');
+  assert(updatedTask?.confidence !== undefined, 'confidence written to task');
+  assert(updatedTask?.confidence.signals.length > 0, 'signals populated');
+  assert(typeof updatedTask?.confidence.overall === 'number', 'overall is number');
+  assert(sseBroadcasts.length === 1, 'SSE broadcast sent');
+  assert(sseBroadcasts[0].ev === 'task.confidence_updated', 'SSE event name correct');
+  assert(sseBroadcasts[0].data.taskId === 'T1', 'SSE data has taskId');
+  assert(logEntries.length === 1, 'log entry appended');
+  assert(logEntries[0].event === 'confidence_computed', 'log event name correct');
+  assert(logEntries[0].trigger === 'review_completed', 'log trigger correct');
+}
+
+function testTriggerMissingTask() {
+  let boardState = { taskPlan: { tasks: [] } };
+  const mockDeps = {
+    readBoard: () => JSON.parse(JSON.stringify(boardState)),
+    writeBoard: () => {},
+    broadcastSSE: () => {},
+    appendLog: () => {},
+  };
+
+  // Should not throw, just skip silently
+  engine.triggerConfidence('NONEXISTENT', 'manual', mockDeps);
+  ok('triggerConfidence skips missing task');
+}
+
+try {
+  testTrigger();
+} catch (e) {
+  fail('triggerConfidence', e.message);
+}
+
+try {
+  testTriggerMissingTask();
+} catch (e) {
+  fail('triggerConfidence missing task', e.message);
+}
+
+// --- Overall score denominator ---
+console.log('\n-- overall denominator --');
+
+// When some signals are null, overall should only count non-null green signals
+const partialTask = makeTask({
+  review: { score: 85, issues: [] },
+  lastReply: '',        // no scope data → null signal
+  description: '',      // no checkboxes → null signal
+  assignee: null,       // no assignee → null agent signal
+});
+const partialConf = engine.computeConfidence(makeBoard(), partialTask);
+const nonNullCount = partialConf.signals.length;
+assert(nonNullCount < 6, `some signals skipped (got ${nonNullCount})`);
+assert(partialConf.overall <= nonNullCount, 'overall <= non-null count');
+
+// --- Constants exported ---
+console.log('\n-- constants --');
+
+assert(QUALITY_GREEN === 70, 'QUALITY_GREEN = 70');
+assert(QUALITY_YELLOW === 50, 'QUALITY_YELLOW = 50');
+assert(SCOPE_GREEN_FILES === 5, 'SCOPE_GREEN_FILES = 5');
+assert(SCOPE_YELLOW_FILES === 15, 'SCOPE_YELLOW_FILES = 15');
+assert(AGENT_GREEN_RATE === 80, 'AGENT_GREEN_RATE = 80');
+assert(AGENT_YELLOW_RATE === 50, 'AGENT_YELLOW_RATE = 50');
+assert(AGENT_MIN_REVIEWS === 3, 'AGENT_MIN_REVIEWS = 3');
+assert(MAX_WARNINGS === 3, 'MAX_WARNINGS = 3');
+
+// --- Summary ---
+console.log(`\n${'='.repeat(40)}`);
+console.log(`Total: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- Add `server/confidence-engine.js` — standalone module that computes 6 confidence signals (tests, quality, scope, requirements, preflight, agent) for completed tasks using pure numeric/rule-based logic, no LLM calls
- Integrate into `server.js` trigger flow: runs after review completes and on manual approval, before L2 digest so `task.confidence` feeds into digest context
- Add `GET/POST /api/tasks/:id/confidence` endpoints for reading and manually triggering confidence computation
- Add 87 unit tests covering all dimensions, boundary values, warnings, and graceful fallbacks
- Update `smoke-test.js` with confidence API endpoint coverage

## Design

Follows the proven `digest-task.js` pattern:
- Separate module with injected dependencies (`readBoard`, `writeBoard`, `broadcastSSE`, `appendLog`)
- Synchronous computation (no async needed since no LLM)
- SSE broadcast (`task.confidence_updated`) for real-time UI updates
- Writes to `task.confidence` field on `board.json`

### 6 Dimensions

| Signal | Source | Green | Yellow | Red |
|--------|--------|-------|--------|-----|
| tests | review.issues keywords | No test issues | Flaky | Test failures |
| quality | review.score | >=70 | 50-69 | <50 |
| scope | lastReply/review file count | <=5 files | 6-15 files | >15 files |
| requirements | description checkboxes | All checked | >=50% | <50% |
| preflight | matchLessonsForTask() | No hits | 1-2 lessons | 3+ lessons |
| agent | signals review history | >=80% | 50-79% | <50% |

Null signals (insufficient data) are gracefully skipped — `overall` denominator adjusts accordingly.

## Test plan

- [x] `node --check server/confidence-engine.js` — syntax valid
- [x] `node --check server/server.js` — syntax valid
- [x] `node server/test-confidence-engine.js` — 87/87 pass, 0 fail
- [x] `npm test` — evolution loop integration test passes
- [ ] Smoke test with running server (`node server/smoke-test.js 3461`)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)