### PR TITLE
fix(village): wire cross-module integration for meeting pipeline

### DIFF
--- a/server/kernel.js
+++ b/server/kernel.js
@@ -167,7 +167,13 @@ function createKernel(deps) {
           // Step pipeline includes review as step[3] — all steps succeeded means approved
           latestTask.status = 'approved';
           latestTask.completedAt = helpers.nowIso();
-          latestTask.result = { status: 'approved', summary: `All ${task.steps.length} steps succeeded (including review)` };
+          // Preserve payload from last step's artifact for downstream access
+          const lastStepOutput = artifactStore.readArtifact(step.run_id, stepId, 'output');
+          latestTask.result = {
+            status: 'approved',
+            summary: lastStepOutput?.summary || `All ${task.steps.length} steps succeeded (including review)`,
+            payload: lastStepOutput?.payload || null,
+          };
         }
 
         // Unlock dependent tasks (autoUnlockDependents checks for 'approved')

--- a/server/management.js
+++ b/server/management.js
@@ -436,6 +436,10 @@ function gatherUpstreamArtifacts(board, task) {
     } else if (dep.result?.summary) {
       entry.summary = dep.result.summary.slice(0, 600);
     }
+    // Include structured payload from step output (proposal, plan, etc.)
+    if (dep.result?.payload) {
+      entry.payload = dep.result.payload;
+    }
     results.push(entry);
   }
   return results;

