### PR TITLE
fix(village): filter gatherRecentSignals by goalIds

### DIFF
--- a/server/test-village-smoke.js
+++ b/server/test-village-smoke.js
@@ -303,6 +303,80 @@ const testRunId = `smoke-${Date.now()}`;
   });
 
   // ══════════════════════════════════════════════════════
+  // DoD 6: gatherRecentSignals filters by goalIds (#159)
+  // ══════════════════════════════════════════════════════
+  console.log('\n── DoD 6: gatherRecentSignals filters by goalIds ──');
+
+  await test('gatherRecentSignals filters signals by goalIds', () => {
+    const board = createVillageBoard();
+    board.village.departments.push({
+      id: 'content', name: 'Content', assignee: 'engineer_lite',
+      promptFile: 'village/roles/engineering.md', goalIds: ['G2'],
+    });
+    board.village.goals.push({ id: 'G2', text: 'Content goal', active: true });
+    board.taskPlan.tasks = [
+      { id: 'T-eng-1', department: 'engineering', status: 'completed' },
+      { id: 'T-con-1', department: 'content', status: 'completed' },
+    ];
+    board.signals = [
+      { id: 's1', type: 'status_change', content: 'eng signal', refs: ['T-eng-1'], data: { taskId: 'T-eng-1' } },
+      { id: 's2', type: 'status_change', content: 'content signal', refs: ['T-con-1'], data: { taskId: 'T-con-1' } },
+      { id: 's3', type: 'lesson_validated', content: 'shared lesson', refs: [], data: {} },
+    ];
+    const result = villageMeeting.gatherRecentSignals(board, ['G1']);
+    assert.ok(result.includes('eng signal'), 'should include engineering signal');
+    assert.ok(!result.includes('content signal'), 'should NOT include content signal');
+    assert.ok(result.includes('shared lesson'), 'should include cross-cutting signal');
+  });
+
+  await test('gatherRecentSignals includes cross-cutting signals for any goalIds', () => {
+    const board = createVillageBoard();
+    board.taskPlan.tasks = [
+      { id: 'T-eng-1', department: 'engineering', status: 'completed' },
+    ];
+    board.signals = [
+      { id: 's1', type: 'lesson_validated', content: 'cross-cutting lesson', data: {} },
+      { id: 's2', type: 'review_result', content: 'generic review' },
+    ];
+    const result = villageMeeting.gatherRecentSignals(board, ['G1']);
+    assert.ok(result.includes('cross-cutting lesson'), 'lesson_validated always included');
+    assert.ok(result.includes('generic review'), 'signal without task ref always included');
+  });
+
+  await test('gatherRecentSignals returns all when goalIds empty', () => {
+    const board = createVillageBoard();
+    board.signals = [
+      { id: 's1', type: 'status_change', content: 'sig A', refs: ['T-1'], data: { taskId: 'T-1' } },
+      { id: 's2', type: 'status_change', content: 'sig B', refs: ['T-2'], data: { taskId: 'T-2' } },
+    ];
+    const result = villageMeeting.gatherRecentSignals(board, []);
+    assert.ok(result.includes('sig A'), 'empty goalIds -> all signals');
+    assert.ok(result.includes('sig B'), 'empty goalIds -> all signals');
+  });
+
+  await test('gatherRecentSignals returns all when goalIds undefined', () => {
+    const board = createVillageBoard();
+    board.signals = [
+      { id: 's1', type: 'status_change', content: 'sig X', refs: ['T-1'], data: { taskId: 'T-1' } },
+    ];
+    const result = villageMeeting.gatherRecentSignals(board);
+    assert.ok(result.includes('sig X'), 'undefined goalIds -> all signals');
+  });
+
+  await test('gatherRecentSignals returns only cross-cutting when no tasks match dept', () => {
+    const board = createVillageBoard();
+    // No tasks in board at all
+    board.taskPlan.tasks = [];
+    board.signals = [
+      { id: 's1', type: 'status_change', content: 'task signal', refs: ['T-unknown'], data: { taskId: 'T-unknown' } },
+      { id: 's2', type: 'lesson_validated', content: 'lesson signal', data: {} },
+    ];
+    const result = villageMeeting.gatherRecentSignals(board, ['G1']);
+    assert.ok(!result.includes('task signal'), 'task signal for unknown task excluded');
+    assert.ok(result.includes('lesson signal'), 'cross-cutting signal included');
+  });
+
+  // ══════════════════════════════════════════════════════
   // BONUS: push notifications for village events
   // ══════════════════════════════════════════════════════
   console.log('\n── Bonus: push notifications ──');

