### PR TITLE
fix(village): auto-register VT task assignees as agent participants

### DIFF
--- a/server/routes/village.js
+++ b/server/routes/village.js
@@ -20,6 +20,23 @@ const DEFAULT_VILLAGE = {
 };
 
 /**
+ * Ensure an agent is registered as a participant on the board.
+ * tryAutoDispatch silently skips tasks whose assignee isn't in
+ * board.participants, so we auto-register department assignees.
+ */
+function ensureAgentParticipant(board, agentId) {
+  if (!agentId) return;
+  if (!Array.isArray(board.participants)) board.participants = [];
+  if (board.participants.find(p => p.id === agentId)) return;
+  board.participants.push({
+    id: agentId,
+    type: 'agent',
+    displayName: agentId,
+    agentId: agentId,
+  });
+}
+
+/**
  * Ensure board.village exists with default structure.
  * Called on every request that touches village data.
  */
@@ -136,6 +153,7 @@ module.exports = function villageRoutes(req, res, helpers, deps) {
           if (body.skills !== undefined) existing.skills = body.skills;
           if (body.promptFile !== undefined) existing.promptFile = body.promptFile;
           if (body.goalIds !== undefined) existing.goalIds = body.goalIds;
+          if (existing.assignee) ensureAgentParticipant(board, existing.assignee);
           helpers.writeBoard(board);
           helpers.appendLog({ ts: now, event: 'village_department_updated', deptId: existing.id });
           return json(res, 200, { ok: true, department: existing });
@@ -154,6 +172,7 @@ module.exports = function villageRoutes(req, res, helpers, deps) {
           goalIds: Array.isArray(body.goalIds) ? body.goalIds : [],
         };
         village.departments.push(dept);
+        ensureAgentParticipant(board, dept.assignee);
         helpers.writeBoard(board);
         helpers.appendLog({ ts: now, event: 'village_department_created', deptId: dept.id });
         return json(res, 201, { ok: true, department: dept });
@@ -299,6 +318,11 @@ module.exports = function villageRoutes(req, res, helpers, deps) {
             error: 'no_departments',
             message: 'Cannot trigger meeting without departments. Add departments first via POST /api/village/departments',
           });
+        }
+
+        // Ensure all department assignees are registered as participants
+        for (const dept of village.departments) {
+          ensureAgentParticipant(board, dept.assignee);
         }
 
         // Generate meeting tasks

--- a/server/test-village-smoke.js
+++ b/server/test-village-smoke.js
@@ -247,6 +247,62 @@ const testRunId = `smoke-${Date.now()}`;
   });
 
   // ══════════════════════════════════════════════════════
+  // DoD 5: parsePlanAndDispatch auto-registers assignees as participants
+  // ══════════════════════════════════════════════════════
+  console.log('\n── DoD 5: auto-register assignees as participants ──');
+
+  await test('parsePlanAndDispatch registers missing assignees as agent participants', () => {
+    const board = createVillageBoard();
+    board.village.currentCycle = { cycleId: 'cycle-reg', phase: 'synthesis' };
+    // Board has NO agent participants — only 'owner' (human)
+    assert.ok(!board.participants.find(p => p.id === 'engineer_lite'), 'precondition: no engineer_lite');
+    const helpers = createMockHelpers(board);
+
+    const planData = {
+      cycle: 'cycle-reg',
+      tasks: [
+        { title: 'Task A', assignee: 'engineer_lite', pipeline: ['implement'], priority: 'P1' },
+        { title: 'Task B', assignee: 'engineer_pro', pipeline: ['implement'], priority: 'P2' },
+      ],
+    };
+
+    const deps = { mgmt, tryAutoDispatch: () => {}, push: null, PUSH_TOKENS_PATH: null };
+
+    planDispatcher.parsePlanAndDispatch(currentBoard, planData, helpers, deps, null);
+
+    // Verify assignees were auto-registered
+    const lite = currentBoard.participants.find(p => p.id === 'engineer_lite');
+    const pro = currentBoard.participants.find(p => p.id === 'engineer_pro');
+    assert.ok(lite, 'engineer_lite should be registered');
+    assert.strictEqual(lite.type, 'agent', 'should be agent type');
+    assert.strictEqual(lite.agentId, 'engineer_lite', 'agentId should match');
+    assert.ok(pro, 'engineer_pro should be registered');
+    assert.strictEqual(pro.type, 'agent');
+
+    // Verify VT tasks were created with correct assignees
+    const vtTasks = currentBoard.taskPlan.tasks.filter(t => t.source?.type === 'village_plan');
+    assert.strictEqual(vtTasks.length, 2);
+    observe('auto-registered participants', currentBoard.participants.map(p => `${p.id}(${p.type})`));
+  });
+
+  await test('parsePlanAndDispatch does not duplicate existing participants', () => {
+    const board = createVillageBoard();
+    board.participants.push({ id: 'engineer_lite', type: 'agent', displayName: 'Engineer Lite', agentId: 'engineer_lite' });
+    board.village.currentCycle = { cycleId: 'cycle-dup', phase: 'synthesis' };
+    const helpers = createMockHelpers(board);
+
+    const planData = {
+      cycle: 'cycle-dup',
+      tasks: [{ title: 'Task X', assignee: 'engineer_lite', pipeline: ['implement'], priority: 'P1' }],
+    };
+    const deps = { mgmt, tryAutoDispatch: null, push: null, PUSH_TOKENS_PATH: null };
+    planDispatcher.parsePlanAndDispatch(currentBoard, planData, helpers, deps, null);
+
+    const matches = currentBoard.participants.filter(p => p.id === 'engineer_lite');
+    assert.strictEqual(matches.length, 1, `should not duplicate participant, found ${matches.length}`);
+  });
+
+  // ══════════════════════════════════════════════════════
   // BONUS: push notifications for village events
   // ══════════════════════════════════════════════════════
   console.log('\n── Bonus: push notifications ──');

