### PR TITLE
feat(dispatch): adjust modelHint logic for CLI runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,13 @@ brief-panel/output/
 .claude/
 .edda/
 .env
+
+# Temp / scratch files
+.tmp/
+.deep-dive/
+.git-commit-msg.tmp
+server/.board-*.tmp
+server/_reset-*.js
+server/log.jsonl
+server/usage/
+server/docs/launch/

--- a/server/management.js
+++ b/server/management.js
@@ -797,9 +797,9 @@ function buildDispatchPlan(board, task, options = {}) {
     runtimeHint,
     userId,
     agentId: task.assignee,
-    // AGENT_MODEL_MAP contains OpenClaw/API model IDs — skip for CLI-based runtimes
-    // (claude, opencode) which use their own model selection.
-    modelHint: (runtimeHint === 'claude' || runtimeHint === 'opencode') ? null : preferredModelFor(task.assignee),
+    // AGENT_MODEL_MAP contains OpenClaw/API model IDs — skip for Claude Code CLI
+    // which uses its own model selection (--model flag not needed).
+    modelHint: runtimeHint === 'claude' ? null : preferredModelFor(task.assignee),
     timeoutSec: options.timeoutSec || 300,
     sessionId: task.childSessionKey || null,
     message,

--- a/server/test-step-schema.js
+++ b/server/test-step-schema.js
@@ -333,6 +333,20 @@ test('buildDispatchPlan includes steps field', () => {
   assert.strictEqual(planNoSteps.steps, null);
 });
 
+test('buildDispatchPlan includes modelHint for opencode runtime', () => {
+  const board = {
+    taskPlan: { tasks: [{ id: 'T-00001', assignee: 'engineer_lite', status: 'dispatched' }] },
+    controls: {},
+    lessons: [],
+    participants: [{ id: 'owner', type: 'human' }],
+  };
+  const task = board.taskPlan.tasks[0];
+  // Before this fix: opencode runtime got null modelHint (hardcoded skip)
+  // After this fix: opencode runtime receives modelHint via preferredModelFor
+  const plan = mgmt.buildDispatchPlan(board, task, { runtimeHint: 'opencode' });
+  assert.notStrictEqual(plan.modelHint, null);
+});
+
 // ─────────────────────────────────────
 // Cleanup & Summary
 // ─────────────────────────────────────


### PR DESCRIPTION
## Summary
Adjust modelHint handling so opencode runtime can receive model hints.

## Changes
- **management.js**: Updated modelHint logic to only skip for 'claude' runtime (removed 'opencode' from skip list)
  - Before: `modelHint: (runtimeHint === 'claude' || runtimeHint === 'opencode') ? null : ...`
  - After: `modelHint: runtimeHint === 'claude' ? null : ...`
  - OpenCode can now accept modelHint via `--model` flag
  - Claude Code CLI still skips modelHint (uses its own model selection)

- **test-step-schema.js**: Added test to verify opencode receives modelHint

## Behavior Change
**Before**: opencode runtime never received modelHint (set to null)
**After**: opencode runtime receives modelHint from preferredModelFor(task.assignee)

This IS a behavior change - opencode can now use custom models when specified.

## Test Results
- ✅ test-step-schema.js: 28 passed (1 new test for opencode modelHint)