### PR TITLE
fix(village): register synthesis assignee + isolate test board data

### DIFF
--- a/server/routes/village.js
+++ b/server/routes/village.js
@@ -329,6 +329,12 @@ module.exports = function villageRoutes(req, res, helpers, deps) {
         const { generateMeetingTasks } = require('../village/village-meeting');
         const meetingTasks = generateMeetingTasks(board, meetingType);
 
+        // Ensure ALL meeting task assignees are registered as participants
+        // (covers synthesis/chief assignee in addition to department assignees)
+        for (const task of meetingTasks) {
+          ensureAgentParticipant(board, task.assignee);
+        }
+
         // Add tasks to board
         if (!board.taskPlan) board.taskPlan = { goal: '', phase: 'idle', tasks: [] };
         if (!Array.isArray(board.taskPlan.tasks)) board.taskPlan.tasks = [];

--- a/server/test-evolution-loop.js
+++ b/server/test-evolution-loop.js
@@ -11,11 +11,14 @@
 
 const http = require('http');
 const fs = require('fs');
+const os = require('os');
 const { spawn, spawnSync } = require('child_process');
 const path = require('path');
 
 const PORT = Number(process.env.TEST_PORT) || 13461;
 const API_TOKEN = process.env.KARVI_API_TOKEN || null;
+// Use a temp directory for board data to avoid clobbering production board.json
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'karvi-test-'));
 let serverProc = null;
 
 function post(urlPath, body) {
@@ -48,7 +51,7 @@ function startServer() {
   return new Promise((resolve, reject) => {
     const proc = spawn(process.execPath, [path.join(__dirname, 'server.js')], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, PORT: String(PORT) },
+      env: { ...process.env, PORT: String(PORT), DATA_DIR: TEST_DATA_DIR },
     });
 
     let started = false;
@@ -96,10 +99,10 @@ function stopServer() {
 }
 
 function cleanState() {
-  // Delete board.json so server's ensureBoardExists() creates a fresh default.
-  // This avoids duplicating the default board definition and ensures full replace (not merge).
+  // Clean temp data dir — server's ensureBoardExists() creates a fresh default.
+  // Uses TEST_DATA_DIR (temp) instead of __dirname to avoid clobbering production board.json.
   for (const f of ['board.json', 'board.json.bak', 'task-log.jsonl']) {
-    try { fs.unlinkSync(path.join(__dirname, f)); } catch {}
+    try { fs.unlinkSync(path.join(TEST_DATA_DIR, f)); } catch {}
   }
 }
 


### PR DESCRIPTION
## Summary
- Register ALL meeting task assignees as participants (not just department assignees), fixing synthesis task (`engineer_pro`) being silently skipped by `tryAutoDispatch`
- Isolate `test-evolution-loop.js` board data using `DATA_DIR` env pointing to `os.tmpdir()`, preventing spawned agents from clobbering production `board.json`

## Root Cause
During real E2E village meeting run:
1. Proposal completed → synthesis unlocked → `tryAutoDispatch` skipped synthesis because `engineer_pro` wasn't in `board.participants`
2. Spawned Claude agent ran `test-evolution-loop.js` which deleted and recreated `board.json`, wiping all village state mid-cycle

## Test plan
- [x] All 17 smoke tests pass (`node server/test-village-smoke.js`)
- [x] Real E2E run: trigger → proposal → synthesis → plan-dispatch → 7 VT tasks created → first VT auto-dispatched
- [x] `engineer_pro` confirmed in `board.participants` after trigger
- [x] Board data stable throughout pipeline (no clobbering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)