### PR TITLE
feat(protection): three-layer agent protection system

### DIFF
--- a/server/management.js
+++ b/server/management.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
 const bb = require('./blackboard-server');
 const { nowIso, uid } = bb;
 const stepSchema = require('./step-schema');
@@ -550,6 +551,97 @@ function buildPreflightSection(board, task, options = {}) {
   return { lines, lessonResult };
 }
 
+// --- Edda Decision Injection (Layer 1 of Agent Protection) ---
+
+let _eddaDecisionCache = { ts: 0, decisions: [] };
+const EDDA_DECISION_CACHE_TTL_MS = 60_000;
+
+/**
+ * Load architectural decisions from edda ledger.
+ * Cached for 60s. Graceful degradation if edda not installed.
+ * @returns {Array<{ key: string, value: string, reason: string, ts: string }>}
+ */
+function loadEddaDecisions() {
+  const now = Date.now();
+  if (now - _eddaDecisionCache.ts < EDDA_DECISION_CACHE_TTL_MS && _eddaDecisionCache.decisions.length > 0) {
+    return _eddaDecisionCache.decisions;
+  }
+
+  const eddaCmd = process.env.EDDA_CMD;
+  if (!eddaCmd) return _eddaDecisionCache.decisions;
+
+  try {
+    const cmd = process.platform === 'win32'
+      ? `cmd.exe /d /s /c ${eddaCmd} log --tag decision --json --limit 50`
+      : `${eddaCmd} log --tag decision --json --limit 50`;
+
+    const raw = execSync(cmd, {
+      encoding: 'utf8',
+      timeout: 5000,
+      cwd: path.resolve(DIR, '..'),
+    }).trim();
+
+    if (!raw) { _eddaDecisionCache = { ts: now, decisions: [] }; return []; }
+
+    const decisions = raw.split('\n')
+      .filter(Boolean)
+      .map(line => {
+        try {
+          const evt = JSON.parse(line);
+          const d = evt.payload?.decision;
+          if (!d?.key) return null;
+          return { key: d.key, value: d.value, reason: d.reason, ts: evt.ts };
+        } catch { return null; }
+      })
+      .filter(Boolean);
+
+    _eddaDecisionCache = { ts: now, decisions };
+    return decisions;
+  } catch {
+    return _eddaDecisionCache.decisions;
+  }
+}
+
+/**
+ * Build a "PROTECTED DECISIONS" prompt section from edda decisions.
+ * Tells agents which architectural choices must not be reverted.
+ * @returns {string[]} lines to inject into dispatch prompt
+ */
+function buildProtectedDecisionsSection() {
+  const decisions = loadEddaDecisions();
+  if (decisions.length === 0) return [];
+
+  // Filter to infrastructure/architecture decisions (broadly relevant)
+  const relevant = decisions.filter(d =>
+    /^(dispatch|runtime|step-worker|kernel|route-engine|management|server)\./.test(d.key)
+  );
+  if (relevant.length === 0) return [];
+
+  const lines = [];
+  lines.push('');
+  lines.push('## PROTECTED DECISIONS \u2014 do NOT revert these');
+  lines.push('The following architectural decisions were made deliberately. Do not change code that implements them:');
+  lines.push('');
+
+  let charCount = 0;
+  const MAX_CHARS = 2000;
+
+  for (const d of relevant) {
+    const line = `- **${d.key}** = ${d.value} \u2014 ${d.reason}`;
+    if (charCount + line.length > MAX_CHARS) {
+      lines.push('  ... (more decisions omitted)');
+      break;
+    }
+    lines.push(line);
+    charCount += line.length;
+  }
+
+  lines.push('');
+  lines.push('If you encounter code that seems wrong but implements one of these decisions, LEAVE IT ALONE.');
+
+  return lines;
+}
+
 function buildTaskDispatchMessage(board, task, options = {}) {
   const lines = [];
 
@@ -642,6 +734,12 @@ function buildTaskDispatchMessage(board, task, options = {}) {
     lines.push(...preflight.lines);
   }
 
+  // --- Protected Decisions (edda) ---
+  const protectedDecisions = buildProtectedDecisionsSection();
+  if (protectedDecisions.length > 0) {
+    lines.push(...protectedDecisions);
+  }
+
   return lines.join('\n');
 }
 
