### PR TITLE
fix(village): default VT runtime to claude + fix STEP_RESULT status

### DIFF
--- a/server/village/plan-dispatcher.js
+++ b/server/village/plan-dispatcher.js
@@ -231,21 +231,21 @@ function isSynthesisTask(task) {
  */
 function normalizePipeline(pipeline) {
   if (!Array.isArray(pipeline) || pipeline.length === 0) {
-    return [{ type: 'implement', instruction: null }];
+    return [{ type: 'implement', instruction: null, runtime_hint: 'claude' }];
   }
   return pipeline.map(entry => {
     if (typeof entry === 'string') {
-      return { type: entry };
+      return { type: entry, runtime_hint: 'claude' };
     }
     if (entry && typeof entry === 'object' && typeof entry.type === 'string') {
       return {
         type: entry.type,
         instruction: entry.instruction || null,
         skill: entry.skill || null,
-        runtime_hint: entry.runtime_hint || null,
+        runtime_hint: entry.runtime_hint || 'claude',
       };
     }
-    return { type: 'implement', instruction: null };
+    return { type: 'implement', instruction: null, runtime_hint: 'claude' };
   });
 }
 

--- a/server/village/village-meeting.js
+++ b/server/village/village-meeting.js
@@ -98,7 +98,7 @@ function buildProposalInstruction(rolePrompt, goals, recentSignals) {
   lines.push('## Instructions');
   lines.push('Based on the goals and signals above, produce your weekly proposal.');
   lines.push('Follow the Proposal Format defined in your role document.');
-  lines.push('Output your result as: STEP_RESULT:{"status":"completed","proposal":{...}}');
+  lines.push('Output your result as: STEP_RESULT:{"status":"succeeded","summary":"one line summary","proposal":{...}}');
   return lines.join('\n');
 }
 
@@ -146,7 +146,7 @@ function buildCheckinInstruction(chiefPrompt, goals, execTasks) {
   lines.push('3. **Recommended adjustments**: Priority changes, reassignments, or new actions needed.');
   lines.push('');
   lines.push('Output your result as:');
-  lines.push('STEP_RESULT:{"status":"completed","summary":{...}}');
+  lines.push('STEP_RESULT:{"status":"succeeded","summary":"one line summary","checkin":{...}}');
   lines.push('where summary contains: { progress, blockers, recommendations }');
   return lines.join('\n');
 }
@@ -176,7 +176,7 @@ function buildSynthesisInstruction(chiefPrompt, goals) {
   lines.push('## Instructions');
   lines.push('Synthesize all department proposals into a unified weekly execution plan.');
   lines.push('Follow the Output Format defined in your role document.');
-  lines.push('Output your result as: STEP_RESULT:{"status":"completed","plan":{...}}');
+  lines.push('Output your result as: STEP_RESULT:{"status":"succeeded","summary":"one line summary","plan":{...}}');
   return lines.join('\n');
 }
 


### PR DESCRIPTION
## Summary
- Default all VT execution task pipeline entries to `runtime_hint: 'claude'` so agents can access the codebase
- Fix 3 STEP_RESULT status mismatches in `village-meeting.js` prompts: `"completed"` → `"succeeded"`

## Root Cause
During E2E village meeting run, VT execution tasks:
1. Had `runtime_hint: null` → `getRuntime(null)` returned openclaw runtime → agents couldn't see code files
2. Meeting prompts told agents to output `status:"completed"` but `step-worker.js` only recognizes `"succeeded"` (the pipeline worked anyway because the `--append-system-prompt` override was correct, but the in-prompt instruction was misleading)

## Test plan
- [x] All 17 smoke tests pass
- [x] `grep '"completed"' village-meeting.js` returns 0 matches
- [x] All `normalizePipeline` paths produce `runtime_hint: 'claude'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)