### PR TITLE
feat(step-worker): contract-based post-check validation

### DIFF
--- a/server/context-compiler.js
+++ b/server/context-compiler.js
@@ -85,6 +85,7 @@ function buildEnvelope(decision, runState, deps) {
     idempotency_key: idempotencyKey,
     timeout_ms: targetStep.retry_policy?.timeout_ms || 300_000,
     model_hint: null,
+    contract: task.contract || null,
   };
 
   return envelope;

--- a/server/route-engine.js
+++ b/server/route-engine.js
@@ -14,8 +14,9 @@ const FAILURE_MODES = {
   CONFLICT:           'CONFLICT',
   TEST_FAILURE:       'TEST_FAILURE',
   TOOL_ERROR:         'TOOL_ERROR',
-  STRATEGY_MISMATCH:  'STRATEGY_MISMATCH',
-  FINALIZE_ERROR:     'FINALIZE_ERROR',
+  STRATEGY_MISMATCH:    'STRATEGY_MISMATCH',
+  FINALIZE_ERROR:       'FINALIZE_ERROR',
+  CONTRACT_VIOLATION:   'CONTRACT_VIOLATION',
 };
 
 const BUDGET_DEFAULTS = {
@@ -31,8 +32,9 @@ const REMEDIATION_LIMITS = {
   ENVIRONMENT:       2,
   CONFLICT:          1,
   TEST_FAILURE:      2,
-  STRATEGY_MISMATCH: 2,
-  FINALIZE_ERROR:    1,
+  STRATEGY_MISMATCH:   2,
+  FINALIZE_ERROR:      1,
+  CONTRACT_VIOLATION:  2,
 };
 
 // --- Failure classification ---
@@ -45,7 +47,8 @@ const FAILURE_PATTERNS = [
   { mode: FAILURE_MODES.TEST_FAILURE,     pattern: /test.*fail|assert.*fail|expect.*received|spec.*fail/i },
   { mode: FAILURE_MODES.STRATEGY_MISMATCH, pattern: /wrong.direction|rethink|strategy.*(?:fail|wrong|bad)|approach.*(?:fail|wrong|bad)|(?:fail|wrong|bad).*(?:strategy|approach)/i },
   { mode: FAILURE_MODES.TOOL_ERROR,       pattern: /timeout|ETIMEDOUT|rate.limit|ECONNREFUSED|socket.hang/i },
-  { mode: FAILURE_MODES.FINALIZE_ERROR,   pattern: /uncommitted.changes|auto.finalize|finalize.error/i },
+  { mode: FAILURE_MODES.FINALIZE_ERROR,     pattern: /uncommitted.changes|auto.finalize|finalize.error/i },
+  { mode: FAILURE_MODES.CONTRACT_VIOLATION, pattern: /contract.violation|deliverable.*missing|deliverable.*not.found/i },
 ];
 
 function classifyFailure(agentOutput) {

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -185,6 +185,25 @@ function createStepWorker(deps) {
           }
         }
       }
+
+      // 5c. Contract validation — verify declared deliverables exist
+      if (status === 'succeeded' && envelope.contract?.deliverable) {
+        const contractResult = validateContract(
+          envelope.contract,
+          { status, summary, payload: stepResult, failure },
+          postCheckResult,
+          plan.workingDir || plan.cwd,
+        );
+        if (!contractResult.ok) {
+          status = 'failed';
+          failure = {
+            failure_signature: contractResult.reason,
+            failure_mode: 'CONTRACT_VIOLATION',
+            retryable: true,
+          };
+          summary = `Contract violation: ${contractResult.reason}`;
+        }
+      }
     }
 
     // Preserve full STEP_RESULT payload (proposal, plan, etc.) for downstream modules.
@@ -313,6 +332,104 @@ function autoFinalize(workDir, envelope) {
   } catch (err) {
     return { ok: false, error: err.message?.slice(0, 200) || 'unknown' };
   }
