### PR TITLE
feat(route-engine): generic revision loop for arbitrary pipelines

### DIFF
--- a/server/kernel.js
+++ b/server/kernel.js
@@ -130,35 +130,38 @@ function createKernel(deps) {
       }
 
       case 'revision': {
-        // Review found fixable issues → reset implement+review steps and re-dispatch.
-        // The review feedback is injected into the implement step's context.
-        const implStep = latestTask?.steps?.find(s => s.type === 'implement');
-        const revStep = latestTask?.steps?.find(s => s.type === 'review');
-        if (implStep && revStep) {
-          // Reset implement step for re-dispatch (fresh attempt)
-          implStep.state = 'queued';
-          implStep.attempt = 0;
-          implStep.error = null;
-          implStep.output_ref = null;
-          implStep.locked_by = null;
-          implStep.lock_expires_at = null;
-          // Reset review step
-          revStep.state = 'queued';
-          revStep.attempt = 0;
-          revStep.error = null;
-          revStep.output_ref = null;
-          revStep.locked_by = null;
-          revStep.lock_expires_at = null;
-          // Store review feedback on task for context-compiler to inject
+        // Generic revision: find target and source steps from decision metadata,
+        // reset all steps in between, and re-dispatch the target step.
+        const targetStepId = decision.next_step?.step_id;
+        const sourceStepId = decision.from_step_id;
+        const targetStep = latestTask?.steps?.find(s => s.step_id === targetStepId);
+        const sourceStep = latestTask?.steps?.find(s => s.step_id === sourceStepId);
+
+        if (targetStep && sourceStep) {
+          const targetIdx = latestTask.steps.indexOf(targetStep);
+          const sourceIdx = latestTask.steps.indexOf(sourceStep);
+          for (let i = targetIdx; i <= sourceIdx; i++) {
+            const s = latestTask.steps[i];
+            s.state = 'queued';
+            s.attempt = 0;
+            s.error = null;
+            s.output_ref = null;
+            s.locked_by = null;
+            s.lock_expires_at = null;
+          }
+
+          if (!latestTask._revisionCounts) latestTask._revisionCounts = {};
+          latestTask._revisionCounts[targetStepId] = (latestTask._revisionCounts[targetStepId] || 0) + 1;
+
           latestTask.reviewFeedback = decision.review_feedback || null;
-          console.log(`[kernel] revision cycle for ${taskId}: resetting implement+review, feedback: ${(decision.review_feedback || '').slice(0, 100)}`);
+          console.log(`[kernel] revision: ${sourceStep.step_id} → ${targetStep.step_id} (cycle ${latestTask._revisionCounts[targetStepId]})`);
         }
-        // Build envelope using fresh runState from latestTask (steps were just reset above)
+
         const freshRunState = { task: latestTask, steps: latestTask.steps, run_id: runState.run_id, budget: latestTask.budget };
         const revEnvelope = contextCompiler.buildEnvelope(decision, freshRunState, deps);
-        if (revEnvelope && implStep) {
+        if (revEnvelope && targetStep) {
           artifactStore.writeArtifact(revEnvelope.run_id, revEnvelope.step_id, 'input', revEnvelope);
-          stepSchema.transitionStep(implStep, 'running', {
+          stepSchema.transitionStep(targetStep, 'running', {
             locked_by: 'kernel-revision',
             input_ref: artifactStore.artifactPath(revEnvelope.run_id, revEnvelope.step_id, 'input'),
           });

--- a/server/management.js
+++ b/server/management.js
@@ -781,7 +781,11 @@ function buildDispatchPlan(board, task, options = {}) {
 
 // --- Step-level helpers ---
 
-const DEFAULT_STEP_PIPELINE = ['plan', 'implement', 'review'];
+const DEFAULT_STEP_PIPELINE = [
+  'plan',
+  'implement',
+  { type: 'review', revision_target: 'implement' },
+];
 
 function normalizePipelineEntry(entry) {
   if (typeof entry === 'string') {
@@ -797,6 +801,8 @@ function normalizePipelineEntry(entry) {
       skill: typeof entry.skill === 'string' ? entry.skill : null,
       runtime_hint: typeof entry.runtime_hint === 'string' ? entry.runtime_hint : null,
       retry_policy: entry.retry_policy && typeof entry.retry_policy === 'object' ? entry.retry_policy : null,
+      revision_target: typeof entry.revision_target === 'string' ? entry.revision_target : null,
+      max_revision_cycles: typeof entry.max_revision_cycles === 'number' ? entry.max_revision_cycles : null,
     };
   }
   return null;
@@ -818,6 +824,8 @@ function generateStepsForTask(task, runId, pipeline) {
     if (stepDef.skill) opts.skill = stepDef.skill;
     if (stepDef.runtime_hint) opts.runtime_hint = stepDef.runtime_hint;
     if (stepDef.retry_policy) opts.retry_policy = stepDef.retry_policy;
+    if (stepDef.revision_target) opts.revision_target = stepDef.revision_target;
+    if (stepDef.max_revision_cycles != null) opts.max_revision_cycles = stepDef.max_revision_cycles;
     return stepSchema.createStep(task.id, runId, stepDef.type, opts);
   });
 }

--- a/server/route-engine.js
+++ b/server/route-engine.js
@@ -159,21 +159,22 @@ function decideNext(agentOutput, runState) {
     const currentIdx = stepTypes.indexOf(fromStep?.type);
     const nextIdx = currentIdx + 1;
 
-    // Review→Fix cycle: if review step found actionable findings, loop back
-    // to implement for a fix pass instead of completing the pipeline.
+    // Revision cycle: if a step with revision_target found actionable findings,
+    // loop back to the target step for a fix pass.
     // Guard: limit revision cycles to avoid infinite loops.
-    if (fromStep?.type === 'review' && needsRevision(agentOutput)) {
-      const revisionCount = steps.filter(s => s.type === 'implement' && s.state === 'succeeded').length;
-      if (revisionCount < MAX_REVISION_CYCLES) {
-        const implStep = steps.find(s => s.type === 'implement');
-        if (implStep) {
+    if (fromStep?.revision_target && needsRevision(agentOutput)) {
+      const targetStep = steps.find(s => s.type === fromStep.revision_target);
+      if (targetStep) {
+        const maxCycles = fromStep.max_revision_cycles || MAX_REVISION_CYCLES;
+        const revisionCount = task._revisionCounts?.[targetStep.step_id] || 0;
+        if (revisionCount < maxCycles) {
           return { ...base, action: 'revision', rule: 'review_needs_fix', confidence: 0.9,
             retry: null, human_review: null,
-            next_step: { step_id: implStep.step_id, step_type: 'implement', priority: 0 },
+            next_step: { step_id: targetStep.step_id, step_type: targetStep.type, priority: 0 },
             review_feedback: agentOutput.summary || null };
         }
+        // Max cycles reached — accept as-is
       }
-      // Max cycles reached — accept as-is
     }
 
     // More steps in pipeline?
@@ -199,6 +200,7 @@ module.exports = {
   FAILURE_MODES,
   BUDGET_DEFAULTS,
   REMEDIATION_LIMITS,
+  MAX_REVISION_CYCLES,
   classifyFailure,
   isBudgetExceeded,
   decideNext,

--- a/server/step-schema.js
+++ b/server/step-schema.js
@@ -50,6 +50,8 @@ function createStep(taskId, runId, type, opts = {}) {
     instruction: opts.instruction || null,
     skill: opts.skill || null,
     runtime_hint: opts.runtime_hint || null,
+    revision_target: opts.revision_target || null,
+    max_revision_cycles: opts.max_revision_cycles || null,
     retry_policy: retry,
     error: null,
     started_at: null,

--- a/server/test-route-engine.js
+++ b/server/test-route-engine.js
@@ -143,6 +143,58 @@ test('isBudgetExceeded returns true when any limit hit', () => {
   }), false);
 });
 
+// --- Revision (generic revision_target) ---
+
+test('decideNext returns revision when step has revision_target and needsRevision', () => {
+  const steps = [
+    { step_id: 'T-1:plan', type: 'plan', state: 'succeeded', attempt: 0, max_attempts: 3, run_id: 'run-1', retry_policy: { backoff_base_ms: 5000 } },
+    { step_id: 'T-1:draft', type: 'draft', state: 'succeeded', attempt: 0, max_attempts: 3, run_id: 'run-1', retry_policy: { backoff_base_ms: 5000 } },
+    { step_id: 'T-1:edit', type: 'edit', state: 'succeeded', attempt: 0, max_attempts: 3, run_id: 'run-1', retry_policy: { backoff_base_ms: 5000 }, revision_target: 'draft', max_revision_cycles: 3 },
+  ];
+  const runState = makeRunState({ steps, task: { _revisionCounts: {} } });
+  const output = { step_id: 'T-1:edit', status: 'succeeded', summary: 'Request changes: tone too casual' };
+  const d = routeEngine.decideNext(output, runState);
+  assert.strictEqual(d.action, 'revision');
+  assert.strictEqual(d.rule, 'review_needs_fix');
+  assert.strictEqual(d.next_step.step_id, 'T-1:draft');
+  assert.strictEqual(d.next_step.step_type, 'draft');
+  assert.ok(d.review_feedback);
+});
+
+test('decideNext accepts as-is when max_revision_cycles reached', () => {
+  const steps = [
+    { step_id: 'T-1:draft', type: 'draft', state: 'succeeded', attempt: 0, max_attempts: 3, run_id: 'run-1', retry_policy: { backoff_base_ms: 5000 } },
+    { step_id: 'T-1:edit', type: 'edit', state: 'succeeded', attempt: 0, max_attempts: 3, run_id: 'run-1', retry_policy: { backoff_base_ms: 5000 }, revision_target: 'draft', max_revision_cycles: 1 },
+  ];
+  const runState = makeRunState({ steps, task: { _revisionCounts: { 'T-1:draft': 1 } } });
+  const output = { step_id: 'T-1:edit', status: 'succeeded', summary: 'Request changes: still needs work' };
+  const d = routeEngine.decideNext(output, runState);
+  assert.strictEqual(d.action, 'done');
+});
+
+test('decideNext skips revision when no revision_target on step', () => {
+  const steps = [
+    { step_id: 'T-1:scan', type: 'scan', state: 'succeeded', attempt: 0, max_attempts: 3, run_id: 'run-1', retry_policy: { backoff_base_ms: 5000 } },
+    { step_id: 'T-1:report', type: 'report', state: 'succeeded', attempt: 0, max_attempts: 3, run_id: 'run-1', retry_policy: { backoff_base_ms: 5000 } },
+  ];
+  const runState = makeRunState({ steps });
+  const output = { step_id: 'T-1:report', status: 'succeeded', summary: 'Request changes in report' };
+  const d = routeEngine.decideNext(output, runState);
+  assert.strictEqual(d.action, 'done');
+});
+
+test('decideNext uses default MAX_REVISION_CYCLES when max_revision_cycles not set', () => {
+  const steps = [
+    { step_id: 'T-1:impl', type: 'impl', state: 'succeeded', attempt: 0, max_attempts: 3, run_id: 'run-1', retry_policy: { backoff_base_ms: 5000 } },
+    { step_id: 'T-1:review', type: 'review', state: 'succeeded', attempt: 0, max_attempts: 3, run_id: 'run-1', retry_policy: { backoff_base_ms: 5000 }, revision_target: 'impl' },
+  ];
+  const runState = makeRunState({ steps, task: { _revisionCounts: { 'T-1:impl': routeEngine.MAX_REVISION_CYCLES } } });
+  const output = { step_id: 'T-1:review', status: 'succeeded', summary: 'Request changes: bugs found' };
+  const d = routeEngine.decideNext(output, runState);
+  // max cycles reached → falls through to done
+  assert.strictEqual(d.action, 'done');
+});
+
 // --- Summary ---
 console.log(`\n${'─'.repeat(40)}`);
 console.log(`Results: ${passed} passed, ${failed} failed`);

--- a/server/test-step-schema.js
+++ b/server/test-step-schema.js
@@ -239,6 +239,32 @@ test('generateStepsForTask accepts semantic pipeline objects', () => {
   assert.strictEqual(steps[1].runtime_hint, 'claude');
 });
 
+test('default pipeline review step has revision_target=implement', () => {
+  const task = { id: 'T-REV0' };
+  const steps = mgmt.generateStepsForTask(task, 'run-rev0');
+  assert.strictEqual(steps.length, 3);
+  // review step should carry revision_target from DEFAULT_STEP_PIPELINE
+  assert.strictEqual(steps[2].type, 'review');
+  assert.strictEqual(steps[2].revision_target, 'implement');
+  // plan and implement should NOT have revision_target
+  assert.strictEqual(steps[0].revision_target, null);
+  assert.strictEqual(steps[1].revision_target, null);
+});
+
+test('generateStepsForTask passes revision_target and max_revision_cycles from pipeline', () => {
+  const task = { id: 'T-REV1' };
+  const steps = mgmt.generateStepsForTask(task, 'run-rev1', [
+    'plan',
+    'implement',
+    { type: 'review', revision_target: 'implement', max_revision_cycles: 5 },
+  ]);
+  assert.strictEqual(steps.length, 3);
+  assert.strictEqual(steps[2].revision_target, 'implement');
+  assert.strictEqual(steps[2].max_revision_cycles, 5);
+  assert.strictEqual(steps[0].revision_target, null);
+  assert.strictEqual(steps[1].revision_target, null);
+});
+
 test('buildDispatchPlan includes steps field', () => {
   // Minimal board and task for buildDispatchPlan
   const board = {


### PR DESCRIPTION
## Summary

- Replace hardcoded `review → implement` revision loop with generic `revision_target` field
- Any pipeline step can now declare which earlier step to loop back to when `needsRevision()` triggers
- `DEFAULT_STEP_PIPELINE` updated to mixed format: `['plan', 'implement', { type: 'review', revision_target: 'implement' }]`
- Kernel uses decision metadata for revision routing with generic range reset (all steps from target to source)

## Changes

| File | Change |
|------|--------|
| `server/step-schema.js` | Add `revision_target`, `max_revision_cycles` to `createStep()` |
| `server/management.js` | Pass-through in `normalizePipelineEntry` + `generateStepsForTask` |
| `server/route-engine.js` | Replace `type==='review'` with `fromStep.revision_target` |
| `server/kernel.js` | Use decision metadata, generic range reset |
| `server/test-route-engine.js` | 4 new revision tests |
| `server/test-step-schema.js` | 2 new pipeline pass-through tests |

## Test plan

- [x] All 14 route-engine tests pass (4 new)
- [x] All 21 step-schema tests pass (2 new)
- [x] Backward compatible: default pipeline still produces `plan → implement → review` with `review.revision_target = 'implement'`

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)