--- a/server/push.js
+++ b/server/push.js
@@ -106,7 +106,14 @@ function sendPush(tokenStrings, { title, body, data }) {
 // Notification Builder
 // ---------------------------------------------------------------------------
 
-function buildNotification(task, eventType) {
+function buildNotification(task, eventType, extra) {
+  // Village events don't require a task object
+  if (eventType.startsWith('village.')) {
+    return buildVillageNotification(eventType, extra);
+  }
+
+  if (!task) return null;
+
   const map = {
     'task.completed': {
       title: `${task.id} Completed`,
@@ -136,8 +143,6 @@ function buildNotification(task, eventType) {
       title: `${task.id} Requirements Updated`,
       body: `${task.title} — acceptance criteria changed, please review`,
     },
-    // TODO: pr.created — 當 PR review 功能 (#27) 落地後，加入 PR 建立通知。
-    // 屆時需在 server.js 的 PR 建立流程中呼叫 notifyTaskEvent(path, task, 'pr.created')。
     'pr.created': {
       title: `PR Created: ${task.id}`,
       body: task.pr?.url || task.title,
@@ -157,12 +162,46 @@ function buildNotification(task, eventType) {
   };
 }
 
+function buildVillageNotification(eventType, extra) {
+  const cycleId = extra?.cycleId || '';
+  const map = {
+    'village.meeting_started': {
+      title: 'Village: Meeting Started',
+      body: `Cycle ${cycleId} — departments are preparing proposals`,
+    },
+    'village.proposals_ready': {
+      title: 'Village: Proposals Ready',
+      body: `${extra?.departmentCount || 0} departments submitted — synthesis starting`,
+    },
+    'village.plan_ready': {
+      title: extra?.needsApproval ? 'Village: Plan Needs Approval' : 'Village: Plan Ready',
+      body: `Cycle ${cycleId} — weekly plan synthesized`,
+    },
+    'village.plan_executing': {
+      title: 'Village: Execution Started',
+      body: `${extra?.taskCount || 0} tasks dispatched for cycle ${cycleId}`,
+    },
+    'village.checkin_summary': {
+      title: 'Village: Check-in Complete',
+      body: `${extra?.completed || 0}/${extra?.total || 0} tasks done, ${extra?.blocked || 0} blocked`,
+    },
+  };
+
+  const msg = map[eventType];
+  if (!msg) return null;
+
+  return {
+    ...msg,
+    data: { eventType, cycleId, ...(extra || {}) },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // High-Level: Notify + Cleanup stale tokens
 // ---------------------------------------------------------------------------
 
-async function notifyTaskEvent(filePath, task, eventType) {
-  const notification = buildNotification(task, eventType);
+async function notifyTaskEvent(filePath, task, eventType, extra) {
+  const notification = buildNotification(task, eventType, extra);
   if (!notification) return;
 
   const data = loadTokens(filePath);
@@ -201,5 +240,6 @@ module.exports = {
   removeToken,
   sendPush,
   buildNotification,
+  buildVillageNotification,
   notifyTaskEvent,
 };

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -36,12 +36,12 @@ function createStepWorker(deps) {
     if (!task) throw new Error(`Task ${envelope.task_id} not found`);
 
     // 1. Build dispatch plan
-    const stepMessage = buildStepMessage(envelope);
     const plan = mgmt.buildDispatchPlan(board, task, {
       mode: 'dispatch',
       timeoutSec: Math.ceil(envelope.timeout_ms / 1000),
       steps: task.steps,
     });
+    const stepMessage = buildStepMessage(envelope, plan.artifacts);
     plan.message = stepMessage;
     plan.stepId = envelope.step_id;
     plan.stepType = envelope.step_type;
@@ -86,7 +86,7 @@ function createStepWorker(deps) {
     // 3b. Preflight: check if work is already done (zero tokens)
     const preflightResult = runPreflight(envelope, plan.workingDir || plan.cwd);
 
-    let status, failure, summary, durationMs, usage, postCheckResult;
+    let status, failure, summary, durationMs, usage, postCheckResult, stepResult;
 
     if (preflightResult.alreadyDone) {
       // Skip dispatch — work already exists in codebase
@@ -124,7 +124,7 @@ function createStepWorker(deps) {
       //    is inside parsed.result, not in raw stdout)
       const replyText = rt.extractReplyText(result.parsed, result.stdout);
       usage = rt.extractUsage?.(result.parsed, result.stdout) || null;
-      const stepResult = parseStepResult(replyText) || parseStepResult(result.stdout);
+      stepResult = parseStepResult(replyText) || parseStepResult(result.stdout);
 
       if (stepResult) {
         // Structured output from agent
@@ -168,6 +168,13 @@ function createStepWorker(deps) {
       }
     }
 
+    // Preserve full STEP_RESULT payload (proposal, plan, etc.) for downstream modules.
+    // Without this, structured data from agents is lost and only summary text survives.
+    const payload = stepResult ? (() => {
+      const { status: _s, summary: _sm, error: _e, failure_mode: _f, retryable: _r, ...extra } = stepResult;
+      return Object.keys(extra).length > 0 ? extra : null;
+    })() : null;
+
     const agentOutput = {
       run_id: envelope.run_id,
       step_id: envelope.step_id,
@@ -178,6 +185,7 @@ function createStepWorker(deps) {
       duration_ms: durationMs,
       model_used: plan.modelHint,
       post_check: postCheckResult,
+      payload,
       ...(preflightResult.alreadyDone ? { skipped: true, preflight: preflightResult } : {}),
     };
     artifactStore.writeArtifact(envelope.run_id, envelope.step_id, 'output', agentOutput);
@@ -406,7 +414,7 @@ function parseStepResult(stdout) {
  * skill directly. The headless agent (`claude -p`) runs in the repo directory
  * and has access to `.claude/skills/`.
  */
-function buildStepMessage(envelope) {
+function buildStepMessage(envelope, upstreamArtifacts) {
   // Extract issue number from task source or task ID (GH-123 → 123)
   const source = envelope.input_refs?.task_source;
   const issueNumber = source?.number
@@ -442,6 +450,22 @@ function buildStepMessage(envelope) {
 
   if (envelope.input_refs.task_description) {
     lines.push('', `Task description: ${envelope.input_refs.task_description}`);
+  }
+
+  // Inject upstream artifacts (from completed dependency tasks)
+  if (Array.isArray(upstreamArtifacts) && upstreamArtifacts.length > 0) {
+    lines.push('', '## Upstream Task Outputs');
+    for (const u of upstreamArtifacts) {
+      lines.push(`### ${u.id} — ${u.title || '(untitled)'} [${u.status}]`);
+      if (u.payload) {
+        lines.push('```json');
+        lines.push(JSON.stringify(u.payload, null, 2));
+        lines.push('```');
+      } else if (u.summary) {
+        lines.push(u.summary);
+      }
+    }
+    lines.push('');
   }
 
   if (envelope.retry_context) {

--- a/server/test-village-smoke.js
+++ b/server/test-village-smoke.js
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+/**
+ * test-village-smoke.js — Village integration smoke test
+ *
+ * Exercises the REAL village pipeline end-to-end with mocked runtime.
+ * Integration DoD: all 4 checkpoints must pass for the pipeline to work.
+ *
+ *   1. trigger → board produces proposal tasks (depends correct)
+ *   2. proposals complete → synthesis auto-unlocks and executes
+ *   3. synthesis artifact contains tasks[]
+ *   4. dispatcher creates execution tasks from tasks[]
+ *
+ * Usage: node server/test-village-smoke.js
+ */
+const assert = require('assert');
+const stepSchema = require('./step-schema');
+const artifactStore = require('./artifact-store');
+const mgmt = require('./management');
+const villageMeeting = require('./village/village-meeting');
+const planDispatcher = require('./village/plan-dispatcher');
+
+let passed = 0;
+let failed = 0;
+
+function ok(label) { passed++; console.log(`  ✅ ${label}`); }
+function fail(label, reason) { failed++; console.log(`  ❌ ${label}: ${reason}`); process.exitCode = 1; }
+
+async function test(label, fn) {
+  try { await fn(); ok(label); } catch (err) { fail(label, err.message); }
+}
+
+function observe(label, value) {
+  console.log(`  👁 [${label}]`, typeof value === 'object' ? JSON.stringify(value, null, 2).slice(0, 800) : value);
+}
+
+// --- Board with minimal village config ---
+function createVillageBoard() {
+  return {
+    taskPlan: { goal: 'village smoke test', phase: 'idle', tasks: [] },
+    signals: [],
+    insights: [],
+    lessons: [],
+    participants: [{ id: 'owner', type: 'human' }],
+    controls: { auto_review: false, auto_dispatch: false },
+    village: {
+      departments: [{
+        id: 'engineering',
+        name: 'Engineering',
+        assignee: 'engineer_lite',
+        promptFile: 'village/roles/engineering.md',
+        goalIds: ['G1'],
+      }],
+      goals: [
+        { id: 'G1', text: 'Improve test coverage', cadence: 'weekly', active: true, metrics: ['coverage %'] },
+      ],
+      schedule: { weeklyPlanning: { day: 1, hour: 9 } },
+      currentCycle: null,
+    },
+  };
+}
+
+let currentBoard = null;
+const logEntries = [];
+
+function createMockHelpers(board) {
+  currentBoard = JSON.parse(JSON.stringify(board));
+  logEntries.length = 0;
+  return {
+    readBoard: () => currentBoard,
+    writeBoard: (b) => { currentBoard = b; },
+    appendLog: (e) => { logEntries.push(e); },
+    broadcastSSE: () => {},
+    nowIso: () => new Date().toISOString(),
+    uid: (prefix) => `${prefix}-${Date.now()}-smoke`,
+  };
+}
+
+const testRunId = `smoke-${Date.now()}`;
+
+// --- Tests ---
+
+(async () => {
+  console.log('\n━━━ Village Integration Smoke Test ━━━\n');
+
+  // ══════════════════════════════════════════════════════
+  // DoD 1: trigger → board produces proposal tasks (depends correct)
+  // ══════════════════════════════════════════════════════
+  console.log('── DoD 1: generateMeetingTasks → correct task DAG ──');
+
+  let meetingTasks, proposalTasks, synthesisTasks;
+
+  await test('generateMeetingTasks produces proposal + synthesis', () => {
+    const board = createVillageBoard();
+    meetingTasks = villageMeeting.generateMeetingTasks(board, 'weekly_planning');
+    proposalTasks = meetingTasks.filter(t => t.id.includes('proposal'));
+    synthesisTasks = meetingTasks.filter(t => t.id.includes('synthesis'));
+
+    assert.ok(proposalTasks.length >= 1, `expected >= 1 proposal, got ${proposalTasks.length}`);
+    assert.strictEqual(synthesisTasks.length, 1, `expected 1 synthesis, got ${synthesisTasks.length}`);
+  });
+
+  await test('synthesis depends on all proposals', () => {
+    const synthesis = synthesisTasks[0];
+    for (const p of proposalTasks) {
+      assert.ok(synthesis.depends.includes(p.id), `synthesis should depend on ${p.id}`);
+    }
+  });
+
+  await test('proposal pipeline carries instruction', () => {
+    const instruction = proposalTasks[0].pipeline[0]?.instruction;
+    assert.ok(instruction && instruction.length > 50, 'proposal instruction must exist and be substantial');
+  });
+
+  await test('generateStepsForTask preserves custom types', () => {
+    const pSteps = mgmt.generateStepsForTask(proposalTasks[0], testRunId, proposalTasks[0].pipeline);
+    assert.strictEqual(pSteps[0].type, 'propose');
+    assert.ok(pSteps[0].instruction, 'step must carry instruction');
+
+    const sSteps = mgmt.generateStepsForTask(synthesisTasks[0], testRunId, synthesisTasks[0].pipeline);
+    assert.strictEqual(sSteps[0].type, 'synthesize');
+  });
+
+  // ══════════════════════════════════════════════════════
+  // DoD 2: step-worker preserves payload + upstream flows
+  // ══════════════════════════════════════════════════════
+  console.log('\n── DoD 2: data preservation across step-worker ──');
+
+  await test('step-worker payload extraction preserves custom fields', () => {
+    // Simulate what step-worker does after parseStepResult
+    const stepResult = {
+      status: 'succeeded',
+      summary: 'Engineering proposal completed',
+      proposal: {
+        tasks: [{ title: 'Add unit tests for auth module', priority: 'P1' }],
+        rationale: 'Coverage is at 42%',
+      },
+    };
+
+    // This is what our fix does: extract extra fields as payload
+    const { status: _s, summary: _sm, error: _e, failure_mode: _f, retryable: _r, ...extra } = stepResult;
+    const payload = Object.keys(extra).length > 0 ? extra : null;
+
+    observe('extracted payload', payload);
+    assert.ok(payload, 'payload should not be null');
+    assert.ok(payload.proposal, 'payload.proposal should be preserved');
+    assert.deepStrictEqual(payload.proposal.tasks[0].title, 'Add unit tests for auth module');
+  });
+
+  await test('gatherUpstreamArtifacts includes payload from task.result', () => {
+    const board = createVillageBoard();
+    const proposal = {
+      ...proposalTasks[0],
+      status: 'approved',
+      result: {
+        status: 'approved',
+        summary: 'Engineering proposal completed',
+        payload: {
+          proposal: {
+            tasks: [{ title: 'Add auth tests', priority: 'P1' }],
+            rationale: 'Coverage is at 42%',
+          },
+        },
+      },
+    };
+    board.taskPlan.tasks = [proposal, synthesisTasks[0]];
+
+    const synthesis = board.taskPlan.tasks[1];
+    const upstream = mgmt.gatherUpstreamArtifacts(board, synthesis);
+
+    observe('upstream with payload', upstream);
+    assert.ok(upstream.length > 0, 'should find upstream');
+    assert.ok(upstream[0].payload, 'upstream should include payload');
+    assert.ok(upstream[0].payload.proposal, 'payload should contain proposal');
+  });
+
+  // ══════════════════════════════════════════════════════
+  // DoD 3: synthesis artifact → plan extraction works
+  // ══════════════════════════════════════════════════════
+  console.log('\n── DoD 3: plan extraction from synthesis artifact ──');
+
+  await test('extractPlanFromArtifact works with payload.plan as object', () => {
+    const artifact = {
+      status: 'succeeded',
+      summary: 'Plan synthesized',
+      payload: {
+        plan: {
+          tasks: [{ title: 'Add auth tests', department: 'engineering', priority: 'P1' }],
+          deferred: [],
+          conflicts_resolved: [],
+        },
+      },
+    };
+
+    const plan = planDispatcher.extractPlanFromArtifact(artifact);
+    observe('extracted plan (object)', plan);
+    assert.ok(plan, 'plan should be extracted');
+    assert.ok(Array.isArray(plan.tasks), 'plan.tasks should be array');
+    assert.strictEqual(plan.tasks[0].title, 'Add auth tests');
+  });
+
+  await test('extractPlanFromArtifact works with payload.plan as array', () => {
+    // In case agent outputs plan as array (backward compat)
+    const artifact = {
+      status: 'succeeded',
+      payload: {
+        plan: [{ title: 'Task A', department: 'engineering' }],
+      },
+    };
+
+    const plan = planDispatcher.extractPlanFromArtifact(artifact);
+    observe('extracted plan (array)', plan);
+    assert.ok(plan, 'plan should be extracted from array format');
+    assert.ok(Array.isArray(plan.tasks), 'should be wrapped as { tasks: [...] }');
+  });
+
+  await test('extractPlanFromArtifact returns null without payload', () => {
+    const artifact = { status: 'succeeded', summary: 'Plan done', tokens_used: 500 };
+    const plan = planDispatcher.extractPlanFromArtifact(artifact);
+    assert.strictEqual(plan, null, 'should return null when no plan data');
+  });
+
+  // ══════════════════════════════════════════════════════
+  // DoD 4: dispatcher creates execution tasks from plan
+  // ══════════════════════════════════════════════════════
+  console.log('\n── DoD 4: parsePlanAndDispatch creates execution tasks ──');
+
+  await test('parsePlanAndDispatch creates tasks on board', () => {
+    const board = createVillageBoard();
+    board.village.currentCycle = { cycleId: 'cycle-test', phase: 'synthesis' };
+    const helpers = createMockHelpers(board);
+
+    const planData = {
+      cycle: 'cycle-test',
+      tasks: [
+        { title: 'Add auth tests', department: 'engineering', assignee: 'engineer_lite', pipeline: ['implement'], priority: 'P1' },
+        { title: 'Fix flaky CI', department: 'engineering', pipeline: [{ type: 'implement', instruction: 'Fix auth.test.js' }], priority: 'P2' },
+      ],
+    };
+
+    const deps = { mgmt, tryAutoDispatch: null, push: null, PUSH_TOKENS_PATH: null };
+    const result = planDispatcher.parsePlanAndDispatch(currentBoard, planData, helpers, deps, null);
+
+    assert.strictEqual(result.dispatched, 2, 'should dispatch 2 tasks');
+    const execTasks = currentBoard.taskPlan.tasks.filter(t => t.source?.type === 'village_plan');
+    assert.strictEqual(execTasks.length, 2, 'board should have 2 execution tasks');
+    observe('execution tasks', execTasks.map(t => ({ id: t.id, title: t.title, status: t.status })));
+  });
+
+  // ══════════════════════════════════════════════════════
+  // BONUS: push notifications for village events
+  // ══════════════════════════════════════════════════════
+  console.log('\n── Bonus: push notifications ──');
+
+  await test('buildNotification handles village events with null task', () => {
+    const push = require('./push');
+
+    const tests = [
+      ['village.meeting_started', { cycleId: 'cycle-test' }],
+      ['village.proposals_ready', { cycleId: 'cycle-test', departmentCount: 3 }],
+      ['village.plan_ready', { cycleId: 'cycle-test' }],
+      ['village.plan_ready', { cycleId: 'cycle-test', needsApproval: true }],
+      ['village.plan_executing', { cycleId: 'cycle-test', taskCount: 5 }],
+      ['village.checkin_summary', { cycleId: 'cycle-test', completed: 3, total: 5, blocked: 1 }],
+    ];
+
+    for (const [eventType, extra] of tests) {
+      const notification = push.buildNotification(null, eventType, extra);
+      assert.ok(notification, `${eventType} should produce notification`);
+      assert.ok(notification.title, `${eventType} should have title`);
+      assert.ok(notification.body, `${eventType} should have body`);
+      observe(`${eventType}`, { title: notification.title, body: notification.body });
+    }
+  });
+
+  await test('buildNotification still works for task events', () => {
+    const push = require('./push');
+    const task = { id: 'T-1', title: 'Test task', blocker: null, review: null };
+    const notification = push.buildNotification(task, 'task.completed');
+    assert.ok(notification, 'task.completed should still work');
+    assert.ok(notification.title.includes('T-1'));
+  });
+
+  await test('buildNotification returns null for unknown events', () => {
+    const push = require('./push');
+    assert.strictEqual(push.buildNotification(null, 'unknown.event'), null);
+  });
+
+  // ══════════════════════════════════════════════════════
+  // BONUS: end-to-end schema alignment
+  // ══════════════════════════════════════════════════════
+  console.log('\n── Bonus: chief.md ↔ dispatcher schema alignment ──');
+
+  await test('chief prompt instructs correct output schema', () => {
+    // Use actual chief.md content (not mock) to verify schema alignment
+    const chiefContent = villageMeeting.readRoleFile('village/roles/chief.md');
+    const instruction = villageMeeting.buildSynthesisInstruction(chiefContent, []);
+    // Chief role must tell agent to output plan with "tasks" key (not "plan" key)
+    assert.ok(chiefContent.includes('"tasks"'), 'chief.md should use "tasks" key in output format');
+    assert.ok(instruction.includes('STEP_RESULT'), 'instruction should mention STEP_RESULT');
+  });
+
+  await test('simulated chief output matches dispatcher expectation', () => {
+    // Simulate what an agent following the updated chief.md would output
+    const stepResult = {
+      status: 'succeeded',
+      plan: {
+        tasks: [{ title: 'Task A', department: 'engineering', assignee: 'engineer_lite', pipeline: ['implement'], priority: 'P1' }],
+        deferred: [],
+        conflicts_resolved: [],
+      },
+    };
+
+    // Extract payload (step-worker fix)
+    const { status: _s, summary: _sm, error: _e, failure_mode: _f, retryable: _r, ...extra } = stepResult;
+    const payload = Object.keys(extra).length > 0 ? extra : null;
+
+    // Build artifact as step-worker would
+    const artifact = { status: 'succeeded', summary: 'Plan synthesized', payload };
+
+    // Extract plan (plan-dispatcher)
+    const plan = planDispatcher.extractPlanFromArtifact(artifact);
+    assert.ok(plan, 'plan should be extractable');
+    assert.ok(Array.isArray(plan.tasks), 'plan.tasks should be array');
+    assert.strictEqual(plan.tasks[0].title, 'Task A');
+
+    // Feed to dispatcher
+    const board = createVillageBoard();
+    board.village.currentCycle = { cycleId: 'cycle-e2e', phase: 'synthesis' };
+    const helpers = createMockHelpers(board);
+    const deps = { mgmt, tryAutoDispatch: null, push: null, PUSH_TOKENS_PATH: null };
+    const result = planDispatcher.parsePlanAndDispatch(currentBoard, plan, helpers, deps, null);
+    assert.strictEqual(result.dispatched, 1, 'should dispatch 1 task');
+    observe('e2e: chief → step-worker → dispatcher → board', `${result.dispatched} task(s) created`);
+  });
+
+  // ══════════════════════════════════════════════════════
+  // SUMMARY
+  // ══════════════════════════════════════════════════════
+  console.log('\n════════════════════════════════════════');
+  console.log(`Total: ${passed} passed, ${failed} failed`);
+
+  if (failed === 0) {
+    console.log('\n✅ All integration DoD checkpoints passed.');
+    console.log('   Pipeline: trigger → proposals → synthesis → plan → dispatch');
+  }
+})();

--- a/server/village/plan-dispatcher.js
+++ b/server/village/plan-dispatcher.js
@@ -32,9 +32,18 @@ function extractPlanFromArtifact(artifact) {
     return artifact.plan;
   }
 
-  // Path 2: STEP_RESULT was parsed by step-worker, plan is in summary text
-  // The summary field contains the raw agent output which may include
-  // STEP_RESULT:{"status":"succeeded","plan":{...}}
+  // Path 2: step-worker preserved STEP_RESULT payload containing plan
+  if (artifact.payload?.plan) {
+    // Handle both formats: plan as { tasks: [...] } or plan as [...]
+    if (Array.isArray(artifact.payload.plan.tasks)) {
+      return artifact.payload.plan;
+    }
+    if (Array.isArray(artifact.payload.plan)) {
+      return { tasks: artifact.payload.plan };
+    }
+  }
+
+  // Path 3: STEP_RESULT was parsed by step-worker, plan is in summary text
   const summaryText = artifact.summary || '';
   const planFromText = extractPlanFromText(summaryText);
   if (planFromText) return planFromText;

--- a/server/village/roles/chief.md
+++ b/server/village/roles/chief.md
@@ -7,12 +7,12 @@ and ensure the plan advances the village's goals.
 
 ## How to Read Upstream Artifacts
 Each department submits a proposal as an upstream artifact. You will receive them
-automatically via the `gatherUpstreamArtifacts` mechanism. Each artifact contains:
+in the "Upstream Task Outputs" section of your prompt. Each artifact contains:
 - `id`: the proposal task ID
 - `title`: the department name
-- `summary`: the proposal JSON (items, conflicts, resource_needs)
+- Structured payload (JSON) with proposal items, conflicts, resource needs
 
-Parse each proposal's summary to extract the structured data.
+Read each proposal's payload to extract the structured data.
 
 ## Conflict Resolution Rules
 When departments have conflicting proposals, resolve using this priority order:
@@ -31,11 +31,11 @@ When departments have conflicting proposals, resolve using this priority order:
    and alternate between departments for fairness.
 
 ## Output Format
-Produce a weekly plan as a JSON array of tasks. Each task has:
+Produce a weekly plan as a JSON object. The `tasks` array contains the execution tasks:
 
 ```json
 {
-  "plan": [
+  "tasks": [
     {
       "title": "Task title (from proposal item)",
       "department": "engineering | content | ...",
@@ -43,7 +43,7 @@ Produce a weekly plan as a JSON array of tasks. Each task has:
       "pipeline": [
         { "type": "implement", "instruction": "..." }
       ],
-      "depends": ["task-id-if-any"],
+      "depends": [],
       "priority": "P0 | P1 | P2",
       "goalRef": "G-001"
     }
@@ -67,5 +67,5 @@ Produce a weekly plan as a JSON array of tasks. Each task has:
 ## Final Output
 Wrap your plan JSON inside a STEP_RESULT block:
 ```
-STEP_RESULT:{"status":"completed","plan":{...}}
+STEP_RESULT:{"status":"succeeded","plan":{"tasks":[...],"deferred":[...],"conflicts_resolved":[...]}}
 ```


### PR DESCRIPTION
## Summary

Village system had 6 integration breaks where modules communicated with imaginary neighbors. Found via observability-first approach (smoke test before fix).

**Root cause**: each module was built by a separate agent that understood its own contract but not the adjacent module's actual behavior.

### Breaks fixed

| # | Break | Fix |
|---|-------|-----|
| 1 | step-worker discards STEP_RESULT custom fields (proposal, plan) | Preserve as `payload` in output artifact |
| 2 | Synthesis agent receives zero upstream data | Inject upstream artifacts into step message |
| 3 | kernel doesn't save structured data in task.result | Save `payload` from last step artifact |
| 4 | gatherUpstreamArtifacts only returns truncated text | Include `result.payload` |
| 5 | extractPlanFromArtifact can't find plan data | Check `payload.plan` path, support array + object |
| 6 | chief.md schema ("plan") ≠ dispatcher schema ("tasks") | Unified to "tasks" |
| 7 | push notifications crash on null task for village events | New `buildVillageNotification` + `extra` param |

### Files changed (6 modified, 1 new)

- `server/step-worker.js` — payload preservation + upstream injection
- `server/kernel.js` — save payload in task.result
- `server/management.js` — gatherUpstreamArtifacts includes payload
- `server/village/plan-dispatcher.js` — flexible plan extraction
- `server/village/roles/chief.md` — corrected output schema
- `server/push.js` — village notification support
- `server/test-village-smoke.js` — 15 integration tests (new)

## Test plan

- [x] `node server/test-village-smoke.js` — 15/15 passed (4 DoD checkpoints + bonus)
- [x] `node server/test-step-worker.js` — 11/11 passed (no regression)
- [x] `node server/test-kernel-integration.js` — 5/5 passed (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)