### PR TITLE
feat(step-worker): post-condition verification after step completion (#137)

### DIFF
--- a/server/route-engine.js
+++ b/server/route-engine.js
@@ -15,6 +15,7 @@ const FAILURE_MODES = {
   TEST_FAILURE:       'TEST_FAILURE',
   TOOL_ERROR:         'TOOL_ERROR',
   STRATEGY_MISMATCH:  'STRATEGY_MISMATCH',
+  FINALIZE_ERROR:     'FINALIZE_ERROR',
 };
 
 const BUDGET_DEFAULTS = {
@@ -31,6 +32,7 @@ const REMEDIATION_LIMITS = {
   CONFLICT:          1,
   TEST_FAILURE:      2,
   STRATEGY_MISMATCH: 2,
+  FINALIZE_ERROR:    1,
 };
 
 // --- Failure classification ---
@@ -43,6 +45,7 @@ const FAILURE_PATTERNS = [
   { mode: FAILURE_MODES.TEST_FAILURE,     pattern: /test.*fail|assert.*fail|expect.*received|spec.*fail/i },
   { mode: FAILURE_MODES.STRATEGY_MISMATCH, pattern: /wrong.direction|rethink|strategy.*(?:fail|wrong|bad)|approach.*(?:fail|wrong|bad)|(?:fail|wrong|bad).*(?:strategy|approach)/i },
   { mode: FAILURE_MODES.TOOL_ERROR,       pattern: /timeout|ETIMEDOUT|rate.limit|ECONNREFUSED|socket.hang/i },
+  { mode: FAILURE_MODES.FINALIZE_ERROR,   pattern: /uncommitted.changes|auto.finalize|finalize.error/i },
 ];
 
 function classifyFailure(agentOutput) {

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -8,6 +8,7 @@
  * Extracted from kernel.js:dispatchStep() (issue #92).
  * Kernel = routing decisions, StepWorker = execution.
  */
+const { execSync } = require('child_process');
 const LOCK_GRACE_MS = 30_000; // 30s grace on top of step timeout
 
 /**
@@ -131,6 +132,28 @@ function createStepWorker(deps) {
       } : null;
     }
 
+    // 5b. Post-condition verification — only when agent self-reported success
+    let postCheckResult = null;
+    if (status === 'succeeded') {
+      const postResult = await runPostCheck(plan.workingDir || plan.cwd);
+      postCheckResult = postResult;
+      if (postResult.hasUncommittedChanges) {
+        // Attempt auto-finalize
+        const finalized = autoFinalize(plan.workingDir || plan.cwd, envelope);
+        if (!finalized.ok) {
+          status = 'failed';
+          failure = {
+            failure_signature: `Post-check: uncommitted changes (${postResult.files.length} files) and auto-finalize failed: ${finalized.error}`,
+            failure_mode: 'FINALIZE_ERROR',
+            retryable: true,
+          };
+          summary = `Agent reported success but left uncommitted changes. Auto-finalize failed.`;
+        } else {
+          summary = (summary || '') + ` [auto-finalized: ${finalized.commitHash}]`;
+        }
+      }
+    }
+
     const agentOutput = {
       run_id: envelope.run_id,
       step_id: envelope.step_id,
@@ -140,6 +163,7 @@ function createStepWorker(deps) {
       tokens_used: (usage?.inputTokens || 0) + (usage?.outputTokens || 0),
       duration_ms: durationMs,
       model_used: plan.modelHint,
+      post_check: postCheckResult,
     };
     artifactStore.writeArtifact(envelope.run_id, envelope.step_id, 'output', agentOutput);
 
@@ -192,6 +216,56 @@ function createStepWorker(deps) {
 }
 
 // --- Helpers (module-level, testable) ---
+
+/**
+ * Check working directory for uncommitted git changes.
+ * Returns { hasUncommittedChanges, files }.
+ * If the directory is not a git repo, returns a clean result (no-op).
+ */
+async function runPostCheck(workDir) {
+  const opts = { cwd: workDir, encoding: 'utf8', timeout: 10000 };
+  const result = { hasUncommittedChanges: false, files: [], hasNewCommit: false };
+
+  if (!workDir) return result;
+
+  try {
+    const porcelain = execSync('git status --porcelain', opts).trim();
+    if (porcelain) {
+      result.hasUncommittedChanges = true;
+      result.files = porcelain.split('\n').map(l => l.trim()).filter(Boolean);
+    }
+  } catch (err) {
+    // Not a git repo or git not available — skip post-check
+    return result;
+  }
+
+  return result;
+}
+
+/**
+ * Attempt to commit all uncommitted changes on behalf of the agent.
+ * Returns { ok, commitHash } on success or { ok, error } on failure.
+ */
+function autoFinalize(workDir, envelope) {
+  const opts = { cwd: workDir, encoding: 'utf8', timeout: 30000 };
+  try {
+    execSync('git add -A', opts);
+    const msg = `chore: auto-finalize step ${envelope.step_id} for ${envelope.task_id}`;
+    execSync(`git commit -m "${msg}"`, opts);
+    const hash = execSync('git log -1 --format=%h', opts).trim();
+
+    // Try to push if on a branch
+    try {
+      execSync('git push', opts);
+    } catch {
+      // Push failed — still consider commit as success
+    }
+
+    return { ok: true, commitHash: hash };
+  } catch (err) {
+    return { ok: false, error: err.message?.slice(0, 200) || 'unknown' };
+  }
+}
 
 /**
  * Parse structured STEP_RESULT from agent stdout.


### PR DESCRIPTION
## Summary

- `step-worker.js` now runs `runPostCheck()` after any self-reported `succeeded` status; if uncommitted git changes are found, `autoFinalize()` stages, commits, and pushes them automatically
- On auto-finalize success the commit hash is appended to `summary`; on failure the step is downgraded to `failed` with `failure_mode: FINALIZE_ERROR` (retryable)
- The `post_check` result object is always included in the written artifact so it is visible in signals
- `route-engine.js` gains `FINALIZE_ERROR` in `FAILURE_MODES`, `REMEDIATION_LIMITS` (limit 1), and `FAILURE_PATTERNS` for correct downstream routing

## Test plan

- [ ] Run a mock step where agent outputs `STEP_RESULT:{"status":"succeeded"}` but leaves a dirty working tree — confirm `autoFinalize` fires and summary contains `[auto-finalized: <hash>]`
- [ ] Simulate `git commit` failing inside `autoFinalize` — confirm step status becomes `failed` with `failure_mode: FINALIZE_ERROR`
- [ ] Run step in a non-git directory — confirm `runPostCheck` returns clean result and execution continues normally
- [ ] Run step in a clean git repo (no uncommitted files) — confirm no auto-finalize is attempted and `post_check.hasUncommittedChanges` is `false`
- [ ] Confirm `route-engine.decideNext` routes a `FINALIZE_ERROR` failure to `retry` on first attempt and `dead_letter` after limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)