--- a/server/village/plan-dispatcher.js
+++ b/server/village/plan-dispatcher.js
@@ -192,6 +192,11 @@ function parsePlanAndDispatch(board, planData, helpers, deps, synthesisTask) {
     }).catch(err => console.error('[plan-dispatcher] village.plan_executing push error:', err.message));
   }
 
+  // Ensure all VT assignees are registered as agent participants.
+  // Without this, tryAutoDispatch silently skips tasks whose assignee
+  // isn't in board.participants (the participantById guard).
+  ensureAssigneesRegistered(board, createdTaskIds);
+
   // Auto-dispatch tasks that are ready (status === 'dispatched')
   if (deps.tryAutoDispatch) {
     for (const taskId of createdTaskIds) {
@@ -273,6 +278,30 @@ function resolveDependencies(depends, titleToId) {
   return resolved;
 }
 
+/**
+ * Ensure all VT task assignees are registered as agent participants.
+ * tryAutoDispatch checks participantById(board, task.assignee) and silently
+ * skips tasks whose assignee isn't registered. This closes that gap.
+ */
+function ensureAssigneesRegistered(board, taskIds) {
+  if (!Array.isArray(board.participants)) board.participants = [];
+  const existing = new Set(board.participants.map(p => p.id));
+
+  for (const taskId of taskIds) {
+    const task = (board.taskPlan?.tasks || []).find(t => t.id === taskId);
+    if (!task?.assignee || existing.has(task.assignee)) continue;
+
+    board.participants.push({
+      id: task.assignee,
+      type: 'agent',
+      displayName: task.assignee,
+      agentId: task.assignee,
+    });
+    existing.add(task.assignee);
+    console.log(`[village:plan-dispatcher] auto-registered participant: ${task.assignee}`);
+  }
+}
+
 module.exports = {
   extractPlanFromArtifact,
   extractPlanFromText,
@@ -280,4 +309,5 @@ module.exports = {
   isSynthesisTask,
   normalizePipeline,
   resolveDependencies,
+  ensureAssigneesRegistered,
 };


### PR DESCRIPTION
## Summary

- **Root cause**: `tryAutoDispatch` (tasks.js:260) silently skips tasks whose assignee isn't in `board.participants`. Plan-dispatcher creates VT tasks with `assignee='engineer_lite'` but never registers the agent, causing execution tasks to stay stuck in `queued` forever.
- **Three-layer fix**:
  1. `plan-dispatcher.js`: `ensureAssigneesRegistered()` after creating VT tasks, before scheduling `setImmediate(tryAutoDispatch)`
  2. `routes/village.js`: auto-register assignee when department is created or updated
  3. `routes/village.js`: auto-register all department assignees when meeting is triggered
- **Tests**: 2 new smoke test cases (DoD 5) — registration works + no duplicates. All 17 pass.

## Test plan

- [ ] Trigger village meeting with a department whose assignee is NOT pre-registered via `/api/participants` — VT tasks should auto-dispatch instead of silently stalling
- [ ] Verify no duplicate participants when assignee already registered
- [ ] `node server/test-village-smoke.js` — 17/17 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)