### PR TITLE
feat(projects): Project Orchestrator — dependency-driven batch execution

### DIFF
--- a/server/management.js
+++ b/server/management.js
@@ -875,14 +875,19 @@ function autoUnlockDependents(board) {
   const unlocked = [];
   allTasks.forEach(t => {
     if (t.status === 'pending' && t.depends?.length > 0) {
-      const allDepsApproved = t.depends.every(depId => {
+      const allDepsMet = t.depends.every(depId => {
         const dep = allTasks.find(d => d.id === depId);
-        return dep && dep.status === 'approved';
+        if (!dep) return false;
+        // completionTrigger === 'pr_merged' requires PR actually merged
+        if (dep.completionTrigger === 'pr_merged') {
+          return dep.status === 'approved' && dep.pr?.outcome === 'merged';
+        }
+        return dep.status === 'approved';
       });
-      if (allDepsApproved) {
+      if (allDepsMet) {
         t.status = 'dispatched';
         t.history = t.history || [];
-        t.history.push({ ts: nowIso(), status: 'dispatched', reason: 'dependencies_approved' });
+        t.history.push({ ts: nowIso(), status: 'dispatched', reason: 'dependencies_met' });
         unlocked.push(t.id);
       }
     }

--- a/server/routes/github.js
+++ b/server/routes/github.js
@@ -118,6 +118,38 @@ module.exports = function githubRoutes(req, res, helpers, deps) {
                 push.notifyTaskEvent(PUSH_TOKENS_PATH, task, `task.${signalType}`)
                   .catch(err => console.error('[push] pr outcome notify failed:', err.message));
               }
+
+              // Project Orchestrator: pr_merged → unlock dependents + check completion
+              if (result.outcome === 'merged' && task.projectId) {
+                const project = (board.projects || []).find(p => p.id === task.projectId);
+                if (project && project.status === 'executing') {
+                  const unlocked = mgmt.autoUnlockDependents(board);
+                  if (unlocked.length > 0) {
+                    helpers.writeBoard(board);
+                    if (deps.tryAutoDispatch) {
+                      for (const unlockedId of unlocked) {
+                        setImmediate(() => deps.tryAutoDispatch(unlockedId));
+                      }
+                    }
+                  }
+                  // Check project completion
+                  const projectTasks = (board.taskPlan?.tasks || [])
+                    .filter(t => t.projectId === project.id);
+                  const allDone = projectTasks.every(t => t.pr?.outcome === 'merged');
+                  if (allDone) {
+                    project.status = 'done';
+                    project.completedAt = helpers.nowIso();
+                    board.signals.push({
+                      id: helpers.uid('sig'), ts: helpers.nowIso(),
+                      by: 'project-orchestrator', type: 'project_done',
+                      content: `Project "${project.title}" completed (${projectTasks.length} tasks)`,
+                      refs: project.taskIds,
+                      data: { projectId: project.id },
+                    });
+                    helpers.writeBoard(board);
+                  }
+                }
+              }
             }
             json(res, 200, { ok: true, action: 'pr_outcome', taskId: result.taskId, outcome: result.outcome });
             return;

--- a/server/routes/projects.js
+++ b/server/routes/projects.js
@@ -1,0 +1,274 @@
+/**
+ * routes/projects.js — Project Orchestrator API
+ *
+ * POST   /api/projects          — create project (batch of GH tasks with deps)
+ * GET    /api/projects          — list all projects with progress
+ * GET    /api/projects/:id      — single project with progress
+ * POST   /api/projects/:id/pause  — pause project
+ * POST   /api/projects/:id/resume — resume project
+ */
+const bb = require('../blackboard-server');
+const { json } = bb;
+
+/**
+ * Detect circular dependencies in a task graph.
+ * @param {Array<{issue: number, depends: number[]}>} tasks
+ * @returns {boolean} true if a cycle exists
+ */
+function hasCycle(tasks) {
+  const adj = new Map();
+  for (const t of tasks) {
+    adj.set(t.issue, t.depends || []);
+  }
+  const visited = new Set();
+  const inStack = new Set();
+
+  function dfs(node) {
+    if (inStack.has(node)) return true;
+    if (visited.has(node)) return false;
+    visited.add(node);
+    inStack.add(node);
+    for (const dep of (adj.get(node) || [])) {
+      if (dfs(dep)) return true;
+    }
+    inStack.delete(node);
+    return false;
+  }
+
+  for (const t of tasks) {
+    if (dfs(t.issue)) return true;
+  }
+  return false;
+}
+
+/**
+ * Compute real-time progress for a project.
+ */
+function computeProgress(board, project) {
+  const allTasks = board.taskPlan?.tasks || [];
+  const projectTasks = allTasks.filter(t => t.projectId === project.id);
+  const total = projectTasks.length;
+  if (total === 0) return { total: 0, done: 0, in_progress: 0, pending: 0, blocked: 0, pct: 0 };
+
+  let done = 0, in_progress = 0, pending = 0, blocked = 0;
+  for (const t of projectTasks) {
+    if (project.completionTrigger === 'pr_merged') {
+      if (t.pr?.outcome === 'merged') { done++; continue; }
+    } else {
+      if (t.status === 'approved') { done++; continue; }
+    }
+    if (t.status === 'blocked') { blocked++; }
+    else if (t.status === 'pending') { pending++; }
+    else { in_progress++; }
+  }
+  return { total, done, in_progress, pending, blocked, pct: Math.round((done / total) * 100) };
+}
+
+module.exports = function projectsRoutes(req, res, helpers, deps) {
+  const { mgmt } = deps;
+
+  // POST /api/projects — create project
+  if (req.method === 'POST' && req.url === '/api/projects') {
+    let body = '';
+    req.on('data', c => (body += c));
+    req.on('end', () => {
+      try {
+        const input = JSON.parse(body || '{}');
+        const { title, repo, concurrency, completionTrigger, tasks } = input;
+
+        // Validation
+        if (!title || typeof title !== 'string') return json(res, 400, { error: 'title is required' });
+        if (!repo || typeof repo !== 'string') return json(res, 400, { error: 'repo is required' });
+        if (!Array.isArray(tasks) || tasks.length === 0) return json(res, 400, { error: 'tasks array is required and must not be empty' });
+
+        // Validate completion trigger
+        const trigger = completionTrigger || 'pr_merged';
+        if (trigger !== 'pr_merged' && trigger !== 'approved') {
+          return json(res, 400, { error: 'completionTrigger must be pr_merged or approved' });
+        }
+
+        // Validate task entries
+        for (const entry of tasks) {
+          if (!entry.issue || typeof entry.issue !== 'number') {
+            return json(res, 400, { error: 'each task must have a numeric issue field' });
+          }
+        }
+
+        // Cycle detection
+        if (hasCycle(tasks)) {
+          return json(res, 400, { error: 'circular dependency detected in tasks' });
+        }
+
+        const board = helpers.readBoard();
+        board.projects = board.projects || [];
+        board.taskPlan = board.taskPlan || { tasks: [] };
+
+        const projectId = helpers.uid('PROJ');
+        const taskIds = [];
+
+        for (const entry of tasks) {
+          const taskId = `GH-${entry.issue}`;
+          const depIds = (entry.depends || []).map(d => `GH-${d}`);
+          const existing = board.taskPlan.tasks.find(t => t.id === taskId);
+
+          if (existing) {
+            // Update existing task
+            existing.depends = depIds;
+            existing.projectId = projectId;
+            existing.completionTrigger = trigger;
+            if (depIds.length === 0 && existing.status === 'pending') {
+              existing.status = 'dispatched';
+              existing.history = existing.history || [];
+              existing.history.push({ ts: helpers.nowIso(), status: 'dispatched', reason: 'project_no_deps' });
+            }
+          } else {
+            // Create new GH task
+            const newTask = {
+              id: taskId,
+              title: entry.title || `Issue #${entry.issue}`,
+              status: depIds.length > 0 ? 'pending' : 'dispatched',
+              assignee: entry.assignee || null,
+              depends: depIds,
+              type: 'gh',
+              source: repo,
+              githubIssue: entry.issue,
+              projectId,
+              completionTrigger: trigger,
+              history: [{ ts: helpers.nowIso(), status: depIds.length > 0 ? 'pending' : 'dispatched', reason: 'project_created' }],
+            };
+            board.taskPlan.tasks.push(newTask);
+          }
+          taskIds.push(taskId);
+        }
+
+        const project = {
+          id: projectId,
+          title,
+          repo,
+          status: 'executing',
+          concurrency: concurrency || 3,
+          completionTrigger: trigger,
+          taskIds,
+          createdAt: helpers.nowIso(),
+        };
+        board.projects.push(project);
+
+        // Signal
+        mgmt.ensureEvolutionFields(board);
+        board.signals.push({
+          id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'project-orchestrator',
+          type: 'project_created',
+          content: `Project "${title}" created with ${taskIds.length} tasks`,
+          refs: taskIds,
+          data: { projectId, taskIds },
+        });
+        if (board.signals.length > 500) board.signals = board.signals.slice(-500);
+
+        helpers.writeBoard(board);
+        helpers.appendLog({ ts: helpers.nowIso(), event: 'project_created', projectId, taskIds });
+        helpers.broadcastSSE('board', board);
+
+        // Auto-dispatch no-dep tasks
+        if (deps.tryAutoDispatch) {
+          const dispatchable = taskIds.filter(tid => {
+            const t = board.taskPlan.tasks.find(tt => tt.id === tid);
+            return t && t.status === 'dispatched';
+          });
+          for (const tid of dispatchable) {
+            setImmediate(() => deps.tryAutoDispatch(tid));
+          }
+        }
+
+        json(res, 201, { ok: true, project, progress: computeProgress(board, project) });
+      } catch (error) {
+        json(res, 400, { error: error.message });
+      }
+    });
+    return;
+  }
+
+  // GET /api/projects — list all
+  if (req.method === 'GET' && req.url === '/api/projects') {
+    try {
+      const board = helpers.readBoard();
+      const projects = (board.projects || []).map(p => ({
+        ...p,
+        progress: computeProgress(board, p),
+      }));
+      return json(res, 200, projects);
+    } catch (error) {
+      return json(res, 500, { error: error.message });
+    }
+  }
+
+  // GET /api/projects/:id
+  const getMatch = req.method === 'GET' && req.url.match(/^\/api\/projects\/([^/]+)$/);
+  if (getMatch) {
+    try {
+      const board = helpers.readBoard();
+      const project = (board.projects || []).find(p => p.id === getMatch[1]);
+      if (!project) return json(res, 404, { error: 'project not found' });
+      const allTasks = board.taskPlan?.tasks || [];
+      const projectTasks = allTasks.filter(t => t.projectId === project.id);
+      return json(res, 200, {
+        ...project,
+        progress: computeProgress(board, project),
+        tasks: projectTasks.map(t => ({ id: t.id, title: t.title, status: t.status, depends: t.depends, pr: t.pr })),
+      });
+    } catch (error) {
+      return json(res, 500, { error: error.message });
+    }
+  }
+
+  // POST /api/projects/:id/pause
+  if (req.method === 'POST' && req.url.match(/^\/api\/projects\/([^/]+)\/pause$/)) {
+    const id = req.url.match(/^\/api\/projects\/([^/]+)\/pause$/)[1];
+    try {
+      const board = helpers.readBoard();
+      const project = (board.projects || []).find(p => p.id === id);
+      if (!project) return json(res, 404, { error: 'project not found' });
+      if (project.status === 'done') return json(res, 400, { error: 'cannot pause a completed project' });
+      project.status = 'paused';
+      helpers.writeBoard(board);
+      helpers.broadcastSSE('board', board);
+      return json(res, 200, { ok: true, project });
+    } catch (error) {
+      return json(res, 500, { error: error.message });
+    }
+  }
+
+  // POST /api/projects/:id/resume
+  if (req.method === 'POST' && req.url.match(/^\/api\/projects\/([^/]+)\/resume$/)) {
+    const id = req.url.match(/^\/api\/projects\/([^/]+)\/resume$/)[1];
+    try {
+      const board = helpers.readBoard();
+      const project = (board.projects || []).find(p => p.id === id);
+      if (!project) return json(res, 404, { error: 'project not found' });
+      if (project.status === 'done') return json(res, 400, { error: 'cannot resume a completed project' });
+      project.status = 'executing';
+      helpers.writeBoard(board);
+      helpers.broadcastSSE('board', board);
+
+      // Re-trigger dispatch for dispatched tasks
+      if (deps.tryAutoDispatch) {
+        const allTasks = board.taskPlan?.tasks || [];
+        for (const tid of project.taskIds) {
+          const t = allTasks.find(tt => tt.id === tid);
+          if (t && t.status === 'dispatched') {
+            setImmediate(() => deps.tryAutoDispatch(tid));
+          }
+        }
+      }
+
+      return json(res, 200, { ok: true, project });
+    } catch (error) {
+      return json(res, 500, { error: error.message });
+    }
+  }
+
+  return false;
+};
+
+// Export for testing
+module.exports.hasCycle = hasCycle;
+module.exports.computeProgress = computeProgress;

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -281,6 +281,23 @@ function tryAutoDispatch(taskId, deps, helpers) {
     return;
   }
 
+  // Project concurrency gate
+  if (task.projectId) {
+    const project = (board.projects || []).find(p => p.id === task.projectId);
+    if (project) {
+      if (project.status === 'paused') {
+        console.log(`[auto-dispatch:${taskId}] skip: project ${project.id} is paused`);
+        return;
+      }
+      const projectInProgress = (board.taskPlan?.tasks || [])
+        .filter(t => t.projectId === project.id && t.status === 'in_progress').length;
+      if (projectInProgress >= (project.concurrency || 3)) {
+        console.log(`[auto-dispatch:${taskId}] skip: project concurrency ${projectInProgress}/${project.concurrency}`);
+        return;
+      }
+    }
+  }
+
   // Worktree creation: isolate each task in its own git worktree
   if (ctrl.use_worktrees) {
     const worktree = require('../worktree');

--- a/server/server.js
+++ b/server/server.js
@@ -138,6 +138,7 @@ const briefsRoutes = require('./routes/briefs');
 const chatRoutes = require('./routes/chat');
 const jiraRoutes = require('./routes/jira');
 const villageRoutes = require('./routes/village');
+const projectsRoutes = require('./routes/projects');
 const tasksRoutes = require('./routes/tasks');
 
 // --- Route chain ---
@@ -152,6 +153,7 @@ const routes = [
   chatRoutes,
   jiraRoutes,
   villageRoutes,
+  projectsRoutes,
   tasksRoutes,
 ];
 
@@ -191,6 +193,7 @@ tasksRoutes.init(deps, routeHelpers);
 bb.ensureBoardExists(ctx, {
   taskPlan: { goal: '', phase: 'idle', tasks: [] },
   pipelineTemplates: {},
+  projects: [],
   conversations: [],
   participants: [],
   signals: [],
@@ -218,6 +221,7 @@ let dirty = false;
 if (!Array.isArray(initBoard.signals)) { initBoard.signals = []; dirty = true; }
 if (!Array.isArray(initBoard.insights)) { initBoard.insights = []; dirty = true; }
 if (!Array.isArray(initBoard.lessons)) { initBoard.lessons = []; dirty = true; }
+if (!Array.isArray(initBoard.projects)) { initBoard.projects = []; dirty = true; }
 // Village Chief: ensure village block exists on startup
 if (!initBoard.village) { villageRoutes.ensureVillage(initBoard); dirty = true; }
 if (dirty) writeBoard(initBoard);

--- a/server/test-projects.js
+++ b/server/test-projects.js
@@ -1,0 +1,401 @@
+#!/usr/bin/env node
+/**
+ * test-projects.js — Unit tests for Project Orchestrator (#194)
+ *
+ * Tests: CRUD, autoUnlockDependents with completionTrigger,
+ * tryAutoDispatch project concurrency gate, pr_merged → project advance.
+ *
+ * Usage: node server/test-projects.js
+ */
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const mgmt = require('./management');
+const { hasCycle, computeProgress } = require('./routes/projects');
+
+let passed = 0;
+let failed = 0;
+
+function ok(label) { passed++; console.log(`  ✅ ${label}`); }
+function fail(label, reason) { failed++; console.log(`  ❌ ${label}: ${reason}`); process.exitCode = 1; }
+
+async function test(label, fn) {
+  try { await fn(); ok(label); } catch (err) { fail(label, err.message); }
+}
+
+function nowIso() { return new Date().toISOString(); }
+function uid(prefix) { return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`; }
+
+function createBoard(tasks, projects) {
+  return {
+    taskPlan: { goal: 'project test', phase: 'executing', tasks },
+    projects: projects || [],
+    signals: [],
+    insights: [],
+    lessons: [],
+    participants: [
+      { id: 'owner', type: 'human' },
+      { id: 'engineer_lite', type: 'agent' },
+    ],
+    controls: { auto_dispatch: true, auto_review: false },
+  };
+}
+
+function createMockHelpers(board) {
+  const state = { board: JSON.parse(JSON.stringify(board)), log: [] };
+  return {
+    readBoard: () => state.board,
+    writeBoard: (b) => { state.board = b; },
+    appendLog: (e) => { state.log.push(e); },
+    broadcastSSE: () => {},
+    nowIso,
+    uid,
+    _state: state,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: hasCycle — no cycle
+// ---------------------------------------------------------------------------
+test('1. hasCycle — no cycle returns false', async () => {
+  const tasks = [
+    { issue: 1, depends: [] },
+    { issue: 2, depends: [1] },
+    { issue: 3, depends: [1, 2] },
+  ];
+  assert.strictEqual(hasCycle(tasks), false);
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: hasCycle — cycle detected
+// ---------------------------------------------------------------------------
+test('2. hasCycle — cycle returns true', async () => {
+  const tasks = [
+    { issue: 1, depends: [3] },
+    { issue: 2, depends: [1] },
+    { issue: 3, depends: [2] },
+  ];
+  assert.strictEqual(hasCycle(tasks), true);
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: computeProgress — basic calculation
+// ---------------------------------------------------------------------------
+test('3. computeProgress — counts tasks correctly', async () => {
+  const project = { id: 'PROJ-1', completionTrigger: 'approved', taskIds: ['GH-1', 'GH-2', 'GH-3'] };
+  const board = createBoard([
+    { id: 'GH-1', status: 'approved', projectId: 'PROJ-1' },
+    { id: 'GH-2', status: 'in_progress', projectId: 'PROJ-1' },
+    { id: 'GH-3', status: 'pending', projectId: 'PROJ-1' },
+  ], [project]);
+
+  const p = computeProgress(board, project);
+  assert.strictEqual(p.total, 3);
+  assert.strictEqual(p.done, 1);
+  assert.strictEqual(p.in_progress, 1);
+  assert.strictEqual(p.pending, 1);
+  assert.strictEqual(p.pct, 33);
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: computeProgress — pr_merged trigger counts merged PRs
+// ---------------------------------------------------------------------------
+test('4. computeProgress — pr_merged trigger counts merged PRs as done', async () => {
+  const project = { id: 'PROJ-1', completionTrigger: 'pr_merged', taskIds: ['GH-1', 'GH-2'] };
+  const board = createBoard([
+    { id: 'GH-1', status: 'approved', projectId: 'PROJ-1', pr: { outcome: 'merged' } },
+    { id: 'GH-2', status: 'approved', projectId: 'PROJ-1', pr: { outcome: null } },
+  ], [project]);
+
+  const p = computeProgress(board, project);
+  assert.strictEqual(p.done, 1);
+  assert.strictEqual(p.in_progress, 1); // approved but not merged = in_progress
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: autoUnlockDependents — default trigger (approved) — existing behavior
+// ---------------------------------------------------------------------------
+test('5. autoUnlockDependents — default trigger (approved) unlocks normally', async () => {
+  const board = createBoard([
+    { id: 'GH-1', status: 'approved' },
+    { id: 'GH-2', status: 'pending', depends: ['GH-1'] },
+  ]);
+
+  const unlocked = mgmt.autoUnlockDependents(board);
+  assert.deepStrictEqual(unlocked, ['GH-2']);
+  assert.strictEqual(board.taskPlan.tasks[1].status, 'dispatched');
+});
+
+// ---------------------------------------------------------------------------
+// Test 6: autoUnlockDependents — pr_merged trigger, dep approved but NOT merged
+// ---------------------------------------------------------------------------
+test('6. autoUnlockDependents — pr_merged trigger, dep approved but not merged → no unlock', async () => {
+  const board = createBoard([
+    { id: 'GH-1', status: 'approved', completionTrigger: 'pr_merged', pr: { outcome: null } },
+    { id: 'GH-2', status: 'pending', depends: ['GH-1'] },
+  ]);
+
+  const unlocked = mgmt.autoUnlockDependents(board);
+  assert.deepStrictEqual(unlocked, []);
+  assert.strictEqual(board.taskPlan.tasks[1].status, 'pending');
+});
+
+// ---------------------------------------------------------------------------
+// Test 7: autoUnlockDependents — pr_merged trigger, dep approved AND merged
+// ---------------------------------------------------------------------------
+test('7. autoUnlockDependents — pr_merged trigger, dep approved + merged → unlocks', async () => {
+  const board = createBoard([
+    { id: 'GH-1', status: 'approved', completionTrigger: 'pr_merged', pr: { outcome: 'merged' } },
+    { id: 'GH-2', status: 'pending', depends: ['GH-1'] },
+  ]);
+
+  const unlocked = mgmt.autoUnlockDependents(board);
+  assert.deepStrictEqual(unlocked, ['GH-2']);
+  assert.strictEqual(board.taskPlan.tasks[1].status, 'dispatched');
+});
+
+// ---------------------------------------------------------------------------
+// Test 8: autoUnlockDependents — mixed triggers in deps
+// ---------------------------------------------------------------------------
+test('8. autoUnlockDependents — mixed triggers: one pr_merged (merged) + one approved', async () => {
+  const board = createBoard([
+    { id: 'GH-1', status: 'approved', completionTrigger: 'pr_merged', pr: { outcome: 'merged' } },
+    { id: 'GH-2', status: 'approved' }, // default trigger = approved
+    { id: 'GH-3', status: 'pending', depends: ['GH-1', 'GH-2'] },
+  ]);
+
+  const unlocked = mgmt.autoUnlockDependents(board);
+  assert.deepStrictEqual(unlocked, ['GH-3']);
+});
+
+// ---------------------------------------------------------------------------
+// Test 9: autoUnlockDependents — mixed triggers, one not met
+// ---------------------------------------------------------------------------
+test('9. autoUnlockDependents — mixed triggers: pr_merged dep not merged → no unlock', async () => {
+  const board = createBoard([
+    { id: 'GH-1', status: 'approved', completionTrigger: 'pr_merged', pr: { outcome: null } },
+    { id: 'GH-2', status: 'approved' },
+    { id: 'GH-3', status: 'pending', depends: ['GH-1', 'GH-2'] },
+  ]);
+
+  const unlocked = mgmt.autoUnlockDependents(board);
+  assert.deepStrictEqual(unlocked, []);
+});
+
+// ---------------------------------------------------------------------------
+// Test 10: Project CRUD — POST creates project + tasks
+// ---------------------------------------------------------------------------
+test('10. POST /api/projects — creates project and tasks on board', async () => {
+  const projectsRoutes = require('./routes/projects');
+  const board = createBoard([]);
+  const helpers = createMockHelpers(board);
+  const deps = { mgmt, tryAutoDispatch: null };
+
+  const input = {
+    title: 'Test Project',
+    repo: 'owner/repo',
+    concurrency: 2,
+    completionTrigger: 'pr_merged',
+    tasks: [
+      { issue: 10, depends: [], title: 'Task 10' },
+      { issue: 11, depends: [10], title: 'Task 11' },
+    ],
+  };
+
+  // Simulate request
+  const req = createMockReq('POST', '/api/projects', JSON.stringify(input));
+  const res = createMockRes();
+
+  projectsRoutes(req, res, helpers, deps);
+  req.emit('data', JSON.stringify(input));
+  req.emit('end');
+
+  await tick();
+
+  assert.strictEqual(res._statusCode, 201);
+  const result = JSON.parse(res._body);
+  assert.strictEqual(result.ok, true);
+  assert.strictEqual(result.project.title, 'Test Project');
+  assert.strictEqual(result.project.taskIds.length, 2);
+
+  // Verify board state
+  const b = helpers._state.board;
+  assert.strictEqual(b.projects.length, 1);
+  assert.strictEqual(b.taskPlan.tasks.length, 2);
+
+  const t10 = b.taskPlan.tasks.find(t => t.id === 'GH-10');
+  assert.strictEqual(t10.status, 'dispatched'); // no deps
+  assert.strictEqual(t10.projectId, result.project.id);
+
+  const t11 = b.taskPlan.tasks.find(t => t.id === 'GH-11');
+  assert.strictEqual(t11.status, 'pending'); // has deps
+  assert.deepStrictEqual(t11.depends, ['GH-10']);
+});
+
+// ---------------------------------------------------------------------------
+// Test 11: POST /api/projects — empty tasks → 400
+// ---------------------------------------------------------------------------
+test('11. POST /api/projects — empty tasks → 400', async () => {
+  const projectsRoutes = require('./routes/projects');
+  const board = createBoard([]);
+  const helpers = createMockHelpers(board);
+  const deps = { mgmt, tryAutoDispatch: null };
+
+  const input = { title: 'Bad', repo: 'owner/repo', tasks: [] };
+  const req = createMockReq('POST', '/api/projects', JSON.stringify(input));
+  const res = createMockRes();
+
+  projectsRoutes(req, res, helpers, deps);
+  req.emit('data', JSON.stringify(input));
+  req.emit('end');
+
+  await tick();
+  assert.strictEqual(res._statusCode, 400);
+});
+
+// ---------------------------------------------------------------------------
+// Test 12: POST /api/projects — circular deps → 400
+// ---------------------------------------------------------------------------
+test('12. POST /api/projects — circular deps → 400', async () => {
+  const projectsRoutes = require('./routes/projects');
+  const board = createBoard([]);
+  const helpers = createMockHelpers(board);
+  const deps = { mgmt, tryAutoDispatch: null };
+
+  const input = {
+    title: 'Cyclic',
+    repo: 'owner/repo',
+    tasks: [
+      { issue: 1, depends: [2] },
+      { issue: 2, depends: [1] },
+    ],
+  };
+  const req = createMockReq('POST', '/api/projects', JSON.stringify(input));
+  const res = createMockRes();
+
+  projectsRoutes(req, res, helpers, deps);
+  req.emit('data', JSON.stringify(input));
+  req.emit('end');
+
+  await tick();
+  assert.strictEqual(res._statusCode, 400);
+  assert.ok(JSON.parse(res._body).error.includes('circular'));
+});
+
+// ---------------------------------------------------------------------------
+// Test 13: POST /api/projects/:id/pause
+// ---------------------------------------------------------------------------
+test('13. POST /api/projects/:id/pause → status = paused', async () => {
+  const projectsRoutes = require('./routes/projects');
+  const project = { id: 'PROJ-1', title: 'P1', status: 'executing', taskIds: [] };
+  const board = createBoard([], [project]);
+  const helpers = createMockHelpers(board);
+  const deps = { mgmt, tryAutoDispatch: null };
+
+  const req = createMockReq('POST', '/api/projects/PROJ-1/pause');
+  const res = createMockRes();
+
+  projectsRoutes(req, res, helpers, deps);
+
+  assert.strictEqual(res._statusCode, 200);
+  assert.strictEqual(helpers._state.board.projects[0].status, 'paused');
+});
+
+// ---------------------------------------------------------------------------
+// Test 14: POST /api/projects/:id/resume
+// ---------------------------------------------------------------------------
+test('14. POST /api/projects/:id/resume → status = executing', async () => {
+  const projectsRoutes = require('./routes/projects');
+  const project = { id: 'PROJ-1', title: 'P1', status: 'paused', taskIds: ['GH-1'] };
+  const board = createBoard([
+    { id: 'GH-1', status: 'dispatched', projectId: 'PROJ-1' },
+  ], [project]);
+  const helpers = createMockHelpers(board);
+  let dispatched = [];
+  const deps = { mgmt, tryAutoDispatch: (id) => dispatched.push(id) };
+
+  const req = createMockReq('POST', '/api/projects/PROJ-1/resume');
+  const res = createMockRes();
+
+  projectsRoutes(req, res, helpers, deps);
+
+  assert.strictEqual(res._statusCode, 200);
+  assert.strictEqual(helpers._state.board.projects[0].status, 'executing');
+  // tryAutoDispatch called via setImmediate — verify after tick
+  await tick();
+  assert.deepStrictEqual(dispatched, ['GH-1']);
+});
+
+// ---------------------------------------------------------------------------
+// Test 15: POST /api/projects — existing GH task → updates depends
+// ---------------------------------------------------------------------------
+test('15. POST /api/projects — existing GH task gets updated with deps + projectId', async () => {
+  const projectsRoutes = require('./routes/projects');
+  const existingTask = { id: 'GH-5', title: 'Existing', status: 'pending', depends: [] };
+  const board = createBoard([existingTask]);
+  const helpers = createMockHelpers(board);
+  const deps = { mgmt, tryAutoDispatch: null };
+
+  const input = {
+    title: 'Update Project',
+    repo: 'owner/repo',
+    tasks: [
+      { issue: 5, depends: [6] },
+      { issue: 6, depends: [], title: 'New' },
+    ],
+  };
+  const req = createMockReq('POST', '/api/projects', JSON.stringify(input));
+  const res = createMockRes();
+
+  projectsRoutes(req, res, helpers, deps);
+  req.emit('data', JSON.stringify(input));
+  req.emit('end');
+
+  await tick();
+  assert.strictEqual(res._statusCode, 201);
+
+  const b = helpers._state.board;
+  const t5 = b.taskPlan.tasks.find(t => t.id === 'GH-5');
+  assert.deepStrictEqual(t5.depends, ['GH-6']);
+  assert.ok(t5.projectId);
+  assert.strictEqual(t5.completionTrigger, 'pr_merged');
+});
+
+// ---------------------------------------------------------------------------
+// Helpers for simulating HTTP requests
+// ---------------------------------------------------------------------------
+
+function createMockReq(method, url, body) {
+  const req = new EventEmitter();
+  req.method = method;
+  req.url = url;
+  req.headers = {};
+  return req;
+}
+
+function createMockRes() {
+  const res = {
+    _statusCode: null,
+    _body: null,
+    _headers: {},
+    writeHead(code, headers) { res._statusCode = code; Object.assign(res._headers, headers || {}); },
+    end(body) { res._body = body || ''; },
+    setHeader(k, v) { res._headers[k] = v; },
+  };
+  // Patch json helper — projectsRoutes uses bb.json which calls writeHead+end
+  return res;
+}
+
+function tick(ms = 10) {
+  return new Promise(resolve => setImmediate(() => setTimeout(resolve, ms)));
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+(async () => {
+  console.log('\n🧪 test-projects.js — Project Orchestrator (#194)\n');
+  // Give async tests time to settle
+  await tick(50);
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exitCode = 1;
+})();

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -172,6 +172,27 @@ export interface Task {
   jiraUrl?: string;
   source?: string;
   priority?: string;
+  projectId?: string;
+  completionTrigger?: 'pr_merged' | 'approved';
+}
+
+// ---------------------------------------------------------------------------
+// Project Orchestrator
+// ---------------------------------------------------------------------------
+
+export type ProjectStatus = 'created' | 'executing' | 'paused' | 'done';
+
+/** Project — dependency-driven batch execution of GitHub issues */
+export interface Project {
+  id: string;
+  title: string;
+  repo: string;
+  status: ProjectStatus;
+  concurrency: number;
+  completionTrigger: 'pr_merged' | 'approved';
+  taskIds: string[];
+  createdAt: string;
+  completedAt?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -350,6 +371,7 @@ export interface Integrations {
 /** Board — accessed via GET/POST /api/board */
 export interface Board {
   taskPlan: TaskPlan;
+  projects?: Project[];
   conversations: Conversation[];
   participants: Participant[];
   signals: Signal[];


### PR DESCRIPTION
## Summary
- Add **Project entity** (`board.projects[]`) for grouping GH tasks with dependency graph, concurrency control, and completion tracking
- Expand `autoUnlockDependents` to support `completionTrigger` — `pr_merged` requires both `approved` status AND `pr.outcome === 'merged'` before unlocking dependents
- Wire `pr_merged` webhook to unlock dependents + auto-detect project completion
- Add project-level concurrency gate in `tryAutoDispatch`
- New CRUD API: `POST/GET /api/projects`, `GET /api/projects/:id`, `POST /api/projects/:id/pause`, `POST /api/projects/:id/resume`

Closes #194

## Files Changed

| File | Change |
|------|--------|
| `shared/types.ts` | Add `Project` interface, `projectId`/`completionTrigger` on Task |
| `server/routes/projects.js` | **New** — Project CRUD + cycle detection + progress computation |
| `server/management.js` | `autoUnlockDependents` supports `completionTrigger` |
| `server/routes/github.js` | `pr_merged` → project unlock + completion check |
| `server/routes/tasks.js` | Project concurrency gate in `tryAutoDispatch` |
| `server/server.js` | Register routes, board init |
| `server/test-projects.js` | **New** — 15 unit tests |

## Test plan
- [x] 15 new unit tests (all passing)
- [x] Regression: test-kernel-e2e (5/5), test-step-schema (27/27), test-context-compiler (8/8), test-route-engine (14/14)
- [x] test-bridge: 18/20 (2 pre-existing failures, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)