### PR TITLE
fix(village): runtime selection and STEP_RESULT format alignment

### DIFF
--- a/server/routes/controls.js
+++ b/server/routes/controls.js
@@ -31,7 +31,7 @@ module.exports = function controlsRoutes(req, res, helpers, deps) {
         for (const key of allowed) {
           if (key in patch) {
             const val = patch[key];
-            if ((key === 'auto_dispatch' || key === 'auto_review' || key === 'auto_redispatch' || key === 'auto_apply_insights' || key === 'telemetry_enabled') && typeof val === 'boolean') board.controls[key] = val;
+            if ((key === 'auto_dispatch' || key === 'auto_review' || key === 'auto_redispatch' || key === 'auto_apply_insights' || key === 'telemetry_enabled' || key === 'use_step_pipeline') && typeof val === 'boolean') board.controls[key] = val;
             else if (key === 'max_review_attempts' && Number.isFinite(val)) board.controls[key] = Math.max(1, Math.min(10, val));
             else if (key === 'quality_threshold' && Number.isFinite(val)) board.controls[key] = Math.max(0, Math.min(100, val));
             else if (key === 'review_timeout_sec' && Number.isFinite(val)) board.controls[key] = Math.max(30, Math.min(600, val));

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -46,28 +46,6 @@ function createStepWorker(deps) {
     plan.stepId = envelope.step_id;
     plan.stepType = envelope.step_type;
 
-    // Clear AGENT_MODEL_MAP hints for Claude Code runtime — those model IDs
-    // are for API/OpenClaw runtimes and not recognized by `claude -p`.
-    if (plan.runtimeHint === 'claude' && plan.modelHint) {
-      plan.modelHint = null;
-    }
-
-    // Inject STEP_RESULT instruction as system prompt — more reliable than
-    // putting it in the user message, because system prompts persist across
-    // the entire conversation and won't be forgotten by long-running skills.
-    if (plan.runtimeHint === 'claude') {
-      const resultPrompt = [
-        'CRITICAL: When you have completely finished your task, you MUST output the following on a single line (no code fences):',
-        'STEP_RESULT:{"status":"succeeded","summary":"one line summary"}',
-        'Or on failure:',
-        'STEP_RESULT:{"status":"failed","error":"what went wrong","failure_mode":"TEST_FAILURE","retryable":true}',
-        'This line MUST appear in your final message. Without it, the pipeline cannot advance.',
-      ].join('\n');
-      plan.systemPrompt = plan.systemPrompt
-        ? plan.systemPrompt + '\n\n' + resultPrompt
-        : resultPrompt;
-    }
-
     // 2. Set lock with expiry before dispatch
     const lockBoard = helpers.readBoard();
     const lockTask = (lockBoard.taskPlan?.tasks || []).find(t => t.id === envelope.task_id);
@@ -78,10 +56,33 @@ function createStepWorker(deps) {
       helpers.writeBoard(lockBoard);
     }
 
-    // 3. Per-step runtime selection
+    // 3. Per-step runtime selection (envelope.runtime_hint takes precedence)
     const step = task.steps?.find(s => s.step_id === envelope.step_id);
     const runtimeHint = envelope.runtime_hint || step?.runtime_hint || plan.runtimeHint;
     const rt = deps.getRuntime(runtimeHint);
+
+    // Clear AGENT_MODEL_MAP hints for Claude Code runtime — those model IDs
+    // are for API/OpenClaw runtimes and not recognized by `claude -p`.
+    if (runtimeHint === 'claude' && plan.modelHint) {
+      plan.modelHint = null;
+    }
+
+    // Inject STEP_RESULT instruction as system prompt — more reliable than
+    // putting it in the user message, because system prompts persist across
+    // the entire conversation and won't be forgotten by long-running skills.
+    if (runtimeHint === 'claude') {
+      const resultPrompt = [
+        'CRITICAL: When you have completely finished your task, you MUST output the following on a single line (no code fences):',
+        'STEP_RESULT:{"status":"succeeded","summary":"one line summary", ...extra fields as instructed}',
+        'Include any additional payload fields requested by your task instruction (e.g. "proposal", "plan").',
+        'Or on failure:',
+        'STEP_RESULT:{"status":"failed","error":"what went wrong","failure_mode":"TEST_FAILURE","retryable":true}',
+        'This line MUST appear in your final message. Without it, the pipeline cannot advance.',
+      ].join('\n');
+      plan.systemPrompt = plan.systemPrompt
+        ? plan.systemPrompt + '\n\n' + resultPrompt
+        : resultPrompt;
+    }
 
     // 3b. Preflight: check if work is already done (zero tokens)
     const preflightResult = runPreflight(envelope, plan.workingDir || plan.cwd);

--- a/server/village/roles/content.md
+++ b/server/village/roles/content.md
@@ -50,5 +50,5 @@ Your proposal must be valid JSON with the following structure:
 ## Output
 Wrap your proposal JSON inside a STEP_RESULT block:
 ```
-STEP_RESULT:{"status":"completed","proposal":{...}}
+STEP_RESULT:{"status":"succeeded","summary":"one line summary","proposal":{...}}
 ```

--- a/server/village/roles/engineering.md
+++ b/server/village/roles/engineering.md
@@ -51,5 +51,5 @@ Your proposal must be valid JSON with the following structure:
 ## Output
 Wrap your proposal JSON inside a STEP_RESULT block:
 ```
-STEP_RESULT:{"status":"completed","proposal":{...}}
+STEP_RESULT:{"status":"succeeded","summary":"one line summary","proposal":{...}}
 ```


### PR DESCRIPTION
## Summary

- **Runtime ordering bug**: `step-worker.js` resolved the runtime AFTER modelHint clearing, so Claude CLI received OpenClaw model IDs (`custom-ai-t8star-cn/gpt-5.3-codex-high`) and failed. Reordered so runtime is resolved first.
- **STEP_RESULT format conflict**: Role prompts said `status:"completed"` but system prompt said `status:"succeeded"`. Agent followed system prompt and dropped custom payload fields (`proposal` was null). Aligned both formats and updated system prompt to preserve additional payload fields.
- **Controls API gap**: `use_step_pipeline` was in `DEFAULT_CONTROLS` but not in the `POST /api/controls` whitelist, making it unsettable via API.

All three bugs were discovered during a real village meeting run with Claude CLI agents (proposal → synthesis → plan dispatch).

## Test plan

- [ ] Run village meeting trigger end-to-end: proposal agents should output `STEP_RESULT` with full `proposal` payload
- [ ] Verify `POST /api/controls` accepts `use_step_pipeline: true`
- [ ] Verify Claude runtime does not receive OpenClaw model hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)