### PR TITLE
fix(step-worker): heartbeat lock renewal (#206)

### DIFF
--- a/server/runtime-claude.js
+++ b/server/runtime-claude.js
@@ -115,6 +115,17 @@ function dispatch(plan) {
       if (err) reject(err); else resolve(result);
     }
 
+    // Heartbeat: notify caller that runtime is alive (for lock renewal)
+    let lastHeartbeat = 0;
+    const HEARTBEAT_INTERVAL_MS = 60_000;
+    function heartbeat() {
+      if (!plan.onActivity) return;
+      const now = Date.now();
+      if (now - lastHeartbeat < HEARTBEAT_INTERVAL_MS) return;
+      lastHeartbeat = now;
+      try { plan.onActivity(); } catch {}
+    }
+
     // --- Inactivity timeout: resets on every stream event ---
     let inactivityTimer = null;
     function resetInactivityTimer() {
@@ -148,6 +159,7 @@ function dispatch(plan) {
     child.stdout.on('data', chunk => {
       lineBuf += chunk;
       resetInactivityTimer();
+      heartbeat();
 
       const lines = lineBuf.split('\n');
       lineBuf = lines.pop(); // keep incomplete last line

--- a/server/runtime-opencode.js
+++ b/server/runtime-opencode.js
@@ -89,6 +89,17 @@ function dispatch(plan) {
     console.log('[opencode-rt] message file:', msgFile);
     console.log('[opencode-rt] cwd:', workDir, 'timeout:', timeoutMs);
 
+    // Heartbeat: notify caller that runtime is alive (for lock renewal)
+    let lastHeartbeat = 0;
+    const HEARTBEAT_INTERVAL_MS = 60_000;
+    function heartbeat() {
+      if (!plan.onActivity) return;
+      const now = Date.now();
+      if (now - lastHeartbeat < HEARTBEAT_INTERVAL_MS) return;
+      lastHeartbeat = now;
+      try { plan.onActivity(); } catch {}
+    }
+
     const env = { ...process.env };
 
     // Windows: .cmd shims must be invoked via cmd.exe
@@ -155,6 +166,7 @@ function dispatch(plan) {
     child.stdout.on('data', chunk => {
       lineBuf += chunk;
       resetInactivityTimer();
+      heartbeat();
 
       const lines = lineBuf.split('\n');
       lineBuf = lines.pop();

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -94,6 +94,19 @@ function createStepWorker(deps) {
       postCheckResult = null;
     } else {
       // 4. Dispatch with duration tracking (catch failures to transition step properly)
+      //    Heartbeat callback: refresh lock while runtime is alive (prevents retry-poller conflicts)
+      plan.onActivity = () => {
+        try {
+          const hbBoard = helpers.readBoard();
+          const hbTask = (hbBoard.taskPlan?.tasks || []).find(t => t.id === envelope.task_id);
+          const hbStep = hbTask?.steps?.find(s => s.step_id === envelope.step_id);
+          if (hbStep && hbStep.state === 'running' && hbStep.locked_by === 'step-worker') {
+            hbStep.lock_expires_at = new Date(Date.now() + envelope.timeout_ms + LOCK_GRACE_MS).toISOString();
+            helpers.writeBoard(hbBoard);
+          }
+        } catch {}
+      };
+
       const startMs = Date.now();
       let result;
       try {


### PR DESCRIPTION
## Summary
- Runtime adapters call `plan.onActivity()` every 60s while subprocess is producing output
- step-worker uses this callback to refresh `lock_expires_at`
- Prevents retry-poller from re-dispatching steps that are still actively running

## Root Cause
Lock set once at dispatch start (330s = 300s timeout + 30s grace). Slow models (GLM-5 doing 60+ tool-call rounds) exceed this while still actively working. Retry-poller sees expired lock → re-dispatches → two processes on same step → chaos.

## Changes
| File | Change |
|------|--------|
| `server/step-worker.js` | Pass `onActivity` callback that refreshes `lock_expires_at` on board |
| `server/runtime-opencode.js` | Call `heartbeat()` on every NDJSON chunk (debounced 60s) |
| `server/runtime-claude.js` | Same heartbeat pattern for consistency |

## Test plan
- [x] `node server/test-step-worker.js` — 11/11 passing
- [x] `node server/test-kernel-revision.js` — 7/7 passing
- [x] `node -c` syntax check on all 3 files
- [x] Only 3 files in diff (cleaned up from #207)

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)