+}
+
+/**
+ * Validate a deliverable contract after agent reports success.
+ * Returns { ok: true } or { ok: false, reason: "..." }.
+ *
+ * @param {object} contract      - { deliverable, acceptance, file_path? }
+ * @param {object} agentOutput   - { status, summary, payload, failure }
+ * @param {object} postCheckResult - From runPostCheck()
+ * @param {string} workDir       - Working directory
+ */
+function validateContract(contract, agentOutput, postCheckResult, workDir) {
+  if (!contract || !contract.deliverable) return { ok: true };
+
+  switch (contract.deliverable) {
+    case 'pr':             return validatePrDeliverable(agentOutput, workDir);
+    case 'file':           return validateFileDeliverable(contract, workDir);
+    case 'artifact':       return validateArtifactDeliverable(agentOutput);
+    case 'command_result': return validateCommandResultDeliverable(agentOutput);
+    case 'issue':          return validateIssueDeliverable(agentOutput);
+    default:               return { ok: true }; // unknown type → pass (forward-compat)
+  }
+}
+
+function validatePrDeliverable(agentOutput, workDir) {
+  if (!workDir) return { ok: false, reason: 'deliverable pr: no working directory' };
+  const opts = { cwd: workDir, encoding: 'utf8', timeout: 15000 };
+
+  // Check for new commits
+  try {
+    const log = execSync('git log --oneline -1', opts).trim();
+    if (!log) return { ok: false, reason: 'deliverable pr: no commits found' };
+  } catch {
+    return { ok: false, reason: 'deliverable pr: git log failed (not a git repo?)' };
+  }
+
+  // Check for PR URL in agent summary or try gh pr list
+  const text = agentOutput.summary || '';
+  const hasPrUrl = /github\.com\/[^/]+\/[^/]+\/pull\/\d+/i.test(text);
+  if (hasPrUrl) return { ok: true };
+
+  try {
+    const branch = execSync('git branch --show-current', opts).trim();
+    if (branch) {
+      const prList = execSync(`gh pr list --head "${branch}" --json url --limit 1`, opts).trim();
+      const prs = JSON.parse(prList || '[]');
+      if (prs.length > 0) return { ok: true };
+    }
+  } catch {
+    // gh CLI not available — fall through
+  }
+
+  return { ok: false, reason: 'deliverable pr: no PR found for current branch' };
+}
+
+function validateFileDeliverable(contract, workDir) {
+  if (!workDir) return { ok: false, reason: 'deliverable file: no working directory' };
+  const filePath = contract.file_path;
+  if (!filePath) return { ok: false, reason: 'deliverable file: contract.file_path not specified' };
+
+  const fs = require('fs');
+  const path = require('path');
+  const resolved = path.resolve(workDir, filePath);
+
+  if (!fs.existsSync(resolved)) {
+    return { ok: false, reason: `deliverable file: ${filePath} does not exist` };
+  }
+  const stat = fs.statSync(resolved);
+  if (stat.size === 0) {
+    return { ok: false, reason: `deliverable file: ${filePath} is empty` };
+  }
+  return { ok: true };
+}
+
+function validateArtifactDeliverable(agentOutput) {
+  if (!agentOutput.payload) {
+    return { ok: false, reason: 'deliverable artifact: payload is null/empty' };
+  }
+  const summary = agentOutput.summary || '';
+  if (summary.length < 50) {
+    return { ok: false, reason: `deliverable artifact: summary too short (${summary.length} chars, need 50+)` };
+  }
+  return { ok: true };
+}
+
+function validateCommandResultDeliverable(agentOutput) {
+  const summary = agentOutput.summary || '';
+  if (!summary) {
+    return { ok: false, reason: 'deliverable command_result: summary is empty' };
+  }
+  return { ok: true };
+}
+
+function validateIssueDeliverable(agentOutput) {
+  const text = [agentOutput.summary || '', JSON.stringify(agentOutput.payload || '')].join(' ');
+  const hasIssueUrl = /github\.com\/[^/]+\/[^/]+\/issues\/\d+/i.test(text);
+  if (hasIssueUrl) return { ok: true };
+  return { ok: false, reason: 'deliverable issue: no GitHub issue URL found in output' };
 }
 
 /**
@@ -537,4 +654,4 @@ function recoverExpiredLocks(board) {
   return recovered;
 }
 
-module.exports = { createStepWorker, parseStepResult, buildStepMessage, recoverExpiredLocks, runPreflight, extractPreflightTargets };
+module.exports = { createStepWorker, parseStepResult, buildStepMessage, recoverExpiredLocks, runPreflight, extractPreflightTargets, validateContract };

--- a/server/test-bridge.js
+++ b/server/test-bridge.js
@@ -309,6 +309,176 @@ function createFullDeps(runtimeOverrides = {}) {
   });
 
   // ------------------------------------------------------------------
+  // Test 7: Contract validation — artifact deliverable with null payload → CONTRACT_VIOLATION
+  // ------------------------------------------------------------------
+  await test('contract: artifact deliverable with null payload → CONTRACT_VIOLATION', async () => {
+    const { validateContract } = require('./step-worker');
+
+    const contract = { deliverable: 'artifact', acceptance: 'payload non-empty' };
+    const agentOutput = { status: 'succeeded', summary: 'short', payload: null, failure: null };
+    const result = validateContract(contract, agentOutput, null, null);
+
+    assert.strictEqual(result.ok, false, 'should fail when payload is null');
+    assert.ok(result.reason.includes('payload'), `reason should mention payload: ${result.reason}`);
+  });
+
+  // ------------------------------------------------------------------
+  // Test 8: Contract validation — artifact deliverable with short summary → CONTRACT_VIOLATION
+  // ------------------------------------------------------------------
+  await test('contract: artifact deliverable with short summary → CONTRACT_VIOLATION', async () => {
+    const { validateContract } = require('./step-worker');
+
+    const contract = { deliverable: 'artifact', acceptance: 'summary > 50 chars' };
+    const agentOutput = { status: 'succeeded', summary: 'too short', payload: { data: 'exists' }, failure: null };
+    const result = validateContract(contract, agentOutput, null, null);
+
+    assert.strictEqual(result.ok, false, 'should fail when summary < 50 chars');
+    assert.ok(result.reason.includes('summary too short'), `reason should mention summary: ${result.reason}`);
+  });
+
+  // ------------------------------------------------------------------
+  // Test 9: Contract validation — artifact deliverable passes when valid
+  // ------------------------------------------------------------------
+  await test('contract: artifact deliverable passes with payload + long summary', async () => {
+    const { validateContract } = require('./step-worker');
+
+    const contract = { deliverable: 'artifact', acceptance: 'payload non-empty' };
+    const longSummary = 'This is a sufficiently long summary that exceeds the fifty character minimum threshold for artifacts';
+    const agentOutput = { status: 'succeeded', summary: longSummary, payload: { data: 'exists' }, failure: null };
+    const result = validateContract(contract, agentOutput, null, null);
+
+    assert.strictEqual(result.ok, true, 'should pass with valid payload and long summary');
+  });
+
+  // ------------------------------------------------------------------
+  // Test 10: Contract validation — command_result deliverable with empty summary → fail
+  // ------------------------------------------------------------------
+  await test('contract: command_result with empty summary → CONTRACT_VIOLATION', async () => {
+    const { validateContract } = require('./step-worker');
+
+    const contract = { deliverable: 'command_result', acceptance: 'exit 0 + output' };
+    const agentOutput = { status: 'succeeded', summary: '', payload: null, failure: null };
+    const result = validateContract(contract, agentOutput, null, null);
+
+    assert.strictEqual(result.ok, false, 'should fail when summary is empty');
+    assert.ok(result.reason.includes('summary is empty'), `reason should mention empty summary: ${result.reason}`);
+  });
+
+  // ------------------------------------------------------------------
+  // Test 11: Contract validation — command_result passes with non-empty summary
+  // ------------------------------------------------------------------
+  await test('contract: command_result passes with non-empty summary', async () => {
+    const { validateContract } = require('./step-worker');
+
+    const contract = { deliverable: 'command_result', acceptance: 'exit 0' };
+    const agentOutput = { status: 'succeeded', summary: 'Command executed successfully with output', payload: null, failure: null };
+    const result = validateContract(contract, agentOutput, null, null);
+
+    assert.strictEqual(result.ok, true, 'should pass when summary is non-empty');
+  });
+
+  // ------------------------------------------------------------------
+  // Test 12: Contract validation — issue deliverable with URL in summary → passes
+  // ------------------------------------------------------------------
+  await test('contract: issue deliverable with GitHub URL → passes', async () => {
+    const { validateContract } = require('./step-worker');
+
+    const contract = { deliverable: 'issue', acceptance: 'issue URL exists' };
+    const agentOutput = { status: 'succeeded', summary: 'Created https://github.com/org/repo/issues/42', payload: null, failure: null };
+    const result = validateContract(contract, agentOutput, null, null);
+
+    assert.strictEqual(result.ok, true, 'should pass when issue URL found in summary');
+  });
+
+  // ------------------------------------------------------------------
+  // Test 13: Contract validation — issue deliverable without URL → fail
+  // ------------------------------------------------------------------
+  await test('contract: issue deliverable without GitHub URL → CONTRACT_VIOLATION', async () => {
+    const { validateContract } = require('./step-worker');
+
+    const contract = { deliverable: 'issue', acceptance: 'issue URL exists' };
+    const agentOutput = { status: 'succeeded', summary: 'I created an issue', payload: null, failure: null };
+    const result = validateContract(contract, agentOutput, null, null);
+
+    assert.strictEqual(result.ok, false, 'should fail when no issue URL found');
+    assert.ok(result.reason.includes('issue URL'), `reason should mention issue URL: ${result.reason}`);
+  });
+
+  // ------------------------------------------------------------------
+  // Test 14: No contract on envelope → legacy behavior (passes)
+  // ------------------------------------------------------------------
+  await test('no contract → legacy behavior (passes)', async () => {
+    const { validateContract } = require('./step-worker');
+
+    // null contract
+    const result1 = validateContract(null, { status: 'succeeded', summary: 'done', payload: null }, null, null);
+    assert.strictEqual(result1.ok, true, 'null contract should pass');
+
+    // contract without deliverable
+    const result2 = validateContract({}, { status: 'succeeded', summary: 'done', payload: null }, null, null);
+    assert.strictEqual(result2.ok, true, 'empty contract should pass');
+  });
+
+  // ------------------------------------------------------------------
+  // Test 15: Unknown deliverable type → passes (forward-compat)
+  // ------------------------------------------------------------------
+  await test('unknown deliverable type → passes (forward-compat)', async () => {
+    const { validateContract } = require('./step-worker');
+
+    const contract = { deliverable: 'future_type', acceptance: 'something' };
+    const agentOutput = { status: 'succeeded', summary: 'done', payload: null, failure: null };
+    const result = validateContract(contract, agentOutput, null, null);
+
+    assert.strictEqual(result.ok, true, 'unknown deliverable type should pass');
+  });
+
+  // ------------------------------------------------------------------
+  // Test 16: Contract passed through envelope via context-compiler
+  // ------------------------------------------------------------------
+  await test('context-compiler passes contract through envelope', async () => {
+    const taskId = `T-BRIDGE-${++testCounter}`;
+    const contract = { deliverable: 'pr', acceptance: 'PR exists' };
+    const task = { id: taskId, title: 'Contract test', description: 'desc', assignee: 'engineer_lite', status: 'dispatched', contract };
+    const { deps } = createFullDeps();
+    const board = createBoard([task]);
+    const helpers = createMockHelpers(board);
+
+    const runId = helpers.uid('run');
+    const t = currentBoard.taskPlan.tasks[0];
+    t.steps = mgmt.generateStepsForTask(t, runId);
+    const routeEngine = require('./route-engine');
+    t.budget = { limits: { ...routeEngine.BUDGET_DEFAULTS }, used: { llm_calls: 0, tokens: 0, wall_clock_ms: 0, steps: 0 } };
+
+    const firstStep = t.steps[0];
+    const runState = { task: t, steps: t.steps, run_id: runId, budget: t.budget };
+    const decision = { action: 'next_step', next_step: { step_id: firstStep.step_id, step_type: firstStep.type } };
+    const envelope = deps.contextCompiler.buildEnvelope(decision, runState, deps);
+
+    assert.ok(envelope, 'envelope should exist');
+    assert.deepStrictEqual(envelope.contract, contract, 'contract should be passed through');
+  });
+
+  // ------------------------------------------------------------------
+  // Test 17: CONTRACT_VIOLATION classified correctly by route-engine
+  // ------------------------------------------------------------------
+  await test('route-engine classifies CONTRACT_VIOLATION failure mode', async () => {
+    const { classifyFailure, FAILURE_MODES } = require('./route-engine');
+
+    // Explicit failure_mode
+    const result1 = classifyFailure({
+      failure: { failure_signature: 'some error', failure_mode: 'CONTRACT_VIOLATION', retryable: true },
+    });
+    assert.strictEqual(result1, 'CONTRACT_VIOLATION', 'explicit failure_mode should be classified');
+
+    // Pattern-match
+    const result2 = classifyFailure({
+      failure: { failure_signature: 'Contract violation: deliverable missing' },
+      summary: '',
+    });
+    assert.strictEqual(result2, 'CONTRACT_VIOLATION', 'pattern should match contract violation text');
+  });
+
+  // ------------------------------------------------------------------
   // Summary
   // ------------------------------------------------------------------
   console.log(`\n${'─'.repeat(40)}`);


### PR DESCRIPTION
Closes #161

## Summary

- Add `validateContract()` to `step-worker.js` — validates 5 deliverable types (pr, file, artifact, command_result, issue) after agent reports success
- Add `CONTRACT_VIOLATION` failure mode to `route-engine.js` with 2-attempt remediation limit
- Pass `task.contract` through envelope via `context-compiler.js`
- 11 new contract validation tests in `test-bridge.js` (all passing)

## Test plan

- [x] `node server/test-bridge.js` — 15/17 pass (2 pre-existing failures unrelated to this PR)
- [x] `node server/test-runtime-contract.js` — 23/23 pass
- [x] All 11 new contract tests pass
- [x] Backwards compatible: no contract → legacy behavior