### PR TITLE
fix(reliability): budget preservation + wall_clock tracking (#223)

### DIFF
--- a/server/kernel.js
+++ b/server/kernel.js
@@ -77,11 +77,14 @@ function createKernel(deps) {
       tokens_used: output?.tokens_used || 0,
     };
 
-    // Update budget with token usage
+    // Update budget with token usage and wall clock
     if (agentOutput.tokens_used) {
       task.budget.used.tokens = (task.budget.used.tokens || 0) + agentOutput.tokens_used;
     }
     task.budget.used.llm_calls = (task.budget.used.llm_calls || 0) + 1;
+    if (output?.duration_ms) {
+      task.budget.used.wall_clock_ms = (task.budget.used.wall_clock_ms || 0) + output.duration_ms;
+    }
 
     // Route
     const runState = { task, steps: task.steps, run_id: step.run_id, budget: task.budget };

--- a/server/route-engine.js
+++ b/server/route-engine.js
@@ -21,9 +21,9 @@ const FAILURE_MODES = {
 };
 
 const BUDGET_DEFAULTS = {
-  max_llm_calls: 12,
-  max_tokens: 40000,
-  max_wall_clock_ms: 1_200_000,  // 20 min
+  max_llm_calls: 50,       // was 12 — too low for 3-step pipeline with retries
+  max_tokens: 500_000,     // was 40000 — single plan step can use 20K tokens
+  max_wall_clock_ms: 1_800_000,  // 30 min (was 20 min)
   max_steps: 20,
 };
 

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -192,13 +192,16 @@ function dispatchTask(task, board, deps, helpers, opts = {}) {
     console.log(`[dispatchTask:${taskId}] step-pipeline via ${source}`);
     const runId = helpers.uid('run');
     task.steps = mgmt.generateStepsForTask(task, runId, task.pipeline || null, board);
+    task._revisionCounts = {};  // Clear stale revision counts from previous runs
     task.status = 'in_progress';
     task.startedAt = task.startedAt || helpers.nowIso();
     task.history = task.history || [];
     task.history.push({ ts: helpers.nowIso(), status: 'in_progress', by: source, runtime: 'step-pipeline' });
     if (board.taskPlan) board.taskPlan.phase = 'executing';
 
-    task.budget = { limits: { ...routeEngine.BUDGET_DEFAULTS }, used: { llm_calls: 0, tokens: 0, wall_clock_ms: 0, steps: 0 } };
+    if (!task.budget) {
+      task.budget = { limits: { ...routeEngine.BUDGET_DEFAULTS }, used: { llm_calls: 0, tokens: 0, wall_clock_ms: 0, steps: 0 } };
+    }
 
     mgmt.ensureEvolutionFields(board);
     board.signals.push({


### PR DESCRIPTION
## Summary

- **F6**: Budget init conditional — don't reset on re-dispatch
- **F9**: Clear `_revisionCounts` on step regeneration
- **F10**: Track `wall_clock_ms` from step `duration_ms` in kernel
- **F14**: Raise budget defaults (50 calls / 500K tokens / 30min)

Part 3 of 3 for #223. Replaces closed #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)