### PR TITLE
fix: adjust modelHint for opencode + simplify verbose comments

### DIFF
--- a/server/management.js
+++ b/server/management.js
@@ -797,9 +797,9 @@ function buildDispatchPlan(board, task, options = {}) {
     runtimeHint,
     userId,
     agentId: task.assignee,
-    // AGENT_MODEL_MAP contains OpenClaw/API model IDs — skip for CLI-based runtimes
-    // (claude, opencode) which use their own model selection.
-    modelHint: (runtimeHint === 'claude' || runtimeHint === 'opencode') ? null : preferredModelFor(task.assignee),
+    // AGENT_MODEL_MAP contains OpenClaw/API model IDs — skip for Claude Code CLI
+    // which uses its own model selection (--model flag not needed).
+    modelHint: runtimeHint === 'claude' ? null : preferredModelFor(task.assignee),
     timeoutSec: options.timeoutSec || 300,
     sessionId: task.childSessionKey || null,
     message,

--- a/server/runtime-opencode.js
+++ b/server/runtime-opencode.js
@@ -67,19 +67,15 @@ function dispatch(plan) {
     const args = ['run', '--format', 'json'];
 
     if (plan.sessionId) args.push('--session', plan.sessionId);
-    // Model priority: plan.modelHint > OPENCODE_MODEL env > opencode default config
     const model = plan.modelHint || process.env.OPENCODE_MODEL || null;
     if (model) args.push('--model', model);
 
     const workDir = plan.workingDir || path.resolve(DIR, '..');
     args.push('--dir', workDir);
 
-    // Write message to temp file and attach via --file.
-    // cmd.exe truncates multi-line positional args at the first newline,
-    // so the full task prompt goes into the file attachment.
+    // cmd.exe truncates multi-line args — use temp file
     const msgFile = path.join(os.tmpdir(), `karvi-dispatch-${Date.now()}.md`);
     fs.writeFileSync(msgFile, plan.message, 'utf8');
-    // --file must come before positional message to avoid yargs misparse
     args.push('--file', msgFile, '--', 'Read the attached file for your task. Implement everything it describes.');
 
     const timeoutMs = (plan.timeoutSec || 300) * 1000;
@@ -192,16 +188,14 @@ function dispatch(plan) {
           }
         }
 
-        // step_finish — only settle on terminal reasons (not tool-calls which means more steps coming)
+        // step_finish — only settle on terminal reasons
         if (obj.type === 'step_finish') {
           lastFinish = obj.part || {};
           if (obj.sessionID) sessionId = obj.sessionID;
           console.log('[opencode-rt] step_finish: reason=%s cost=%s tokens=%j',
             lastFinish.reason, lastFinish.cost, lastFinish.tokens);
-          // reason=tool-calls means opencode is about to execute tools and continue
           if (lastFinish.reason === 'tool-calls') {
-            console.log('[opencode-rt] tool-calls step — waiting for next step');
-            continue;
+            continue; // more steps coming
           }
           settle(null, buildResult(lastText));
           killTree(child.pid);

--- a/server/test-step-schema.js
+++ b/server/test-step-schema.js
@@ -357,6 +357,20 @@ test('buildDispatchPlan workingDir defaults to null', () => {
   assert.strictEqual(plan.workingDir, null);
 });
 
+test('buildDispatchPlan includes modelHint for opencode runtime', () => {
+  const board = {
+    taskPlan: { tasks: [{ id: 'T-00001', assignee: 'engineer_lite', status: 'dispatched' }] },
+    controls: {},
+    lessons: [],
+    participants: [{ id: 'owner', type: 'human' }],
+  };
+  const task = board.taskPlan.tasks[0];
+  // Before this fix: opencode runtime got null modelHint (hardcoded skip)
+  // After this fix: opencode runtime receives modelHint via preferredModelFor
+  const plan = mgmt.buildDispatchPlan(board, task, { runtimeHint: 'opencode' });
+  assert.notStrictEqual(plan.modelHint, null);
+});
+
 // ─────────────────────────────────────
 // Cleanup & Summary
 // ─────────────────────────────────────


### PR DESCRIPTION
## Summary
Two fixes combined into one PR after resolving CI issues.

## Changes

### 1. modelHint for OpenCode (from PR #204)
- **management.js**: Remove opencode from modelHint skip list
  - Before: `modelHint: (runtimeHint === 'claude' || runtimeHint === 'opencode') ? null : ...`
  - After: `modelHint: runtimeHint === 'claude' ? null : ...`
  - OpenCode can now receive custom model hints via `--model` flag

- **test-step-schema.js**: Added test to verify opencode receives modelHint

### 2. Comment Cleanup (from PR #209)
- **runtime-opencode.js**: Simplified verbose comments
  - Reduced 9 lines of comments to 3 lines
  - Removed redundant console.log for tool-calls steps

## Test Results
- ✅ test-step-schema.js: 30 passed (1 new test)

## Behavior Change
OpenCode runtime now receives modelHint instead of null. This allows users to specify custom models.