### PR TITLE
feat(server): L3 deep timeline — task timeline assembly + HTML report export (#54)

### DIFF
--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -411,7 +411,7 @@ function summarizeBriefAsSignal(taskId, helpers, DIR) {
 }
 
 module.exports = function tasksRoutes(req, res, helpers, deps) {
-  const { mgmt, runtime, push, usage, ctx, jiraIntegration, digestTask, PUSH_TOKENS_PATH, DIR, DATA_DIR } = deps;
+  const { mgmt, runtime, push, usage, ctx, jiraIntegration, digestTask, timelineTask, PUSH_TOKENS_PATH, DIR, DATA_DIR } = deps;
 
   // --- Manual review trigger ---
 
@@ -1233,6 +1233,33 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
     }).then(() => json(res, 200, { ok: true, taskId }))
       .catch(err => json(res, 500, { error: err.message }));
     return;
+  }
+
+  // --- L3 Timeline API ---
+
+  const timelineMatch = req.url.match(/^\/api\/tasks\/([^/]+)\/timeline$/);
+  if (req.method === 'GET' && timelineMatch) {
+    const taskId = decodeURIComponent(timelineMatch[1]);
+    if (!timelineTask) return json(res, 503, { error: 'Timeline module not available' });
+    const board = helpers.readBoard();
+    const task = (board.taskPlan?.tasks || []).find(t => t.id === taskId);
+    if (!task) return json(res, 404, { error: 'Task not found' });
+    const timeline = timelineTask.assembleTimeline(board, task);
+    return json(res, 200, { taskId, count: timeline.length, timeline });
+  }
+
+  const reportMatch = req.url.match(/^\/api\/tasks\/([^/]+)\/report$/);
+  if (req.method === 'GET' && reportMatch) {
+    const taskId = decodeURIComponent(reportMatch[1]);
+    if (!timelineTask) return json(res, 503, { error: 'Timeline module not available' });
+    const board = helpers.readBoard();
+    const task = (board.taskPlan?.tasks || []).find(t => t.id === taskId);
+    if (!task) return json(res, 404, { error: 'Task not found' });
+    const timeline = timelineTask.assembleTimeline(board, task);
+    const report = timelineTask.buildDeliveryReport(board, task, timeline);
+    const html = timelineTask.renderReportHTML(report);
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    return res.end(html);
   }
 
   // --- S6: High-Level Atomic APIs ---

--- a/server/server.js
+++ b/server/server.js
@@ -23,6 +23,9 @@ try { jiraIntegration = require('./integration-jira'); } catch { /* jira integra
 let digestTask = null;
 try { digestTask = require('./digest-task'); } catch { /* digest-task not available, skip */ }
 
+let timelineTask = null;
+try { timelineTask = require('./timeline-task'); } catch { /* timeline-task not available, skip */ }
+
 const telemetry = require('./telemetry');
 const push = require('./push');
 const githubApi = require('./github-api');
@@ -71,6 +74,7 @@ const deps = {
   usage,
   jiraIntegration,
   digestTask,
+  timelineTask,
 
   // Config / paths
   ctx,

--- a/server/smoke-test.js
+++ b/server/smoke-test.js
@@ -536,6 +536,30 @@ async function runSuite(target) {
         throw new Error(`expected 503 or 404, got ${r.status}`);
       }
     } catch (e) { fail('POST /api/tasks/:id/digest', e.message); }
+
+    // 21. GET /api/tasks/:id/timeline → 404 (nonexistent task)
+    try {
+      const r = await get(port, '/api/tasks/SMOKE-NOEXIST/timeline');
+      if (r.status === 404) {
+        const body = JSON.parse(r.body);
+        if (!body.error) throw new Error('missing error message');
+        ok(`GET /api/tasks/:id/timeline (no task) → 404`);
+      } else {
+        throw new Error(`expected 404, got ${r.status}`);
+      }
+    } catch (e) { fail('GET /api/tasks/:id/timeline', e.message); }
+
+    // 22. GET /api/tasks/:id/report → 404 (nonexistent task)
+    try {
+      const r = await get(port, '/api/tasks/SMOKE-NOEXIST/report');
+      if (r.status === 404) {
+        const body = JSON.parse(r.body);
+        if (!body.error) throw new Error('missing error message');
+        ok(`GET /api/tasks/:id/report (no task) → 404`);
+      } else {
+        throw new Error(`expected 404, got ${r.status}`);
+      }
+    } catch (e) { fail('GET /api/tasks/:id/report', e.message); }
   }
 
   // ── Uncovered Endpoint Tests (issue #77) ──

