### PR TITLE
fix(context-compiler): add null guard for missing task in buildEnvelope

### DIFF
--- a/server/context-compiler.js
+++ b/server/context-compiler.js
@@ -16,6 +16,7 @@ const STEP_OBJECTIVES = {
 
 function buildEnvelope(decision, runState, deps) {
   const { task, steps } = runState;
+  if (!task || !steps) return null;
   const { artifactStore, stepSchema } = deps;
 
   const targetStepId = decision.next_step?.step_id;

--- a/server/test-context-compiler.js
+++ b/server/test-context-compiler.js
@@ -127,6 +127,18 @@ test('buildEnvelope returns null for missing target step', () => {
   assert.strictEqual(env, null);
 });
 
+test('buildEnvelope returns null for null task', () => {
+  const decision = { action: 'next_step', next_step: { step_id: 'T-1:implement' } };
+  const runState = { task: null, steps: [], run_id: testRunId };
+  assert.strictEqual(contextCompiler.buildEnvelope(decision, runState, { artifactStore, stepSchema }), null);
+});
+
+test('buildEnvelope returns null for null steps', () => {
+  const decision = { action: 'next_step', next_step: { step_id: 'T-1:implement' } };
+  const runState = { task: { id: 'T-1' }, steps: null, run_id: testRunId };
+  assert.strictEqual(contextCompiler.buildEnvelope(decision, runState, { artifactStore, stepSchema }), null);
+});
+
 // Cleanup
 try {
   fs.rmSync(path.join(artifactStore.ARTIFACT_DIR, testRunId), { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Add `if (!task || !steps) return null` guard in `buildEnvelope()` to prevent crash on null runState fields
- Add 2 test cases for null task and null steps

Closes #98

## Test plan
- [x] `node server/test-context-compiler.js` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)