@@ -692,6 +790,12 @@ function buildRedispatchMessage(board, task, options = {}) {
     lines.push(...preflight.lines);
   }
 
+  // --- Protected Decisions (edda) ---
+  const protectedDecisions = buildProtectedDecisionsSection();
+  if (protectedDecisions.length > 0) {
+    lines.push(...protectedDecisions);
+  }
+
   return lines.join('\n');
 }
 
@@ -734,6 +838,12 @@ function buildGenericDispatchMessage(board, task, options = {}) {
   if (preflight.lines.length > 0) {
     lines.push('');
     lines.push(...preflight.lines);
+  }
+
+  // --- Protected Decisions (edda) ---
+  const protectedDecisions = buildProtectedDecisionsSection();
+  if (protectedDecisions.length > 0) {
+    lines.push(...protectedDecisions);
   }
 
   return lines.join('\n');
@@ -797,8 +907,7 @@ function buildDispatchPlan(board, task, options = {}) {
     runtimeHint,
     userId,
     agentId: task.assignee,
-    // AGENT_MODEL_MAP contains OpenClaw/API model IDs — skip for CLI-based runtimes
-    // (claude, opencode) which use their own model selection.
+    // @protected decision:dispatch.modelHint — AGENT_MODEL_MAP has OpenClaw IDs that CLI runtimes don't recognize; passing them causes silent failure
     modelHint: (runtimeHint === 'claude' || runtimeHint === 'opencode') ? null : preferredModelFor(task.assignee),
     timeoutSec: options.timeoutSec || 300,
     sessionId: task.childSessionKey || null,
@@ -965,6 +1074,8 @@ module.exports = {
   gatherUpstreamArtifacts,
   matchLessonsForTask,
   buildPreflightSection,
+  loadEddaDecisions,
+  buildProtectedDecisionsSection,
   buildTaskDispatchMessage,
   buildRedispatchMessage,
   buildDispatchPlan,

--- a/server/protected-diff-guard.js
+++ b/server/protected-diff-guard.js
@@ -1,0 +1,250 @@
+/**
+ * protected-diff-guard.js — Layer 2+3 of Agent Protection System
+ *
+ * Layer 2: Parse @protected annotations from source files.
+ * Layer 3: Validate git diffs against protected regions — block unauthorized reverts.
+ *
+ * Annotation format:
+ *   // @protected decision:<key> — <reason>
+ *   <protected line(s)>
+ *
+ * Multi-line block:
+ *   // @protected decision:<key> — <reason>
+ *   <line1>
+ *   <line2>
+ *   // @end-protected
+ */
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// Matches: // @protected decision:<key> — <reason>
+// Also:    # @protected ...   or   /* @protected ... */
+const PROTECTED_RE = /(?:\/\/|#|\/\*)\s*@protected\s+decision:(\S+)\s*(?:\u2014|-)\s*(.+?)(?:\s*\*\/)?$/;
+const END_RE = /(?:\/\/|#|\/\*)\s*@end-protected/;
+
+/**
+ * Parse @protected annotations from file content string.
+ *
+ * Each annotation protects lines until @end-protected or the next
+ * non-empty, non-comment line (whichever comes first).
+ *
+ * @param {string} content - File content
+ * @returns {Array<{ startLine: number, endLine: number, key: string, reason: string }>}
+ *   Lines are 1-indexed.
+ */
+function parseProtectedAnnotationsFromContent(content) {
+  if (!content) return [];
+  const lines = content.split('\n');
+  const annotations = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(PROTECTED_RE);
+    if (!match) continue;
+
+    const key = match[1];
+    const reason = match[2].trim();
+    const startLine = i + 1; // 1-indexed (the annotation line itself)
+
+    // First scan for @end-protected (explicit block marker takes priority)
+    let endLine = startLine;
+    let foundEndMarker = false;
+    for (let j = i + 1; j < lines.length; j++) {
+      if (END_RE.test(lines[j])) {
+        endLine = j + 1; // include the @end-protected line
+        foundEndMarker = true;
+        break;
+      }
+    }
+    // If no @end-protected, protect until the next substantive (non-comment) line
+    if (!foundEndMarker) {
+      for (let j = i + 1; j < lines.length; j++) {
+        const trimmed = lines[j].trim();
+        if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('#') || trimmed.startsWith('/*') || trimmed.startsWith('*')) {
+          continue;
+        }
+        endLine = j + 1; // 1-indexed
+        break;
+      }
+    }
+
+    annotations.push({ startLine, endLine, key, reason });
+  }
+
+  return annotations;
+}
+
+/**
+ * Parse @protected annotations from a file on disk.
+ * @param {string} filePath - Absolute path
+ */
+function parseProtectedAnnotations(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    return parseProtectedAnnotationsFromContent(content);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Parse a unified diff to extract which original-file line numbers were modified/deleted.
+ *
+ * Reads @@ hunk headers and counts '-' lines (removed from original).
+ * @param {string} unifiedDiff - Output of `git diff`
+ * @returns {Set<number>} 1-indexed line numbers from the original that were changed/deleted
+ */
+function parseModifiedOriginalLines(unifiedDiff) {
+  const modified = new Set();
+  const lines = unifiedDiff.split('\n');
+  let origLine = 0;
+
+  for (const line of lines) {
+    // Hunk header: @@ -origStart,origCount +newStart,newCount @@
+    const hunkMatch = line.match(/^@@ -(\d+)(?:,\d+)? \+/);
+    if (hunkMatch) {
+      origLine = parseInt(hunkMatch[1], 10);
+      continue;
+    }
+
+    if (origLine === 0) continue; // before first hunk (file header)
+
+    if (line.startsWith('-')) {
+      modified.add(origLine);
+      origLine++;
+    } else if (line.startsWith('+')) {
+      // Added line — no original line number to track
+    } else if (line.startsWith(' ') || line === '') {
+      // Context line
+      origLine++;
+    }
+    // Skip \ No newline at end of file, etc.
+  }
+
+  return modified;
+}
+
+/**
+ * Extract a short snippet from unified diff around a target original line number.
+ */
+function extractDiffSnippet(unifiedDiff, targetLine) {
+  const lines = unifiedDiff.split('\n');
+  let origLine = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const hunkMatch = lines[i].match(/^@@ -(\d+)/);
+    if (hunkMatch) {
+      origLine = parseInt(hunkMatch[1], 10);
+      continue;
+    }
+    if (lines[i].startsWith('-') || lines[i].startsWith(' ')) {
+      if (origLine === targetLine) {
+        const start = Math.max(0, i - 2);
+        const end = Math.min(lines.length, i + 3);
+        return lines.slice(start, end).join('\n');
+      }
+      origLine++;
+    }
+  }
+  return '(diff snippet not found)';
+}
+
+/**
+ * Validate that a git working tree's diff doesn't violate @protected annotations.
+ *
+ * Strategy:
+ *   1. Detect whether changes are committed or uncommitted
+ *   2. Get list of modified files
+ *   3. For each, parse @protected from the ORIGINAL version
+ *   4. Cross-check modified lines against protected ranges
+ *
+ * @param {string} workDir - Working directory (worktree or repo root)
+ * @returns {{ ok: boolean, violations: Array<{ file: string, line: number, key: string, reason: string, diff: string }> }}
+ */
+function validateProtectedDiff(workDir) {
+  if (!workDir) return { ok: true, violations: [] };
+
+  const opts = { cwd: workDir, encoding: 'utf8', timeout: 15000 };
+
+  try {
+    // Determine diff base: if no uncommitted changes → compare HEAD~1..HEAD
+    // If uncommitted → compare HEAD..working tree
+    let diffBase = 'HEAD';
+    let diffTarget = ''; // empty = working tree
+    try {
+      const porcelain = execSync('git status --porcelain', opts).trim();
+      if (!porcelain) {
+        // Everything committed — diff against parent
+        diffBase = 'HEAD~1';
+        diffTarget = 'HEAD';
+      }
+    } catch {
+      return { ok: true, violations: [] }; // not a git repo
+    }
+
+    // Get modified files
+    const diffCmd = diffTarget
+      ? `git diff ${diffBase} ${diffTarget} --name-only`
+      : `git diff ${diffBase} --name-only`;
+    const modifiedFiles = execSync(diffCmd, opts).trim().split('\n').filter(Boolean);
+    if (modifiedFiles.length === 0) return { ok: true, violations: [] };
+
+    const violations = [];
+
+    for (const file of modifiedFiles) {
+      // Get original version's content to find @protected annotations
+      let originalContent;
+      try {
+        originalContent = execSync(`git show ${diffBase}:${file}`, opts);
+      } catch {
+        continue; // new file — no protected annotations to check
+      }
+
+      const annotations = parseProtectedAnnotationsFromContent(originalContent);
+      if (annotations.length === 0) continue;
+
+      // Get unified diff for this specific file
+      const fileDiffCmd = diffTarget
+        ? `git diff ${diffBase} ${diffTarget} -- "${file}"`
+        : `git diff ${diffBase} -- "${file}"`;
+      let unifiedDiff;
+      try {
+        unifiedDiff = execSync(fileDiffCmd, opts);
+      } catch {
+        continue;
+      }
+
+      const modifiedLines = parseModifiedOriginalLines(unifiedDiff);
+
+      // Check for overlap between modified lines and protected ranges
+      for (const ann of annotations) {
+        for (let line = ann.startLine; line <= ann.endLine; line++) {
+          if (modifiedLines.has(line)) {
+            violations.push({
+              file,
+              line,
+              key: ann.key,
+              reason: ann.reason,
+              diff: extractDiffSnippet(unifiedDiff, line),
+            });
+            break; // one violation per annotation is enough
+          }
+        }
+      }
+    }
+
+    return { ok: violations.length === 0, violations };
+  } catch (err) {
+    // Don't block on guard errors — fail open, log warning
+    console.error('[protected-diff-guard] error:', err.message);
+    return { ok: true, violations: [] };
+  }
+}
+
+module.exports = {
+  parseProtectedAnnotations,
+  parseProtectedAnnotationsFromContent,
+  parseModifiedOriginalLines,
+  extractDiffSnippet,
+  validateProtectedDiff,
+};

--- a/server/route-engine.js
+++ b/server/route-engine.js
@@ -17,6 +17,7 @@ const FAILURE_MODES = {
   STRATEGY_MISMATCH:    'STRATEGY_MISMATCH',
   FINALIZE_ERROR:       'FINALIZE_ERROR',
   CONTRACT_VIOLATION:   'CONTRACT_VIOLATION',
+  PROTECTED_CODE_VIOLATION: 'PROTECTED_CODE_VIOLATION',
 };
 
 const BUDGET_DEFAULTS = {
@@ -35,6 +36,7 @@ const REMEDIATION_LIMITS = {
   STRATEGY_MISMATCH:   2,
   FINALIZE_ERROR:      1,
   CONTRACT_VIOLATION:  2,
+  PROTECTED_CODE_VIOLATION: 2,
 };
 
 // --- Failure classification ---
@@ -49,6 +51,7 @@ const FAILURE_PATTERNS = [
   { mode: FAILURE_MODES.TOOL_ERROR,       pattern: /timeout|ETIMEDOUT|rate.limit|ECONNREFUSED|socket.hang/i },
   { mode: FAILURE_MODES.FINALIZE_ERROR,     pattern: /uncommitted.changes|auto.finalize|finalize.error/i },
   { mode: FAILURE_MODES.CONTRACT_VIOLATION, pattern: /contract.violation|deliverable.*missing|deliverable.*not.found/i },
+  { mode: FAILURE_MODES.PROTECTED_CODE_VIOLATION, pattern: /protected.code.violation|@protected.*modified|protected.decision.*reverted/i },
 ];
 
 function classifyFailure(agentOutput) {

--- a/server/runtime-opencode.js
+++ b/server/runtime-opencode.js
@@ -74,13 +74,11 @@ function dispatch(plan) {
     const workDir = plan.workingDir || path.resolve(DIR, '..');
     args.push('--dir', workDir);
 
-    // Write message to temp file and attach via --file.
-    // cmd.exe truncates multi-line positional args at the first newline,
-    // so the full task prompt goes into the file attachment.
+    // @protected decision:runtime.opencode.msgFile — cmd.exe truncates multi-line positional args at first newline; --file must precede -- to avoid yargs misparse
     const msgFile = path.join(os.tmpdir(), `karvi-dispatch-${Date.now()}.md`);
     fs.writeFileSync(msgFile, plan.message, 'utf8');
-    // --file must come before positional message to avoid yargs misparse
     args.push('--file', msgFile, '--', 'Read the attached file for your task. Implement everything it describes.');
+    // @end-protected
 
     const timeoutMs = (plan.timeoutSec || 300) * 1000;
     console.log('[opencode-rt] spawn:', OPENCODE_EXE);
@@ -192,7 +190,7 @@ function dispatch(plan) {
           }
         }
 
-        // step_finish — only settle on terminal reasons (not tool-calls which means more steps coming)
+        // @protected decision:runtime.opencode.settle — only settle on terminal step_finish reasons; tool-calls means more steps coming
         if (obj.type === 'step_finish') {
           lastFinish = obj.part || {};
           if (obj.sessionID) sessionId = obj.sessionID;

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -199,6 +199,34 @@ function createStepWorker(deps) {
         }
       }
 
+      // 5b2. Protected code guard — verify no @protected annotations were violated
+      if (status === 'succeeded') {
+        const { validateProtectedDiff } = require('./protected-diff-guard');
+        const guardResult = validateProtectedDiff(plan.workingDir || plan.cwd);
+        if (!guardResult.ok) {
+          const violationSummary = guardResult.violations
+            .map(v => `${v.file}:${v.line} — decision:${v.key} (${v.reason})`)
+            .join('; ');
+          status = 'failed';
+          failure = {
+            failure_signature: `Protected code violation: ${violationSummary}`.slice(0, 500),
+            failure_mode: 'PROTECTED_CODE_VIOLATION',
+            retryable: true,
+          };
+          summary = `Agent modified protected code. Violations: ${violationSummary}`.slice(0, 500);
+          // Attempt revert if auto-finalize already committed
+          try {
+            if (!postCheckResult?.hasUncommittedChanges) {
+              execSync('git revert --no-edit HEAD', {
+                cwd: plan.workingDir || plan.cwd,
+                encoding: 'utf8',
+                timeout: 10000,
+              });
+            }
+          } catch { /* revert failed — violation report triggers retry anyway */ }
+        }
+      }
+
       // 5c. Contract validation — verify declared deliverables exist
       if (status === 'succeeded' && envelope.contract?.deliverable) {
         const contractResult = validateContract(
@@ -635,6 +663,13 @@ function buildStepMessage(envelope, upstreamArtifacts) {
     lines.push('', '🔄 REVISION — the review found issues to fix:');
     lines.push(envelope.review_feedback);
     lines.push('', 'Fix the issues listed above. Do NOT re-implement from scratch — only address the review findings.');
+  }
+
+  // Protected edda decisions — prevent agents from reverting critical fixes
+  const mgmt = require('./management');
+  const protectedLines = mgmt.buildProtectedDecisionsSection();
+  if (protectedLines.length > 0) {
+    lines.push(...protectedLines);
   }
 
   // Instruct agent to output structured result when done

--- a/server/test-protected-diff-guard.js
+++ b/server/test-protected-diff-guard.js
@@ -1,0 +1,295 @@
+/**
+ * test-protected-diff-guard.js — Unit + integration tests for protected-diff-guard.js
+ */
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
+
+const {
+  parseProtectedAnnotations,
+  parseProtectedAnnotationsFromContent,
+  parseModifiedOriginalLines,
+  extractDiffSnippet,
+  validateProtectedDiff,
+} = require('./protected-diff-guard');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failed++;
+    console.log(`  ✗ ${name}`);
+    console.log(`    ${err.message}`);
+  }
+}
+
+// --- parseProtectedAnnotationsFromContent ---
+
+console.log('\n--- parseProtectedAnnotationsFromContent ---');
+
+test('single-line annotation protects next substantive line', () => {
+  const content = [
+    '// some comment',
+    '// @protected decision:foo.bar — reason here',
+    'const x = 1;',
+    'const y = 2;',
+  ].join('\n');
+  const anns = parseProtectedAnnotationsFromContent(content);
+  assert.strictEqual(anns.length, 1);
+  assert.strictEqual(anns[0].key, 'foo.bar');
+  assert.strictEqual(anns[0].reason, 'reason here');
+  assert.strictEqual(anns[0].startLine, 2); // annotation line
+  assert.strictEqual(anns[0].endLine, 3);   // the protected code line
+});
+
+test('multi-line block with @end-protected', () => {
+  const content = [
+    '// @protected decision:block.test — multi-line block',
+    'const a = 1;',
+    'const b = 2;',
+    '// @end-protected',
+    'const c = 3;',
+  ].join('\n');
+  const anns = parseProtectedAnnotationsFromContent(content);
+  assert.strictEqual(anns.length, 1);
+  assert.strictEqual(anns[0].startLine, 1);
+  assert.strictEqual(anns[0].endLine, 4); // includes @end-protected
+});
+
+test('supports dash separator (not just em-dash)', () => {
+  const content = '// @protected decision:test.dash - reason with dash\ncode();';
+  const anns = parseProtectedAnnotationsFromContent(content);
+  assert.strictEqual(anns.length, 1);
+  assert.strictEqual(anns[0].key, 'test.dash');
+});
+
+test('supports hash comment style', () => {
+  const content = '# @protected decision:py.thing \u2014 python style\nimport os';
+  const anns = parseProtectedAnnotationsFromContent(content);
+  assert.strictEqual(anns.length, 1);
+  assert.strictEqual(anns[0].key, 'py.thing');
+});
+
+test('no annotations returns empty array', () => {
+  const content = '// normal comment\nconst x = 1;\n';
+  assert.strictEqual(parseProtectedAnnotationsFromContent(content).length, 0);
+});
+
+test('empty content returns empty array', () => {
+  assert.strictEqual(parseProtectedAnnotationsFromContent('').length, 0);
+  assert.strictEqual(parseProtectedAnnotationsFromContent(null).length, 0);
+});
+
+test('multiple annotations in same file', () => {
+  const content = [
+    '// @protected decision:a.b \u2014 reason A',
+    'lineA();',
+    '',
+    '// @protected decision:c.d \u2014 reason B',
+    'lineB();',
+  ].join('\n');
+  const anns = parseProtectedAnnotationsFromContent(content);
+  assert.strictEqual(anns.length, 2);
+  assert.strictEqual(anns[0].key, 'a.b');
+  assert.strictEqual(anns[1].key, 'c.d');
+});
+
+test('annotation skips blank lines and comments to find protected code', () => {
+  const content = [
+    '// @protected decision:skip.blank \u2014 reason',
+    '',
+    '// another comment',
+    'actual_code();',
+  ].join('\n');
+  const anns = parseProtectedAnnotationsFromContent(content);
+  assert.strictEqual(anns.length, 1);
+  assert.strictEqual(anns[0].endLine, 4); // actual_code line
+});
+
+// --- parseProtectedAnnotations (file-based) ---
+
+console.log('\n--- parseProtectedAnnotations (file-based) ---');
+
+test('reads from file on disk', () => {
+  const tmpFile = path.join(os.tmpdir(), `karvi-test-protected-${Date.now()}.js`);
+  fs.writeFileSync(tmpFile, '// @protected decision:file.test \u2014 file test\ncode();\n');
+  try {
+    const anns = parseProtectedAnnotations(tmpFile);
+    assert.strictEqual(anns.length, 1);
+    assert.strictEqual(anns[0].key, 'file.test');
+  } finally {
+    fs.unlinkSync(tmpFile);
+  }
+});
+
+test('nonexistent file returns empty array', () => {
+  assert.strictEqual(parseProtectedAnnotations('/nonexistent/file.js').length, 0);
+});
+
+// --- parseModifiedOriginalLines ---
+
+console.log('\n--- parseModifiedOriginalLines ---');
+
+test('basic removal detection', () => {
+  const diff = [
+    'diff --git a/test.js b/test.js',
+    '--- a/test.js',
+    '+++ b/test.js',
+    '@@ -3,4 +3,4 @@',
+    ' context',
+    '-removed line',
+    '+added line',
+    ' context',
+  ].join('\n');
+  const modified = parseModifiedOriginalLines(diff);
+  assert.ok(modified.has(4)); // line 4 was removed (3 + 1 context)
+  assert.ok(!modified.has(3)); // line 3 is context
+  assert.ok(!modified.has(5)); // line 5 is context
+});
+
+test('multiple hunks', () => {
+  const diff = [
+    '@@ -1,3 +1,3 @@',
+    '-old line 1',
+    '+new line 1',
+    ' same',
+    ' same',
+    '@@ -10,3 +10,3 @@',
+    ' context',
+    '-old line 11',
+    '+new line 11',
+    ' context',
+  ].join('\n');
+  const modified = parseModifiedOriginalLines(diff);
+  assert.ok(modified.has(1));
+  assert.ok(modified.has(11));
+  assert.ok(!modified.has(2));
+  assert.ok(!modified.has(10));
+});
+
+test('empty diff returns empty set', () => {
+  assert.strictEqual(parseModifiedOriginalLines('').size, 0);
+});
+
+// --- extractDiffSnippet ---
+
+console.log('\n--- extractDiffSnippet ---');
+
+test('extracts context around target line', () => {
+  const diff = [
+    '@@ -1,5 +1,5 @@',
+    ' line 1',
+    ' line 2',
+    '-line 3 old',
+    '+line 3 new',
+    ' line 4',
+    ' line 5',
+  ].join('\n');
+  const snippet = extractDiffSnippet(diff, 3);
+  assert.ok(snippet.includes('line 3 old') || snippet.includes('line 2'));
+});
+
+// --- validateProtectedDiff (integration) ---
+
+console.log('\n--- validateProtectedDiff ---');
+
+test('returns ok:true for null workDir', () => {
+  const result = validateProtectedDiff(null);
+  assert.strictEqual(result.ok, true);
+});
+
+test('returns ok:true for non-git directory', () => {
+  const result = validateProtectedDiff(os.tmpdir());
+  assert.strictEqual(result.ok, true);
+});
+
+// Full integration test with a temp git repo
+test('detects violation when protected line is modified', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'karvi-guard-test-'));
+  const opts = { cwd: tmpDir, encoding: 'utf8' };
+
+  try {
+    // Set up git repo
+    execSync('git init', opts);
+    execSync('git config user.email "test@test.com"', opts);
+    execSync('git config user.name "Test"', opts);
+
+    // Create file with protected annotation
+    const testFile = path.join(tmpDir, 'code.js');
+    fs.writeFileSync(testFile, [
+      '// @protected decision:test.guard \u2014 this line must not change',
+      'const critical = true;',
+      'const normal = false;',
+    ].join('\n'));
+
+    execSync('git add -A', opts);
+    execSync('git commit -m "initial"', opts);
+
+    // Modify the protected line
+    fs.writeFileSync(testFile, [
+      '// @protected decision:test.guard \u2014 this line must not change',
+      'const critical = false; // CHANGED!',
+      'const normal = false;',
+    ].join('\n'));
+
+    execSync('git add -A', opts);
+    execSync('git commit -m "bad change"', opts);
+
+    const result = validateProtectedDiff(tmpDir);
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.violations.length, 1);
+    assert.strictEqual(result.violations[0].key, 'test.guard');
+    assert.strictEqual(result.violations[0].file, 'code.js');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('passes when only non-protected lines are modified', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'karvi-guard-test-'));
+  const opts = { cwd: tmpDir, encoding: 'utf8' };
+
+  try {
+    execSync('git init', opts);
+    execSync('git config user.email "test@test.com"', opts);
+    execSync('git config user.name "Test"', opts);
+
+    const testFile = path.join(tmpDir, 'code.js');
+    fs.writeFileSync(testFile, [
+      '// @protected decision:test.safe \u2014 this line must not change',
+      'const critical = true;',
+      'const normal = false;',
+    ].join('\n'));
+
+    execSync('git add -A', opts);
+    execSync('git commit -m "initial"', opts);
+
+    // Only modify the non-protected line
+    fs.writeFileSync(testFile, [
+      '// @protected decision:test.safe \u2014 this line must not change',
+      'const critical = true;',
+      'const normal = true; // safe change',
+    ].join('\n'));
+
+    execSync('git add -A', opts);
+    execSync('git commit -m "safe change"', opts);
+
+    const result = validateProtectedDiff(tmpDir);
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.violations.length, 0);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// --- Summary ---
+console.log(`\n${'='.repeat(40)}`);
+console.log(`${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

- **Layer 1 (Prompt)**: Inject edda architectural decisions into all dispatch messages so agents know what not to revert
- **Layer 2 (Code)**: `@protected decision:<key>` annotations mark critical code lines with machine-readable rationale
- **Layer 3 (Gate)**: Post-check diff guard in step-worker detects protected code violations, fails the step, reverts commit, and feeds violation context to revision loop

Triggered by: auto-dispatched opencode agent reverted modelHint skip fix and deleted debug comments (PRs #204, #209, #210 — all closed).

## Files

| File | Change |
|------|--------|
| `server/management.js` | `loadEddaDecisions()` (60s cache), `buildProtectedDecisionsSection()`, injected into all 4 message builders |
| `server/step-worker.js` | Decision injection in `buildStepMessage()`, diff guard post-check between auto-finalize and contract validation |
| `server/route-engine.js` | `PROTECTED_CODE_VIOLATION` failure mode + remediation limit + classification pattern |
| `server/protected-diff-guard.js` | **New**: annotation parser + unified diff analyzer + `validateProtectedDiff()` |
| `server/runtime-opencode.js` | `@protected` annotations on modelHint, msgFile, and settlement logic |
| `server/test-protected-diff-guard.js` | **New**: 18 unit + integration tests |

## Test plan

- [x] `node server/test-protected-diff-guard.js` — 18/18 pass
- [x] `node server/test-step-schema.js` — 29/29 pass
- [x] `node server/test-step-worker.js` — 11/11 pass
- [x] `node server/test-bridge.js` — 18/20 pass (2 pre-existing failures)
- [x] `node -c` syntax check on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)