--- a/server/test-timeline-task.js
+++ b/server/test-timeline-task.js
@@ -1,0 +1,560 @@
+#!/usr/bin/env node
+/**
+ * test-timeline-task.js — Unit tests for timeline-task.js (L3 Deep Timeline)
+ *
+ * 測試 timeline assembly、source mappers、deduplication、report generation、HTML rendering。
+ * 無外部依賴，無需真實 server。
+ *
+ * Usage:
+ *   node server/test-timeline-task.js
+ */
+
+const timeline = require('./timeline-task');
+const {
+  fromHistory,
+  fromSignals,
+  fromDispatch,
+  fromReview,
+  fromInsights,
+  fromLessons,
+  deduplicateNodes,
+  computeDuration,
+  mapHistoryType,
+  mapSignalType,
+  escHtml,
+  NODE_COLORS,
+} = timeline._internal;
+
+let passed = 0;
+let failed = 0;
+
+function ok(name) { passed++; console.log(`  OK  ${name}`); }
+function fail(name, err) { failed++; console.log(`  FAIL  ${name}: ${err || '(unknown)'}`); }
+
+function assert(condition, name, detail) {
+  if (condition) ok(name);
+  else fail(name, detail || 'assertion failed');
+}
+
+// --- Test data ---
+
+const now = '2026-02-28T10:00:00.000Z';
+const t1 = '2026-02-28T10:01:00.000Z';
+const t2 = '2026-02-28T10:02:00.000Z';
+const t3 = '2026-02-28T10:03:00.000Z';
+const t4 = '2026-02-28T10:04:00.000Z';
+const t5 = '2026-02-28T10:05:00.000Z';
+
+const emptyTask = {
+  id: 'T0',
+  title: 'Empty task',
+  status: 'pending',
+};
+
+const emptyBoard = {
+  taskPlan: { tasks: [emptyTask] },
+  signals: [],
+  insights: [],
+  lessons: [],
+};
+
+const richTask = {
+  id: 'T1',
+  title: 'Implement user auth',
+  description: 'JWT-based authentication',
+  status: 'completed',
+  assignee: 'eng_1',
+  history: [
+    { ts: now, status: 'pending', by: 'human' },
+    { ts: t1, status: 'dispatched', by: 'auto-dispatch' },
+    { ts: t2, status: 'in_progress', by: 'auto-dispatch', model: 'claude-sonnet' },
+    { ts: t4, status: 'completed', by: 'agent', score: 85 },
+  ],
+  dispatch: {
+    runtime: 'openclaw',
+    agentId: 'eng_1',
+    model: 'claude-sonnet',
+    timeoutSec: 600,
+    preparedAt: now,
+    startedAt: t1,
+    finishedAt: t4,
+    state: 'completed',
+    planId: 'plan-001',
+    sessionId: 'sess-abc',
+  },
+  review: {
+    score: 85,
+    issues: ['Missing error boundary'],
+    summary: 'Code is clean overall',
+    threshold: 70,
+    verdict: 'pass',
+    reviewedAt: t5,
+    attempt: 1,
+  },
+  digest: {
+    version: 'task_digest.v1',
+    task_id: 'T1',
+    one_liner: 'Auth flow implemented',
+    risk: { level: 'low', reasons: ['Well-tested'] },
+    bullets: {
+      what: ['JWT auth flow'],
+      why: ['Security requirement'],
+      risk: ['Low risk'],
+      notes: [],
+    },
+    warnings: [],
+  },
+};
+
+const richBoard = {
+  taskPlan: { tasks: [richTask] },
+  signals: [
+    { id: 'sig-1', ts: t1, by: 'system', type: 'status_change', content: 'pending -> dispatched', refs: ['T1'], data: { from: 'pending', to: 'dispatched' } },
+    { id: 'sig-2', ts: t2, by: 'system', type: 'status_change', content: 'dispatched -> in_progress', refs: ['T1'], data: { from: 'dispatched', to: 'in_progress' } },
+    { id: 'sig-3', ts: t3, by: 'retro', type: 'insight_applied', content: 'Applied: prefer claude for multi-file', refs: ['T1'], data: { taskId: 'T1' } },
+    { id: 'sig-4', ts: t5, by: 'system', type: 'review_result', content: 'Review: 85/100', refs: ['T1'], data: { score: 85 } },
+    // Signal not related to T1
+    { id: 'sig-5', ts: t3, by: 'system', type: 'error', content: 'Timeout', refs: ['T2'] },
+  ],
+  insights: [
+    { id: 'ins-1', ts: t3, by: 'retro', judgement: 'Prefer claude for multi-file edits', reasoning: 'Better context window', suggestedAction: { type: 'dispatch_hint' }, risk: 'low', status: 'applied', appliedAt: t3, data: { taskId: 'T1', signalId: 'sig-3' } },
+    // Rolled-back insight for T1
+    { id: 'ins-2', ts: t4, by: 'retro', judgement: 'Increase timeout to 900s', reasoning: 'Long task', suggestedAction: { type: 'controls_patch' }, risk: 'medium', status: 'rolled_back', appliedAt: t4, data: { taskId: 'T1' } },
+    // Insight not related to T1
+    { id: 'ins-3', ts: t2, by: 'retro', judgement: 'Unrelated insight', suggestedAction: { type: 'noop' }, risk: 'low', status: 'pending', data: { taskId: 'T2' } },
+  ],
+  lessons: [
+    { id: 'les-1', ts: t4, by: 'retro', fromInsight: 'ins-1', rule: 'Use claude for multi-file tasks', status: 'validated', validatedAt: t4 },
+    { id: 'les-2', ts: t5, by: 'retro', fromInsight: 'ins-1', rule: 'Old lesson (replaced)', status: 'superseded', validatedAt: t4, supersededBy: 'les-1' },
+    // Lesson not from T1 insights
+    { id: 'les-3', ts: t3, by: 'retro', fromInsight: 'ins-3', rule: 'Unrelated lesson', status: 'active' },
+  ],
+};
+
+// =======================================================================
+//  Tests: fromHistory
+// =======================================================================
+
+console.log('\n--- fromHistory ---');
+
+{
+  const nodes = fromHistory(emptyTask);
+  assert(Array.isArray(nodes), 'fromHistory: empty task returns array');
+  assert(nodes.length === 0, 'fromHistory: empty task returns []');
+}
+
+{
+  const nodes = fromHistory(richTask);
+  assert(nodes.length === 4, 'fromHistory: rich task returns 4 nodes', `got ${nodes.length}`);
+
+  const pending = nodes[0];
+  assert(pending.type === 'status', 'fromHistory: pending maps to status', `got ${pending.type}`);
+
+  const dispatched = nodes[1];
+  assert(dispatched.type === 'dispatch', 'fromHistory: dispatched by auto-dispatch maps to dispatch', `got ${dispatched.type}`);
+
+  const inProgress = nodes[2];
+  assert(inProgress.type === 'dispatch', 'fromHistory: in_progress by auto-dispatch maps to dispatch', `got ${inProgress.type}`);
+  assert(inProgress.title.includes('claude-sonnet'), 'fromHistory: in_progress includes model', `title: ${inProgress.title}`);
+
+  const completed = nodes[3];
+  assert(completed.type === 'status', 'fromHistory: completed maps to status', `got ${completed.type}`);
+  assert(completed.title.includes('85'), 'fromHistory: completed includes score', `title: ${completed.title}`);
+}
+
+{
+  const blockedTask = { id: 'TB', history: [{ ts: now, status: 'blocked', by: 'agent', reason: 'Missing API key' }] };
+  const nodes = fromHistory(blockedTask);
+  assert(nodes[0].type === 'error', 'fromHistory: blocked maps to error');
+  assert(nodes[0].title.includes('Missing API key'), 'fromHistory: blocked includes reason');
+}
+
+// =======================================================================
+//  Tests: mapHistoryType
+// =======================================================================
+
+console.log('\n--- mapHistoryType ---');
+
+assert(mapHistoryType({ status: 'in_progress', by: 'auto-dispatch' }) === 'dispatch', 'mapHistoryType: in_progress + auto-dispatch = dispatch');
+assert(mapHistoryType({ status: 'dispatched', by: 'auto-dispatch' }) === 'dispatch', 'mapHistoryType: dispatched + auto-dispatch = dispatch');
+assert(mapHistoryType({ status: 'blocked', by: 'agent' }) === 'error', 'mapHistoryType: blocked = error');
+assert(mapHistoryType({ status: 'completed', by: 'agent' }) === 'status', 'mapHistoryType: completed = status');
+assert(mapHistoryType({ status: 'approved', by: 'human' }) === 'status', 'mapHistoryType: approved = status');
+assert(mapHistoryType({ status: 'reviewing', by: 'system' }) === 'status', 'mapHistoryType: reviewing = status');
+assert(mapHistoryType({ status: 'needs_revision', by: 'system' }) === 'status', 'mapHistoryType: needs_revision = status');
+assert(mapHistoryType({ status: 'pending', by: 'human' }) === 'status', 'mapHistoryType: pending = status');
+assert(mapHistoryType({ status: 'custom', by: 'x' }) === 'note', 'mapHistoryType: unknown = note');
+
+// =======================================================================
+//  Tests: fromSignals
+// =======================================================================
+
+console.log('\n--- fromSignals ---');
+
+{
+  const nodes = fromSignals(emptyBoard, 'T0');
+  assert(nodes.length === 0, 'fromSignals: empty board returns []');
+}
+
+{
+  const nodes = fromSignals(richBoard, 'T1');
+  assert(nodes.length === 4, 'fromSignals: T1 has 4 matching signals', `got ${nodes.length}`);
+
+  const statusNodes = nodes.filter(n => n.type === 'status');
+  assert(statusNodes.length === 2, 'fromSignals: 2 status_change signals', `got ${statusNodes.length}`);
+
+  const decisionNodes = nodes.filter(n => n.type === 'decision');
+  assert(decisionNodes.length === 1, 'fromSignals: 1 insight_applied signal', `got ${decisionNodes.length}`);
+
+  const reviewNodes = nodes.filter(n => n.type === 'review');
+  assert(reviewNodes.length === 1, 'fromSignals: 1 review_result signal', `got ${reviewNodes.length}`);
+}
+
+{
+  const nodes = fromSignals(richBoard, 'T2');
+  assert(nodes.length === 1, 'fromSignals: T2 has 1 matching signal', `got ${nodes.length}`);
+  assert(nodes[0].type === 'error', 'fromSignals: T2 error signal type correct');
+}
+
+{
+  const nodes = fromSignals(richBoard, 'NONEXIST');
+  assert(nodes.length === 0, 'fromSignals: nonexistent task returns []');
+}
+
+// =======================================================================
+//  Tests: mapSignalType
+// =======================================================================
+
+console.log('\n--- mapSignalType ---');
+
+assert(mapSignalType('status_change') === 'status', 'mapSignalType: status_change = status');
+assert(mapSignalType('review_result') === 'review', 'mapSignalType: review_result = review');
+assert(mapSignalType('insight_applied') === 'decision', 'mapSignalType: insight_applied = decision');
+assert(mapSignalType('insight_rolled_back') === 'supersede', 'mapSignalType: insight_rolled_back = supersede');
+assert(mapSignalType('lesson_validated') === 'policy', 'mapSignalType: lesson_validated = policy');
+assert(mapSignalType('error') === 'error', 'mapSignalType: error = error');
+assert(mapSignalType('unknown_type') === 'note', 'mapSignalType: unknown = note');
+
+// =======================================================================
+//  Tests: fromDispatch
+// =======================================================================
+
+console.log('\n--- fromDispatch ---');
+
+{
+  const nodes = fromDispatch(emptyTask);
+  assert(nodes.length === 0, 'fromDispatch: no dispatch returns []');
+}
+
+{
+  const nodes = fromDispatch(richTask);
+  assert(nodes.length === 3, 'fromDispatch: rich task returns 3 nodes (prepared, started, finished)', `got ${nodes.length}`);
+
+  assert(nodes[0].type === 'dispatch', 'fromDispatch: prepared node is dispatch type');
+  assert(nodes[0].title.includes('openclaw'), 'fromDispatch: prepared includes runtime');
+  assert(nodes[0].detail.includes('claude-sonnet'), 'fromDispatch: prepared detail includes model');
+
+  assert(nodes[1].type === 'dispatch', 'fromDispatch: started node is dispatch type');
+  assert(nodes[1].detail.includes('sess-abc'), 'fromDispatch: started includes session');
+
+  assert(nodes[2].type === 'status', 'fromDispatch: finished node is status type (completed)');
+}
+
+{
+  const failedTask = {
+    id: 'TF',
+    dispatch: {
+      runtime: 'codex', agentId: 'eng_2',
+      preparedAt: now, startedAt: t1, finishedAt: t2,
+      state: 'failed', lastError: 'Timeout exceeded',
+    },
+  };
+  const nodes = fromDispatch(failedTask);
+  const finishNode = nodes.find(n => n.ts === t2);
+  assert(finishNode.type === 'error', 'fromDispatch: failed dispatch is error type');
+  assert(finishNode.detail === 'Timeout exceeded', 'fromDispatch: failed includes lastError');
+}
+
+// =======================================================================
+//  Tests: fromReview
+// =======================================================================
+
+console.log('\n--- fromReview ---');
+
+{
+  const nodes = fromReview(emptyTask);
+  assert(nodes.length === 0, 'fromReview: no review returns []');
+}
+
+{
+  const nodes = fromReview(richTask);
+  assert(nodes.length === 1, 'fromReview: rich task returns 1 node');
+  assert(nodes[0].type === 'review', 'fromReview: type is review');
+  assert(nodes[0].title.includes('85'), 'fromReview: title includes score');
+  assert(nodes[0].title.includes('pass'), 'fromReview: title includes verdict');
+  assert(nodes[0].title.includes('1 issue'), 'fromReview: title includes issue count');
+  assert(nodes[0].detail.includes('Missing error boundary'), 'fromReview: detail includes issues');
+  assert(nodes[0].meta.score === 85, 'fromReview: meta includes score');
+}
+
+// =======================================================================
+//  Tests: fromInsights
+// =======================================================================
+
+console.log('\n--- fromInsights ---');
+
+{
+  const nodes = fromInsights(emptyBoard, 'T0');
+  assert(nodes.length === 0, 'fromInsights: empty board returns []');
+}
+
+{
+  const nodes = fromInsights(richBoard, 'T1');
+  assert(nodes.length === 2, 'fromInsights: T1 has 2 related insights', `got ${nodes.length}`);
+
+  const applied = nodes.find(n => n.type === 'decision');
+  assert(applied !== undefined, 'fromInsights: has decision node');
+  assert(applied.title.includes('Prefer claude'), 'fromInsights: decision title correct');
+
+  const rolledBack = nodes.find(n => n.type === 'supersede');
+  assert(rolledBack !== undefined, 'fromInsights: has supersede node');
+  assert(rolledBack.title.includes('Rolled back'), 'fromInsights: supersede title correct');
+}
+
+{
+  const nodes = fromInsights(richBoard, 'T2');
+  assert(nodes.length === 1, 'fromInsights: T2 has 1 unrelated insight', `got ${nodes.length}`);
+}
+
+{
+  const nodes = fromInsights(richBoard, 'NONEXIST');
+  assert(nodes.length === 0, 'fromInsights: nonexistent task returns []');
+}
+
+// =======================================================================
+//  Tests: fromLessons
+// =======================================================================
+
+console.log('\n--- fromLessons ---');
+
+{
+  const nodes = fromLessons(emptyBoard, 'T0');
+  assert(nodes.length === 0, 'fromLessons: empty board returns []');
+}
+
+{
+  const nodes = fromLessons(richBoard, 'T1');
+  assert(nodes.length === 2, 'fromLessons: T1 has 2 related lessons', `got ${nodes.length}`);
+
+  const validated = nodes.find(n => n.type === 'policy');
+  assert(validated !== undefined, 'fromLessons: has policy node');
+  assert(validated.title.includes('Use claude'), 'fromLessons: policy title correct');
+
+  const superseded = nodes.find(n => n.type === 'supersede');
+  assert(superseded !== undefined, 'fromLessons: has supersede node');
+  assert(superseded.refs.supersededBy === 'les-1', 'fromLessons: supersede refs correct');
+}
+
+{
+  const nodes = fromLessons(richBoard, 'NONEXIST');
+  assert(nodes.length === 0, 'fromLessons: nonexistent task returns []');
+}
+
+// =======================================================================
+//  Tests: deduplicateNodes
+// =======================================================================
+
+console.log('\n--- deduplicateNodes ---');
+
+{
+  const nodes = deduplicateNodes([]);
+  assert(nodes.length === 0, 'dedup: empty array returns []');
+}
+
+{
+  // Two nodes with same ts (to the second) and type — signal should win
+  const historyNode = { id: 'h-1', ts: '2026-02-28T10:01:00.000Z', type: 'status', title: 'From history', source: 'history', refs: {} };
+  const signalNode = { id: 's-1', ts: '2026-02-28T10:01:00.500Z', type: 'status', title: 'From signal', source: 'signal', refs: {} };
+  const result = deduplicateNodes([historyNode, signalNode]);
+  assert(result.length === 1, 'dedup: two same-second same-type nodes dedup to 1', `got ${result.length}`);
+  assert(result[0].source === 'signal', 'dedup: signal wins over history', `got ${result[0].source}`);
+}
+
+{
+  // Different types at same timestamp should NOT be deduped
+  const node1 = { id: 'h-1', ts: '2026-02-28T10:01:00.000Z', type: 'status', title: 'Status', source: 'history', refs: {} };
+  const node2 = { id: 's-1', ts: '2026-02-28T10:01:00.000Z', type: 'dispatch', title: 'Dispatch', source: 'signal', refs: {} };
+  const result = deduplicateNodes([node1, node2]);
+  assert(result.length === 2, 'dedup: different types at same ts not deduped', `got ${result.length}`);
+}
+
+{
+  // Different timestamps should NOT be deduped
+  const node1 = { id: 'h-1', ts: '2026-02-28T10:01:00.000Z', type: 'status', title: 'A', source: 'history', refs: {} };
+  const node2 = { id: 's-1', ts: '2026-02-28T10:02:00.000Z', type: 'status', title: 'B', source: 'history', refs: {} };
+  const result = deduplicateNodes([node1, node2]);
+  assert(result.length === 2, 'dedup: different timestamps not deduped', `got ${result.length}`);
+}
+
+// =======================================================================
+//  Tests: computeDuration
+// =======================================================================
+
+console.log('\n--- computeDuration ---');
+
+{
+  const dur = computeDuration(emptyTask);
+  assert(dur === null, 'computeDuration: empty task returns null');
+}
+
+{
+  const dur = computeDuration(richTask);
+  assert(dur === 3, 'computeDuration: rich task duration is 3 min (t1 to t4)', `got ${dur}`);
+}
+
+{
+  const taskHistOnly = {
+    id: 'TH',
+    history: [
+      { ts: '2026-02-28T10:00:00.000Z', status: 'pending', by: 'human' },
+      { ts: '2026-02-28T10:30:00.000Z', status: 'completed', by: 'agent' },
+    ],
+  };
+  const dur = computeDuration(taskHistOnly);
+  assert(dur === 30, 'computeDuration: history-only task = 30 min', `got ${dur}`);
+}
+
+// =======================================================================
+//  Tests: assembleTimeline
+// =======================================================================
+
+console.log('\n--- assembleTimeline ---');
+
+{
+  const tl = timeline.assembleTimeline(emptyBoard, emptyTask);
+  assert(Array.isArray(tl), 'assembleTimeline: returns array');
+  assert(tl.length === 0, 'assembleTimeline: empty task+board returns []');
+}
+
+{
+  const tl = timeline.assembleTimeline(richBoard, richTask);
+  assert(tl.length > 0, 'assembleTimeline: rich data returns non-empty', `got ${tl.length}`);
+
+  // Check chronological order
+  let sorted = true;
+  for (let i = 1; i < tl.length; i++) {
+    if (new Date(tl[i].ts) < new Date(tl[i - 1].ts)) {
+      sorted = false;
+      break;
+    }
+  }
+  assert(sorted, 'assembleTimeline: chronologically sorted');
+
+  // Check all required fields present
+  const firstNode = tl[0];
+  assert(firstNode.id && firstNode.id.startsWith('tln-'), 'assembleTimeline: nodes have tln- prefixed ids');
+  assert(firstNode.ts, 'assembleTimeline: nodes have ts');
+  assert(firstNode.type, 'assembleTimeline: nodes have type');
+  assert(firstNode.title, 'assembleTimeline: nodes have title');
+  assert(firstNode.source, 'assembleTimeline: nodes have source');
+  assert(typeof firstNode.refs === 'object', 'assembleTimeline: nodes have refs object');
+
+  // Check type diversity
+  const types = new Set(tl.map(n => n.type));
+  assert(types.has('dispatch'), 'assembleTimeline: has dispatch type');
+  assert(types.has('status'), 'assembleTimeline: has status type');
+  assert(types.has('review'), 'assembleTimeline: has review type');
+}
+
+{
+  // Task with only history
+  const histOnly = { id: 'TH', title: 'Test', status: 'completed', history: [{ ts: now, status: 'completed', by: 'agent' }] };
+  const boardMin = { taskPlan: { tasks: [histOnly] }, signals: [], insights: [], lessons: [] };
+  const tl = timeline.assembleTimeline(boardMin, histOnly);
+  assert(tl.length === 1, 'assembleTimeline: history-only task has 1 node', `got ${tl.length}`);
+  assert(tl[0].source === 'history', 'assembleTimeline: history-only source is history');
+}
+
+// =======================================================================
+//  Tests: buildDeliveryReport
+// =======================================================================
+
+console.log('\n--- buildDeliveryReport ---');
+
+{
+  const report = timeline.buildDeliveryReport(richBoard, richTask);
+  assert(report.version === 'delivery_report.v1', 'buildDeliveryReport: version correct');
+  assert(report.taskId === 'T1', 'buildDeliveryReport: taskId correct');
+  assert(report.generatedAt, 'buildDeliveryReport: has generatedAt');
+  assert(report.summary.title === 'Implement user auth', 'buildDeliveryReport: summary title correct');
+  assert(report.summary.status === 'completed', 'buildDeliveryReport: summary status correct');
+  assert(report.summary.score === 85, 'buildDeliveryReport: summary score correct');
+  assert(report.summary.durationMin === 3, 'buildDeliveryReport: summary duration correct', `got ${report.summary.durationMin}`);
+  assert(Array.isArray(report.timeline), 'buildDeliveryReport: has timeline array');
+  assert(report.timeline.length > 0, 'buildDeliveryReport: timeline non-empty');
+  assert(report.digest !== null, 'buildDeliveryReport: includes L2 digest');
+  assert(report.digest.one_liner === 'Auth flow implemented', 'buildDeliveryReport: digest one_liner correct');
+}
+
+{
+  const report = timeline.buildDeliveryReport(emptyBoard, emptyTask);
+  assert(report.summary.score === null, 'buildDeliveryReport: empty task score is null');
+  assert(report.summary.durationMin === null, 'buildDeliveryReport: empty task duration is null');
+  assert(report.digest === null, 'buildDeliveryReport: empty task digest is null');
+  assert(report.timeline.length === 0, 'buildDeliveryReport: empty task timeline is []');
+}
+
+// =======================================================================
+//  Tests: renderReportHTML
+// =======================================================================
+
+console.log('\n--- renderReportHTML ---');
+
+{
+  const report = timeline.buildDeliveryReport(richBoard, richTask);
+  const html = timeline.renderReportHTML(report);
+
+  assert(typeof html === 'string', 'renderReportHTML: returns string');
+  assert(html.includes('<!DOCTYPE html>'), 'renderReportHTML: starts with DOCTYPE');
+  assert(html.includes('</html>'), 'renderReportHTML: ends with html close');
+  assert(html.includes('Implement user auth'), 'renderReportHTML: includes task title');
+  assert(html.includes('T1'), 'renderReportHTML: includes task ID');
+  assert(html.includes('85'), 'renderReportHTML: includes score');
+  assert(html.includes('window.print()'), 'renderReportHTML: includes print button');
+  assert(html.includes('@media print'), 'renderReportHTML: includes print styles');
+  assert(html.includes('print=1'), 'renderReportHTML: includes auto-print trigger');
+  assert(html.includes('Auth flow implemented'), 'renderReportHTML: includes L2 digest');
+
+  // Check timeline node colors present
+  assert(html.includes(NODE_COLORS.dispatch), 'renderReportHTML: includes dispatch color');
+  assert(html.includes(NODE_COLORS.review), 'renderReportHTML: includes review color');
+}
+
+{
+  // Empty timeline report
+  const report = timeline.buildDeliveryReport(emptyBoard, emptyTask);
+  const html = timeline.renderReportHTML(report);
+  assert(html.includes('No timeline events'), 'renderReportHTML: empty timeline shows message');
+  assert(html.includes('Empty task'), 'renderReportHTML: empty task title shown');
+}
+
+// =======================================================================
+//  Tests: escHtml
+// =======================================================================
+
+console.log('\n--- escHtml ---');
+
+assert(escHtml('') === '', 'escHtml: empty string');
+assert(escHtml(null) === '', 'escHtml: null');
+assert(escHtml(undefined) === '', 'escHtml: undefined');
+assert(escHtml('<script>alert("xss")</script>') === '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;', 'escHtml: XSS escape');
+assert(escHtml('a & b') === 'a &amp; b', 'escHtml: ampersand');
+assert(escHtml("it's") === "it&#39;s", 'escHtml: single quote');
+
+// =======================================================================
+//  Results
+// =======================================================================
+
+console.log(`\n${'='.repeat(40)}`);
+console.log(`Total: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/server/timeline-task.js
+++ b/server/timeline-task.js
@@ -1,0 +1,850 @@
+/**
+ * timeline-task.js — L3 Deep Timeline + Exportable Delivery Report
+ *
+ * 從 board.json 既有資料組裝任務時間軸，產生 TimelineNode[]。
+ * 支援 HTML 報告匯出（@media print → PDF），零外部依賴。
+ *
+ * 資料來源優先順序：
+ * 1. task.history[]    — 永遠可用
+ * 2. board.signals[]   — 永遠可用（依 refs 過濾）
+ * 3. task.dispatch     — 永遠可用
+ * 4. task.review       — 永遠可用
+ * 5. board.insights[]  — 演化層啟用時可用
+ * 6. board.lessons[]   — 演化層啟用時可用
+ * 7. task.digest       — L2 啟用時可用
+ * 8. Edda decisions    — 未來：EDDA_CMD 可用時
+ *
+ * @module timeline-task
+ */
+
+// --- ID generator ---
+
+let _idCounter = 0;
+
+/**
+ * 產生唯一 timeline node ID。
+ * @param {string} prefix - 節點類型前綴
+ * @returns {string}
+ */
+function tlnId(prefix) {
+  return `tln-${prefix}-${Date.now().toString(36)}-${(++_idCounter).toString(36)}`;
+}
+
+// --- Source mappers ---
+
+/**
+ * 從 task.history[] 映射 timeline nodes。
+ * @param {object} task
+ * @returns {Array} TimelineNode[]
+ */
+function fromHistory(task) {
+  const history = task.history || [];
+  return history.map(entry => {
+    const type = mapHistoryType(entry);
+    const title = buildHistoryTitle(entry);
+    const detail = buildHistoryDetail(entry);
+
+    return {
+      id: tlnId('h'),
+      ts: entry.ts || new Date().toISOString(),
+      type,
+      title,
+      detail: detail || undefined,
+      source: 'history',
+      refs: {},
+      meta: { status: entry.status, by: entry.by, attempt: entry.attempt },
+    };
+  });
+}
+
+/**
+ * 從 history entry 判斷 timeline node type。
+ * @param {object} entry - HistoryEntry
+ * @returns {string} TimelineNodeType
+ */
+function mapHistoryType(entry) {
+  const s = entry.status || '';
+  const by = entry.by || '';
+
+  // dispatch 事件
+  if ((s === 'in_progress' || s === 'dispatched') && (by.includes('dispatch') || by.includes('auto'))) {
+    return 'dispatch';
+  }
+  // blocked = error
+  if (s === 'blocked') return 'error';
+  // completed / approved = status
+  if (s === 'completed' || s === 'approved') return 'status';
+  // reviewing = status
+  if (s === 'reviewing' || s === 'needs_revision') return 'status';
+  // pending = status
+  if (s === 'pending') return 'status';
+  // 其他
+  return 'note';
+}
+
+/**
+ * 組裝 history entry 的標題。
+ * @param {object} entry
+ * @returns {string}
+ */
+function buildHistoryTitle(entry) {
+  const s = entry.status || 'unknown';
+  const by = entry.by || '';
+
+  if (s === 'in_progress' && by.includes('dispatch')) {
+    const model = entry.model ? ` (model: ${entry.model})` : '';
+    return `Dispatched${model}`;
+  }
+  if (s === 'dispatched') {
+    return `Dispatched by ${by}`;
+  }
+  if (s === 'blocked') {
+    return `Blocked: ${entry.reason || entry.message || 'unknown reason'}`;
+  }
+  if (s === 'completed') {
+    const score = entry.score != null ? ` (score: ${entry.score})` : '';
+    return `Task completed${score}`;
+  }
+  if (s === 'approved') {
+    return `Task approved`;
+  }
+  if (s === 'reviewing') {
+    return `Review started`;
+  }
+  if (s === 'needs_revision') {
+    return `Needs revision`;
+  }
+  if (s === 'pending') {
+    if (entry.from) return `Status reset: ${entry.from} -> pending`;
+    return `Task pending`;
+  }
+
+  return `${s} (by ${by})`;
+}
+
+/**
+ * 組裝 history entry 的詳細描述。
+ * @param {object} entry
+ * @returns {string|null}
+ */
+function buildHistoryDetail(entry) {
+  const parts = [];
+  if (entry.reason) parts.push(`Reason: ${entry.reason}`);
+  if (entry.message) parts.push(entry.message);
+  if (entry.model) parts.push(`Model: ${entry.model}`);
+  if (entry.attempt) parts.push(`Attempt: ${entry.attempt}`);
+  if (entry.unblockedBy) parts.push(`Unblocked by: ${entry.unblockedBy}`);
+  if (entry.issues?.length) parts.push(`Issues: ${entry.issues.join(', ')}`);
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
+// ---
+
+/**
+ * 從 board.signals[] 映射 timeline nodes（依 taskId 過濾）。
+ * @param {object} board
+ * @param {string} taskId
+ * @returns {Array} TimelineNode[]
+ */
+function fromSignals(board, taskId) {
+  const signals = (board.signals || []).filter(s => {
+    return s.refs && s.refs.includes(taskId);
+  });
+
+  return signals.map(signal => {
+    const type = mapSignalType(signal.type);
+    const title = signal.content || `Signal: ${signal.type}`;
+
+    return {
+      id: tlnId('s'),
+      ts: signal.ts,
+      type,
+      title,
+      detail: signal.data ? JSON.stringify(signal.data, null, 2) : undefined,
+      source: 'signal',
+      refs: {},
+      meta: { signalId: signal.id, signalType: signal.type, by: signal.by },
+    };
+  });
+}
+
+/**
+ * 從 signal type 映射 timeline node type。
+ * @param {string} signalType
+ * @returns {string}
+ */
+function mapSignalType(signalType) {
+  switch (signalType) {
+    case 'status_change': return 'status';
+    case 'review_result': return 'review';
+    case 'insight_applied': return 'decision';
+    case 'insight_rolled_back': return 'supersede';
+    case 'lesson_validated': return 'policy';
+    case 'error': return 'error';
+    default: return 'note';
+  }
+}
+
+// ---
+
+/**
+ * 從 task.dispatch 映射 timeline nodes。
+ * @param {object} task
+ * @returns {Array} TimelineNode[]
+ */
+function fromDispatch(task) {
+  if (!task.dispatch) return [];
+
+  const d = task.dispatch;
+  const nodes = [];
+
+  // dispatch prepared
+  if (d.preparedAt) {
+    nodes.push({
+      id: tlnId('d'),
+      ts: d.preparedAt,
+      type: 'dispatch',
+      title: `Dispatch prepared: ${d.runtime || 'unknown'} runtime`,
+      detail: [
+        `Agent: ${d.agentId || 'unknown'}`,
+        d.model ? `Model: ${d.model}` : null,
+        `Timeout: ${d.timeoutSec || '?'}s`,
+        d.planId ? `Plan: ${d.planId}` : null,
+      ].filter(Boolean).join('\n'),
+      source: 'dispatch',
+      refs: {},
+      meta: { runtime: d.runtime, agentId: d.agentId, model: d.model },
+    });
+  }
+
+  // dispatch started
+  if (d.startedAt) {
+    nodes.push({
+      id: tlnId('d'),
+      ts: d.startedAt,
+      type: 'dispatch',
+      title: `Agent started execution`,
+      detail: d.sessionId ? `Session: ${d.sessionId}` : undefined,
+      source: 'dispatch',
+      refs: {},
+      meta: { sessionId: d.sessionId },
+    });
+  }
+
+  // dispatch finished
+  if (d.finishedAt) {
+    const isFail = d.state === 'failed';
+    nodes.push({
+      id: tlnId('d'),
+      ts: d.finishedAt,
+      type: isFail ? 'error' : 'status',
+      title: isFail ? `Dispatch failed` : `Agent execution finished`,
+      detail: d.lastError || undefined,
+      source: 'dispatch',
+      refs: {},
+      meta: { state: d.state },
+    });
+  }
+
+  return nodes;
+}
+
+// ---
+
+/**
+ * 從 task.review 映射 timeline nodes。
+ * @param {object} task
+ * @returns {Array} TimelineNode[]
+ */
+function fromReview(task) {
+  if (!task.review) return [];
+
+  const r = task.review;
+  const verdict = r.verdict || (r.score >= (r.threshold || 70) ? 'pass' : 'fail');
+  const issueCount = r.issues?.length || 0;
+
+  return [{
+    id: tlnId('r'),
+    ts: r.reviewedAt || new Date().toISOString(),
+    type: 'review',
+    title: `Review: ${r.score}/100 — ${verdict}${issueCount > 0 ? `, ${issueCount} issue(s)` : ''}`,
+    detail: [
+      r.summary || null,
+      r.issues?.length ? `Issues:\n${r.issues.map(i => `  - ${typeof i === 'string' ? i : JSON.stringify(i)}`).join('\n')}` : null,
+      r.report ? `Report: ${r.report.slice(0, 500)}` : null,
+    ].filter(Boolean).join('\n\n'),
+    source: 'review',
+    refs: {},
+    meta: { score: r.score, verdict, threshold: r.threshold, attempt: r.attempt },
+  }];
+}
+
+// ---
+
+/**
+ * 從 board.insights[] 映射與 task 相關的 timeline nodes。
+ * 透過 signals 的 refs 建立 insight <-> task 關聯。
+ * @param {object} board
+ * @param {string} taskId
+ * @returns {Array} TimelineNode[]
+ */
+function fromInsights(board, taskId) {
+  const insights = board.insights || [];
+  if (insights.length === 0) return [];
+
+  // 找出 task 相關的 signal IDs
+  const taskSignalIds = new Set(
+    (board.signals || [])
+      .filter(s => s.refs && s.refs.includes(taskId))
+      .map(s => s.id)
+  );
+
+  // insight 的 data.signalId 或 data.taskId 關聯到此 task
+  const taskInsights = insights.filter(ins => {
+    if (ins.data?.taskId === taskId) return true;
+    if (ins.data?.signalId && taskSignalIds.has(ins.data.signalId)) return true;
+    if (ins.about && ins.about.includes(taskId)) return true;
+    return false;
+  });
+
+  return taskInsights.map(ins => {
+    const type = ins.status === 'rolled_back' ? 'supersede' : 'decision';
+    const actionDesc = ins.suggestedAction?.type || 'unknown action';
+
+    return {
+      id: tlnId('i'),
+      ts: ins.appliedAt || ins.ts,
+      type,
+      title: type === 'supersede'
+        ? `Rolled back: ${ins.judgement?.slice(0, 80) || actionDesc}`
+        : `Applied: ${ins.judgement?.slice(0, 80) || actionDesc}`,
+      detail: [
+        ins.reasoning || null,
+        `Action: ${actionDesc}`,
+        `Risk: ${ins.risk || 'unknown'}`,
+      ].filter(Boolean).join('\n'),
+      source: 'insight',
+      refs: { insightId: ins.id },
+      meta: { status: ins.status, action: ins.suggestedAction },
+    };
+  });
+}
+
+// ---
+
+/**
+ * 從 board.lessons[] 映射與 task 相關的 timeline nodes。
+ * 透過 fromInsight 鏈回 task-related insights。
+ * @param {object} board
+ * @param {string} taskId
+ * @returns {Array} TimelineNode[]
+ */
+function fromLessons(board, taskId) {
+  const lessons = board.lessons || [];
+  if (lessons.length === 0) return [];
+
+  // 先找出 task 相關的 insight IDs
+  const taskInsightIds = new Set(
+    fromInsights(board, taskId).map(n => n.refs.insightId).filter(Boolean)
+  );
+
+  if (taskInsightIds.size === 0) return [];
+
+  // 找出從 task insights 衍生的 lessons
+  const taskLessons = lessons.filter(l => taskInsightIds.has(l.fromInsight));
+
+  return taskLessons.map(lesson => {
+    const isSuperseded = lesson.status === 'superseded';
+    const type = isSuperseded ? 'supersede' : (lesson.status === 'validated' ? 'policy' : 'note');
+
+    return {
+      id: tlnId('l'),
+      ts: lesson.validatedAt || lesson.ts,
+      type,
+      title: isSuperseded
+        ? `Lesson superseded: ${lesson.rule?.slice(0, 80) || '(no rule)'}`
+        : `Lesson: ${lesson.rule?.slice(0, 80) || '(no rule)'}`,
+      detail: [
+        lesson.effect || null,
+        isSuperseded && lesson.supersededBy ? `Superseded by: ${lesson.supersededBy}` : null,
+      ].filter(Boolean).join('\n') || undefined,
+      source: 'lesson',
+      refs: {
+        lessonId: lesson.id,
+        insightId: lesson.fromInsight,
+        supersededBy: lesson.supersededBy || null,
+      },
+      meta: { status: lesson.status },
+    };
+  });
+}
+
+// --- Deduplication ---
+
+/**
+ * 去重：history 和 signals 可能重複記錄同一事件。
+ * 以 (ts ±1s, type, 相似 title) 為指紋。
+ * Signal 版本優先（資料較豐富）。
+ *
+ * @param {Array} nodes
+ * @returns {Array}
+ */
+function deduplicateNodes(nodes) {
+  const seen = new Map();
+
+  for (const node of nodes) {
+    // 建立去重 key：timestamp 取整到秒 + type
+    const tsSec = node.ts ? node.ts.slice(0, 19) : '';
+    const key = `${tsSec}|${node.type}`;
+
+    if (seen.has(key)) {
+      const existing = seen.get(key);
+      // 優先保留 signal/insight/lesson（較豐富），覆蓋 history
+      if (existing.source === 'history' && node.source !== 'history') {
+        seen.set(key, node);
+      }
+      // 同 source 則保留先出現的
+    } else {
+      seen.set(key, node);
+    }
+  }
+
+  return Array.from(seen.values());
+}
+
+// --- Duration computation ---
+
+/**
+ * 計算任務耗時（分鐘）。
+ * 從 dispatch.startedAt（或第一條 history）到 dispatch.finishedAt（或最後一條 history）。
+ *
+ * @param {object} task
+ * @returns {number|null}
+ */
+function computeDuration(task) {
+  let start = null;
+  let end = null;
+
+  // 優先使用 dispatch 時間
+  if (task.dispatch?.startedAt) {
+    start = new Date(task.dispatch.startedAt);
+  }
+  if (task.dispatch?.finishedAt) {
+    end = new Date(task.dispatch.finishedAt);
+  }
+
+  // fallback 到 history
+  if (!start && task.history?.length) {
+    start = new Date(task.history[0].ts);
+  }
+  if (!end && task.history?.length) {
+    end = new Date(task.history[task.history.length - 1].ts);
+  }
+
+  if (!start || !end || isNaN(start.getTime()) || isNaN(end.getTime())) return null;
+
+  const diffMs = end.getTime() - start.getTime();
+  if (diffMs <= 0) return null;
+
+  return Math.round(diffMs / 60000);
+}
+
+// --- Main assembly ---
+
+/**
+ * 從所有資料來源組裝完整 timeline。
+ *
+ * @param {object} board - board.json 完整物件
+ * @param {object} task - 任務物件
+ * @returns {Array} TimelineNode[] — 依時間排序
+ */
+function assembleTimeline(board, task) {
+  const nodes = [];
+
+  // Source 1: task.history[] — 永遠可用
+  nodes.push(...fromHistory(task));
+
+  // Source 2: board.signals[] — 依 refs 過濾
+  nodes.push(...fromSignals(board, task.id));
+
+  // Source 3: task.dispatch metadata
+  nodes.push(...fromDispatch(task));
+
+  // Source 4: task.review
+  nodes.push(...fromReview(task));
+
+  // Source 5: board.insights[] — 演化層
+  nodes.push(...fromInsights(board, task.id));
+
+  // Source 6: board.lessons[] — 演化層
+  nodes.push(...fromLessons(board, task.id));
+
+  // 去重
+  const deduped = deduplicateNodes(nodes);
+
+  // 依時間排序
+  return deduped.sort((a, b) => new Date(a.ts) - new Date(b.ts));
+}
+
+// --- Delivery Report ---
+
+/**
+ * 組建 delivery report 資料結構。
+ *
+ * @param {object} board
+ * @param {object} task
+ * @returns {object} DeliveryReport
+ */
+function buildDeliveryReport(board, task) {
+  const timeline = assembleTimeline(board, task);
+  const durationMin = computeDuration(task);
+
+  return {
+    version: 'delivery_report.v1',
+    taskId: task.id,
+    generatedAt: new Date().toISOString(),
+    summary: {
+      title: task.title || '(untitled)',
+      status: task.status || 'unknown',
+      score: task.review?.score ?? null,
+      durationMin,
+      decisionCount: timeline.filter(n => n.type === 'decision').length,
+      supersededCount: timeline.filter(n => n.type === 'supersede').length,
+      lessonsApplied: timeline.filter(n => n.type === 'policy').length,
+    },
+    timeline,
+    digest: task.digest || null,
+  };
+}
+
+// --- HTML Report ---
+
+/**
+ * HTML entity escape。
+ * @param {string} str
+ * @returns {string}
+ */
+function escHtml(str) {
+  if (!str) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * 格式化 ISO 時間為易讀格式。
+ * @param {string} ts - ISO 8601
+ * @returns {string}
+ */
+function fmtTime(ts) {
+  if (!ts) return '';
+  try {
+    const d = new Date(ts);
+    return d.toLocaleString('zh-TW', { timeZone: 'Asia/Taipei' });
+  } catch {
+    return ts;
+  }
+}
+
+/**
+ * Timeline node type 對應的顏色。
+ */
+const NODE_COLORS = {
+  dispatch: '#06b6d4',
+  status: '#eab308',
+  decision: '#3b82f6',
+  supersede: '#f97316',
+  policy: '#22c55e',
+  review: '#a855f7',
+  note: '#9ca3af',
+  error: '#ef4444',
+};
+
+/**
+ * Timeline node type 對應的 emoji（報告用）。
+ */
+const NODE_ICONS = {
+  dispatch: '&#128640;', // rocket
+  status: '&#9889;',     // lightning
+  decision: '&#128161;', // lightbulb
+  supersede: '&#128260;', // cycle arrows
+  policy: '&#128220;',   // scroll
+  review: '&#128269;',   // magnifying glass
+  note: '&#128221;',     // memo
+  error: '&#9888;',      // warning
+};
+
+/**
+ * 產生自包含 HTML 報告字串。
+ * 含嵌入 CSS、@media print 樣式、Print to PDF 按鈕。
+ *
+ * @param {object} report - DeliveryReport
+ * @returns {string} HTML string
+ */
+function renderReportHTML(report) {
+  const s = report.summary;
+  const timeline = report.timeline || [];
+
+  const timelineHtml = timeline.map(node => {
+    const color = NODE_COLORS[node.type] || '#9ca3af';
+    const icon = NODE_ICONS[node.type] || '&#9679;';
+    const isSupersede = node.type === 'supersede';
+    const titleStyle = isSupersede ? 'text-decoration: line-through; opacity: 0.7;' : '';
+
+    return `
+      <div class="tln" style="border-left-color: ${color};">
+        <div class="tln-dot" style="background: ${color};">${icon}</div>
+        <div class="tln-content">
+          <div class="tln-time">${escHtml(fmtTime(node.ts))}</div>
+          <div class="tln-type" style="color: ${color};">${escHtml(node.type).toUpperCase()}</div>
+          <div class="tln-title" style="${titleStyle}">${escHtml(node.title)}</div>
+          ${node.detail ? `<div class="tln-detail"><pre>${escHtml(node.detail)}</pre></div>` : ''}
+        </div>
+      </div>`;
+  }).join('\n');
+
+  // L2 digest section
+  let digestHtml = '';
+  if (report.digest) {
+    const d = report.digest;
+    digestHtml = `
+    <div class="section">
+      <h2>L2 Digest</h2>
+      ${d.one_liner ? `<p class="digest-one-liner">${escHtml(d.one_liner)}</p>` : ''}
+      ${d.risk ? `<p>Risk: <span class="risk-${escHtml(d.risk.level || 'unknown')}">${escHtml(d.risk.level || 'unknown')}</span></p>` : ''}
+      ${d.bullets?.what?.length ? `
+        <h3>What</h3>
+        <ul>${d.bullets.what.map(b => `<li>${escHtml(b)}</li>`).join('')}</ul>
+      ` : ''}
+      ${d.bullets?.why?.length ? `
+        <h3>Why</h3>
+        <ul>${d.bullets.why.map(b => `<li>${escHtml(b)}</li>`).join('')}</ul>
+      ` : ''}
+      ${d.bullets?.risk?.length ? `
+        <h3>Risk Assessment</h3>
+        <ul>${d.bullets.risk.map(b => `<li>${escHtml(b)}</li>`).join('')}</ul>
+      ` : ''}
+      ${d.warnings?.length ? `
+        <h3>Warnings</h3>
+        <ul>${d.warnings.map(w => `<li><strong>${escHtml(w.code)}</strong>: ${escHtml(w.text)}</li>`).join('')}</ul>
+      ` : ''}
+    </div>`;
+  }
+
+  return `<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Delivery Report — ${escHtml(s.title)} (${escHtml(report.taskId)})</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f1923;
+      color: #e0e0e0;
+      margin: 0;
+      padding: 24px;
+      line-height: 1.6;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { color: #7aa2f7; margin-bottom: 4px; font-size: 24px; }
+    h2 { color: #7aa2f7; border-bottom: 1px solid #2a3862; padding-bottom: 8px; margin-top: 32px; }
+    h3 { color: #a9b1d6; margin-top: 16px; font-size: 14px; }
+    .subtitle { color: #9ca3af; font-size: 14px; margin-bottom: 24px; }
+
+    .summary-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 12px;
+      margin: 16px 0 32px 0;
+    }
+    .summary-card {
+      background: #1a2332;
+      border: 1px solid #2a3862;
+      border-radius: 8px;
+      padding: 16px;
+      text-align: center;
+    }
+    .summary-card .label { color: #9ca3af; font-size: 11px; text-transform: uppercase; letter-spacing: 1px; }
+    .summary-card .value { font-size: 24px; font-weight: 700; color: #e0e0e0; margin-top: 4px; }
+    .summary-card .value.score { color: #22c55e; }
+    .summary-card .value.warn { color: #f97316; }
+
+    .tln {
+      position: relative;
+      border-left: 3px solid #4a5568;
+      padding: 12px 0 12px 24px;
+      margin-left: 16px;
+    }
+    .tln-dot {
+      position: absolute;
+      left: -12px;
+      top: 14px;
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      background: #4a5568;
+      color: #fff;
+    }
+    .tln-content { }
+    .tln-time { color: #6b7280; font-size: 11px; }
+    .tln-type { font-size: 10px; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; margin: 2px 0; }
+    .tln-title { font-weight: 600; font-size: 14px; }
+    .tln-detail {
+      color: #9ca3af;
+      font-size: 12px;
+      margin-top: 4px;
+      background: #1a2332;
+      border-radius: 4px;
+      padding: 8px;
+    }
+    .tln-detail pre { margin: 0; white-space: pre-wrap; word-break: break-word; font-family: inherit; font-size: inherit; }
+
+    .digest-one-liner { font-size: 18px; font-weight: 600; color: #a9b1d6; }
+    .risk-low { color: #22c55e; }
+    .risk-medium { color: #eab308; }
+    .risk-high { color: #ef4444; }
+    .risk-unknown { color: #9ca3af; }
+
+    ul { padding-left: 20px; }
+    li { margin-bottom: 4px; }
+
+    .print-bar {
+      text-align: right;
+      margin-bottom: 16px;
+    }
+    .print-btn {
+      background: #7aa2f7;
+      color: #0f1923;
+      border: none;
+      padding: 8px 20px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-weight: 600;
+      font-size: 14px;
+    }
+    .print-btn:hover { background: #89b4fa; }
+
+    .footer { margin-top: 40px; padding-top: 16px; border-top: 1px solid #2a3862; color: #6b7280; font-size: 12px; }
+
+    /* --- Print styles --- */
+    @media print {
+      body { background: #fff; color: #000; padding: 16px; }
+      h1 { color: #1a365d; }
+      h2 { color: #1a365d; border-bottom-color: #ccc; }
+      h3 { color: #374151; }
+      .subtitle { color: #6b7280; }
+      .summary-card { background: #f9fafb; border-color: #d1d5db; }
+      .summary-card .label { color: #6b7280; }
+      .summary-card .value { color: #111827; }
+      .summary-card .value.score { color: #166534; }
+      .summary-card .value.warn { color: #c2410c; }
+      .tln { border-left-color: #d1d5db; }
+      .tln-detail { background: #f9fafb; }
+      .tln-title { color: #111827; }
+      .tln-time { color: #6b7280; }
+      .print-bar { display: none; }
+      .digest-one-liner { color: #374151; }
+      .risk-low { color: #166534; }
+      .risk-medium { color: #a16207; }
+      .risk-high { color: #dc2626; }
+      .footer { color: #9ca3af; border-top-color: #d1d5db; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="print-bar">
+      <button class="print-btn" onclick="window.print()">Print / Save as PDF</button>
+    </div>
+
+    <h1>${escHtml(s.title)}</h1>
+    <div class="subtitle">
+      Task ${escHtml(report.taskId)} &mdash; Generated: ${escHtml(fmtTime(report.generatedAt))}
+    </div>
+
+    <div class="section">
+      <h2>Summary</h2>
+      <div class="summary-grid">
+        <div class="summary-card">
+          <div class="label">Status</div>
+          <div class="value">${escHtml(s.status)}</div>
+        </div>
+        <div class="summary-card">
+          <div class="label">Score</div>
+          <div class="value ${s.score != null && s.score >= 70 ? 'score' : 'warn'}">${s.score != null ? s.score : 'N/A'}</div>
+        </div>
+        <div class="summary-card">
+          <div class="label">Duration</div>
+          <div class="value">${s.durationMin != null ? s.durationMin + ' min' : 'N/A'}</div>
+        </div>
+        <div class="summary-card">
+          <div class="label">Decisions</div>
+          <div class="value">${s.decisionCount}</div>
+        </div>
+        <div class="summary-card">
+          <div class="label">Superseded</div>
+          <div class="value ${s.supersededCount > 0 ? 'warn' : ''}">${s.supersededCount}</div>
+        </div>
+        <div class="summary-card">
+          <div class="label">Lessons</div>
+          <div class="value">${s.lessonsApplied}</div>
+        </div>
+      </div>
+    </div>
+
+    ${digestHtml}
+
+    <div class="section">
+      <h2>Timeline (${timeline.length} events)</h2>
+      ${timeline.length === 0
+        ? '<p style="color: #9ca3af;">No timeline events recorded.</p>'
+        : timelineHtml}
+    </div>
+
+    <div class="footer">
+      Karvi Task Engine &mdash; L3 Delivery Report v1 &mdash; ${escHtml(fmtTime(report.generatedAt))}
+    </div>
+  </div>
+
+  <script>
+    // Auto-print when ?print=1 parameter present
+    if (new URLSearchParams(window.location.search).get('print') === '1') {
+      window.addEventListener('load', () => setTimeout(() => window.print(), 500));
+    }
+  </script>
+</body>
+</html>`;
+}
+
+// --- Exports ---
+
+module.exports = {
+  assembleTimeline,
+  buildDeliveryReport,
+  renderReportHTML,
+  // Exposed for testing
+  _internal: {
+    fromHistory,
+    fromSignals,
+    fromDispatch,
+    fromReview,
+    fromInsights,
+    fromLessons,
+    deduplicateNodes,
+    computeDuration,
+    mapHistoryType,
+    mapSignalType,
+    escHtml,
+    fmtTime,
+    NODE_COLORS,
+  },
+};

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -423,3 +423,54 @@ export interface RuntimeResult {
   parsed: Record<string, unknown> | null;
   sessionId?: string | null;
 }
+
+// ---------------------------------------------------------------------------
+// L3 Timeline Types
+// ---------------------------------------------------------------------------
+
+export type TimelineNodeType =
+  | 'dispatch'    // agent dispatched
+  | 'status'      // status transition
+  | 'decision'    // automated decision (insight applied)
+  | 'supersede'   // decision/lesson superseded or rolled back
+  | 'policy'      // lesson validated / policy extracted
+  | 'review'      // review result
+  | 'note'        // general note / log entry
+  | 'error';      // error event
+
+export interface TimelineNodeRefs {
+  supersedes?: string | null;
+  supersededBy?: string | null;
+  insightId?: string | null;
+  lessonId?: string | null;
+}
+
+/** TimelineNode — unified timeline entry for L3 deep timeline */
+export interface TimelineNode {
+  id: string;
+  ts: string;
+  type: TimelineNodeType;
+  title: string;
+  detail?: string;
+  source: 'history' | 'signal' | 'insight' | 'lesson' | 'dispatch' | 'review';
+  refs: TimelineNodeRefs;
+  meta?: Record<string, unknown>;
+}
+
+/** DeliveryReport — exportable task delivery report */
+export interface DeliveryReport {
+  version: 'delivery_report.v1';
+  taskId: string;
+  generatedAt: string;
+  summary: {
+    title: string;
+    status: string;
+    score: number | null;
+    durationMin: number | null;
+    decisionCount: number;
+    supersededCount: number;
+    lessonsApplied: number;
+  };
+  timeline: TimelineNode[];
+  digest?: object | null;
+}


### PR DESCRIPTION
## Summary

- Add `server/timeline-task.js` module that assembles timeline data from 6 existing board sources (task.history, board.signals, task.dispatch, task.review, board.insights, board.lessons) into unified `TimelineNode[]` with 8 node types
- Add `GET /api/tasks/:id/timeline` endpoint returning assembled timeline as JSON
- Add `GET /api/tasks/:id/report` endpoint returning a self-contained, print-optimized HTML report page with `@media print` CSS for browser-native PDF export
- Add TypeScript type definitions (`TimelineNode`, `DeliveryReport`) to `shared/types.ts`
- 126 unit tests in `server/test-timeline-task.js`, smoke test additions for new endpoints

## Design Decisions

- **Server-side assembly, read-only**: Timeline reads from existing board data without storing new data. No board.json size growth.
- **HTML + @media print for PDF**: Zero external dependencies. Browser `window.print()` generates true PDFs. Auto-print via `?print=1` query parameter.
- **Deduplication**: History and signal events that overlap (same second + same type) are deduplicated, preferring signal versions (richer data).
- **Edda fallback**: Timeline works entirely from board.json data. Edda read-back is additive/future (#50).
- **Share links deferred**: Skeleton for future HMAC-signed tokens; not implemented in this PR.
- **UI deferred**: Server-side API only in this PR; inline expandable timeline UI will follow.

## Acceptance Criteria Coverage

| AC | Status |
|----|--------|
| Task Detail can expand timeline view | API ready; UI deferred |
| Timeline displays decision/supersede/policy/note nodes | 8 node types with correct mapping |
| Supersede has old-new association markers | `refs.supersedes/supersededBy` + strikethrough in HTML report |
| Export PDF functionality works | HTML report with @media print + auto-print trigger |
| Fallback to task history when no Edda | Board data is primary; Edda is additive |

## Test plan

- [x] `node --check server/timeline-task.js` — syntax OK
- [x] `node --check server/server.js` — syntax OK
- [x] `node server/test-timeline-task.js` — 126 tests pass
- [x] `node server/test-digest-task.js` — 70 tests pass (no regression)
- [x] `npm test` — evolution loop integration tests pass
- [ ] Manual: start server, hit `/api/tasks/T1/timeline` and `/api/tasks/T1/report`
- [ ] Manual: open report in browser, verify Print to PDF works

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)