### PR TITLE
fix(route-engine): warn on missing revision_target (#183)

### DIFF
--- a/server/route-engine.js
+++ b/server/route-engine.js
@@ -167,7 +167,9 @@ function decideNext(agentOutput, runState) {
     // Guard: limit revision cycles to avoid infinite loops.
     if (fromStep?.revision_target && needsRevision(agentOutput)) {
       const targetStep = steps.find(s => s.type === fromStep.revision_target);
-      if (targetStep) {
+      if (!targetStep) {
+        console.warn("[route-engine] revision_target '%s' not found in pipeline", fromStep.revision_target);
+      } else {
         const maxCycles = fromStep.max_revision_cycles || MAX_REVISION_CYCLES;
         const revisionCount = task._revisionCounts?.[targetStep.step_id] || 0;
         if (revisionCount < maxCycles) {


### PR DESCRIPTION
## Summary
- Add `console.warn` when `revision_target` points to a step type not found in the pipeline
- Addresses review suggestion from PR #182 (generic revision loop)

## Implementation
Restructured the `if (targetStep)` guard in `decideNext()` to log a warning on the missing-target path before falling through to `done`.

## Test plan
- [x] `node server/test-kernel-revision.js` — 7/7 passing (includes non-existent target case)
- [x] `node -c server/route-engine.js` — syntax OK

## Note
Implemented by **opencode/big-pickle** via Karvi server dispatch pipeline — first stable end-to-end opencode completion.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)