--- a/server/village/village-meeting.js
+++ b/server/village/village-meeting.js
@@ -60,13 +60,47 @@ function gatherRecentSignals(board, goalIds, limit) {
   const signals = (board.signals || []).slice(-max * 3);
   if (signals.length === 0) return '(no recent signals)';
 
-  // Prefer signals related to the department's goals or recent reviews
-  const relevant = signals
-    .filter(s => s.type === 'review_result' || s.type === 'status_change' || s.type === 'lesson_validated')
-    .slice(-max);
+  const typeFilter = s =>
+    s.type === 'review_result' ||
+    s.type === 'status_change' ||
+    s.type === 'lesson_validated';
+
+  // No goalIds provided -> return all relevant signals (backward compat)
+  if (!goalIds || goalIds.length === 0) {
+    const relevant = signals.filter(typeFilter).slice(-max);
+    if (relevant.length === 0) return '(no relevant signals)';
+    return relevant.map(s => `- [${s.type}] ${s.content || s.id}`).join('\n');
+  }
+
+  // Build set of department IDs that own these goals
+  const departments = board.village?.departments || [];
+  const deptIds = new Set();
+  for (const dept of departments) {
+    if ((dept.goalIds || []).some(gid => goalIds.includes(gid))) {
+      deptIds.add(dept.id);
+    }
+  }
+
+  // Build set of task IDs belonging to those departments
+  const tasks = board.taskPlan?.tasks || [];
+  const deptTaskIds = new Set();
+  for (const task of tasks) {
+    if (task.department && deptIds.has(task.department)) {
+      deptTaskIds.add(task.id);
+    }
+  }
+
+  // Filter: include cross-cutting signals and dept-matching task signals
+  const relevant = signals.filter(s => {
+    if (!typeFilter(s)) return false;
+    // Cross-cutting signals (no task reference) -> always include
+    const taskId = s.data?.taskId || (s.refs && s.refs[0]);
+    if (!taskId) return true;
+    // Task-linked signals -> include if task belongs to a matching department
+    return deptTaskIds.has(taskId);
+  }).slice(-max);
 
   if (relevant.length === 0) return '(no relevant signals)';
-
   return relevant.map(s => `- [${s.type}] ${s.content || s.id}`).join('\n');
 }
 


### PR DESCRIPTION
## Summary

Fixes #159 — `gatherRecentSignals` accepted a `goalIds` parameter but never used it to filter signals. All departments received identical signal context regardless of their assigned goals.

- **Fix**: Filter task-linked signals by mapping `goalIds → departments → task IDs → signal.refs`
- **Cross-cutting signals** (`lesson_validated`, signals without task refs) are always included
- **Backward compatible**: empty/undefined `goalIds` returns all signals (no behavior change for single-department setups)

## Changes

| File | Change |
|------|--------|
| `server/village/village-meeting.js` | Rewrote `gatherRecentSignals` with goal-aware filtering |
| `server/test-village-smoke.js` | Added DoD 6: 5 test cases for signal filtering |

## Test plan

- [x] `gatherRecentSignals` filters task-linked signals by department
- [x] Cross-cutting signals (no task ref) always included
- [x] Empty goalIds returns all signals (backward compat)
- [x] Undefined goalIds returns all signals
- [x] No tasks match dept → only cross-cutting signals returned
- [x] All 22 existing + new tests pass (`node server/test-village-smoke.js`)