### PR TITLE
feat(village): Cadence Engine scheduler (#125)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -34,6 +34,7 @@ try { confidenceEngine = require('./confidence-engine'); } catch { /* confidence
 
 const telemetry = require('./telemetry');
 const push = require('./push');
+const { createScheduler } = require('./village/village-scheduler');
 const githubApi = require('./github-api');
 const usage = require('./usage');
 
@@ -286,10 +287,23 @@ try {
   console.warn(`[usage] init failed, continuing without usage tracking: ${err.message}`);
 }
 
+// --- Village Scheduler (Cadence Engine) ---
+let villageScheduler = null;
+try {
+  villageScheduler = createScheduler({
+    helpers: routeHelpers,
+    tryAutoDispatch: (taskId) => deps.tryAutoDispatch && deps.tryAutoDispatch(taskId),
+  });
+  villageScheduler.start();
+} catch (err) {
+  console.warn(`[village-scheduler] init failed, continuing without scheduler: ${err.message}`);
+}
+
 // --- Graceful Shutdown ---
 function gracefulShutdown() {
   console.log('[server] shutting down...');
   clearInterval(retryPoller);
+  villageScheduler?.stop();
   telemetryHandle?.stop();
   usageHandle?.stop();
   server.close(() => process.exit(0));

--- a/server/village/village-scheduler.js
+++ b/server/village/village-scheduler.js
@@ -1,0 +1,129 @@
+/**
+ * village-scheduler.js — Cadence Engine
+ *
+ * Periodically checks if a meeting should be triggered based on
+ * the schedule defined in board.village.schedule.
+ *
+ * Uses setInterval (1 hour) to check; no external dependencies.
+ */
+const { generateMeetingTasks } = require('./village-meeting');
+
+const HOUR = 3_600_000;
+
+function createScheduler(deps) {
+  function checkSchedule() {
+    try {
+      const board = deps.helpers.readBoard();
+      const schedule = board.village?.schedule;
+      if (!schedule) return;
+
+      const now = new Date();
+      const day = now.getDay(); // 0=Sun, 1=Mon, ...
+      const hour = now.getHours();
+
+      // Weekly planning: default Monday 9:00
+      if (schedule.weeklyPlanning) {
+        const wp = schedule.weeklyPlanning;
+        if (day === (wp.day !== undefined ? wp.day : 1) && hour === (wp.hour !== undefined ? wp.hour : 9)) {
+          const cycle = board.village?.currentCycle;
+          if (!cycle || cycle.phase === 'done' || cycle.phase === 'execution') {
+            triggerMeeting('weekly_planning');
+          }
+        }
+      }
+
+      // Mid-week check-in: default Wednesday 14:00
+      if (schedule.midweekCheckin) {
+        const mc = schedule.midweekCheckin;
+        if (day === (mc.day !== undefined ? mc.day : 3) && hour === (mc.hour !== undefined ? mc.hour : 14)) {
+          const cycle = board.village?.currentCycle;
+          if (cycle && cycle.phase === 'execution') {
+            triggerMeeting('midweek_checkin');
+          }
+        }
+      }
+    } catch (err) {
+      console.error('[village-scheduler] checkSchedule error:', err.message);
+    }
+  }
+
+  function triggerMeeting(meetingType) {
+    try {
+      const board = deps.helpers.readBoard();
+      const village = board.village;
+      if (!village) return;
+
+      const now = new Date().toISOString();
+
+      // Idempotency: don't start a new meeting if one is already in proposal phase
+      if (village.currentCycle && village.currentCycle.phase === 'proposal') {
+        console.log(`[village-scheduler] skipping ${meetingType} — cycle ${village.currentCycle.cycleId} already in proposal`);
+        return;
+      }
+
+      // Need at least one department
+      if (!Array.isArray(village.departments) || village.departments.length === 0) {
+        console.log(`[village-scheduler] skipping ${meetingType} — no departments configured`);
+        return;
+      }
+
+      const meetingTasks = generateMeetingTasks(board, meetingType);
+
+      if (!board.taskPlan) board.taskPlan = { goal: '', phase: 'idle', tasks: [] };
+      if (!Array.isArray(board.taskPlan.tasks)) board.taskPlan.tasks = [];
+      board.taskPlan.tasks.push(...meetingTasks);
+
+      const cycleId = meetingTasks[0]?.id?.replace(/^MTG-/, '').replace(/-proposal-.*$/, '') || `cycle-${Date.now()}`;
+      village.currentCycle = {
+        cycleId,
+        phase: 'proposal',
+        meetingType,
+        startedAt: now,
+        taskIds: meetingTasks.map(t => t.id),
+      };
+
+      deps.helpers.writeBoard(board);
+      deps.helpers.appendLog({
+        ts: now,
+        event: 'village_meeting_triggered',
+        cycleId,
+        meetingType,
+        taskCount: meetingTasks.length,
+        source: 'scheduler',
+      });
+      deps.helpers.broadcastSSE('village_meeting', { cycleId, meetingType, phase: 'proposal', source: 'scheduler' });
+
+      console.log(`[village-scheduler] triggered ${meetingType} — cycleId=${cycleId}, tasks=${meetingTasks.length}`);
+
+      // Auto-dispatch dispatched tasks (fire-and-forget)
+      if (deps.tryAutoDispatch) {
+        for (const t of meetingTasks) {
+          if (t.status === 'dispatched') {
+            setImmediate(() => deps.tryAutoDispatch(t.id));
+          }
+        }
+      }
+    } catch (err) {
+      console.error(`[village-scheduler] triggerMeeting(${meetingType}) error:`, err.message);
+    }
+  }
+
+  let intervalId = null;
+
+  function start() {
+    if (intervalId) return;
+    intervalId = setInterval(checkSchedule, HOUR);
+    console.log('[village-scheduler] started (1h interval)');
+  }
+
+  function stop() {
+    if (intervalId) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  }
+
+  return { start, stop, checkSchedule };
+}
+
+module.exports = { createScheduler };


### PR DESCRIPTION
## Summary

- Add `server/village/village-scheduler.js` — Cadence Engine that uses `setInterval` (1h) to check `board.village.schedule` and auto-trigger meetings
- Supports `weeklyPlanning` (default Mon 9:00) and `midweekCheckin` (default Wed 14:00) schedule entries
- Replicates the same idempotency check, cycle state update, and auto-dispatch logic from the `/api/village/trigger` route handler — no HTTP self-call
- Wire into `server/server.js`: import, create with `routeHelpers` + live `tryAutoDispatch` wrapper, start after board init, stop on graceful shutdown
- Fire-and-forget error handling: all errors are logged but never crash the server

## Test plan

- [ ] Start server — verify `[village-scheduler] started (1h interval)` appears in logs
- [ ] Add `board.village.schedule = { weeklyPlanning: { day: 1, hour: 9 } }` and call `scheduler.checkSchedule()` manually on a Monday 9am — confirm meeting tasks created
- [ ] Call `checkSchedule()` when `currentCycle.phase === 'proposal'` — confirm idempotency (no duplicate cycle)
- [ ] Call `checkSchedule()` with no departments — confirm graceful skip with log message
- [ ] Stop server — verify `villageScheduler?.stop()` clears the interval without errors
- [ ] Verify `node --check server/server.js` and `node --check server/village/village-scheduler.js` both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)