### PR TITLE
feat(dispatch): enrich messages with skill context + completion criteria (#202)

### DIFF
--- a/server/management.js
+++ b/server/management.js
@@ -642,6 +642,69 @@ function buildProtectedDecisionsSection() {
   return lines;
 }
 
+/**
+ * Build a "Coding Standards" section by extracting key rules from skill files.
+ * Cached per-process so skill files are read only once.
+ * @returns {string[]} lines to inject into dispatch prompt
+ */
+function buildSkillContextSection() {
+  if (!buildSkillContextSection._cache) {
+    const excerpts = [];
+    const skillDir = path.join(__dirname, 'skills');
+
+    // Extract coding rules from engineer-playbook
+    try {
+      const ep = fs.readFileSync(path.join(skillDir, 'engineer-playbook', 'SKILL.md'), 'utf8');
+      // Look for code style / coding rules section
+      const match = ep.match(/## (?:Step 4|Code Style|代碼規範|coding|執行任務)[\s\S]*?(?=\n## |\n---)/i);
+      if (match) excerpts.push(match[0].trim().slice(0, 600));
+    } catch {}
+
+    // Extract constraints from blackboard-basics
+    try {
+      const bb = fs.readFileSync(path.join(skillDir, 'blackboard-basics', 'SKILL.md'), 'utf8');
+      const match = bb.match(/## (?:設計約束|Design Constraints|6 大約束)[\s\S]*?(?=\n## |\n---)/i);
+      if (match) excerpts.push(match[0].trim().slice(0, 400));
+    } catch {}
+
+    if (excerpts.length === 0) {
+      // Hardcoded fallback — always provide minimum context
+      excerpts.push(
+        '- Zero external dependencies (Node.js built-in modules only)\n' +
+        '- Atomic file writes (write to .tmp then rename)\n' +
+        '- Windows-compatible: spawn via cmd.exe /d /s /c\n' +
+        '- board.json is single source of truth — agents do NOT write board directly\n' +
+        '- Follow existing code patterns — do NOT invent new ones\n' +
+        '- Run node -c <file> on every modified JavaScript file'
+      );
+    }
+    buildSkillContextSection._cache = excerpts;
+  }
+
+  const lines = ['', '## Coding Standards (from project skills)'];
+  for (const excerpt of buildSkillContextSection._cache) {
+    lines.push(excerpt);
+  }
+  return lines;
+}
+
+/**
+ * Build a "Completion Criteria" section to prevent agents from declaring done prematurely.
+ * @returns {string[]} lines to inject into dispatch prompt
+ */
+function buildCompletionCriteriaSection() {
+  return [
+    '',
+    '## Completion Criteria',
+    'Before declaring done, you MUST verify ALL of the following:',
+    '1. Re-read the task description — confirm every bullet/numbered item is addressed',
+    '2. List each requirement and its implementation status',
+    '3. Run `node -c <file>` on every modified JavaScript file to verify syntax',
+    '4. If any requirement was skipped, state why explicitly',
+    '5. Commit your changes with a descriptive message before finishing',
+  ];
+}
+
 function buildTaskDispatchMessage(board, task, options = {}) {
   const lines = [];
 
@@ -832,6 +895,12 @@ function buildGenericDispatchMessage(board, task, options = {}) {
   lines.push('2. Implement the changes described above');
   lines.push('3. Run "node -c <file>" on every modified file to verify syntax');
   lines.push('4. Summarize what you changed and any verification results');
+
+  // Coding standards from skill files
+  lines.push(...buildSkillContextSection());
+
+  // Completion criteria — prevent premature "done"
+  lines.push(...buildCompletionCriteriaSection());
 
   // Preflight lessons
   const preflight = buildPreflightSection(board, task, options);
@@ -1076,6 +1145,8 @@ module.exports = {
   buildPreflightSection,
   loadEddaDecisions,
   buildProtectedDecisionsSection,
+  buildSkillContextSection,
+  buildCompletionCriteriaSection,
   buildTaskDispatchMessage,
   buildRedispatchMessage,
   buildDispatchPlan,

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -46,7 +46,7 @@ function createStepWorker(deps) {
     });
     // Enforce: runtime timeout must match lock timeout (prevent misalignment)
     plan.timeoutSec = timeoutSec;
-    const stepMessage = buildStepMessage(envelope, plan.artifacts);
+    const stepMessage = buildStepMessage(envelope, plan.artifacts, board, task);
     plan.message = stepMessage;
     plan.stepId = envelope.step_id;
     plan.stepType = envelope.step_type;
@@ -624,19 +624,21 @@ function parseStepResult(stdout) {
  * skill directly. The headless agent (`claude -p`) runs in the repo directory
  * and has access to `.claude/skills/`.
  */
-function buildStepMessage(envelope, upstreamArtifacts) {
+function buildStepMessage(envelope, upstreamArtifacts, board, task) {
   // Extract issue number from task source or task ID (GH-123 → 123)
   const source = envelope.input_refs?.task_source;
   const issueNumber = source?.number
     || (envelope.task_id.match(/^GH-(\d+)$/) || [])[1]
     || envelope.task_id;
 
-  // Map built-in engineering steps to skill invocations (legacy fallback).
+  // Map built-in engineering steps to skill invocations.
+  // IMPORTANT: Use explicit Skill tool guidance so agents know HOW to load skills.
+  const SKILL_TOOL_HINT = 'You have a "skill" tool available. Use it to load the skill by name, then follow its instructions.';
   const STEP_SKILL_MAP = {
-    plan:      `Execute /issue-plan ${issueNumber}`,
-    implement: `Execute /issue-action for issue #${issueNumber}. The plan has already been posted as a comment on the issue — read it from there.`,
+    plan:      `Use the skill tool to load the "issue-plan" skill, then follow its workflow for issue #${issueNumber}.\n${SKILL_TOOL_HINT}`,
+    implement: `Use the skill tool to load the "issue-action" skill for issue #${issueNumber}. The plan has already been posted as a comment on the issue — read it from there.\n${SKILL_TOOL_HINT}`,
     test:      `Check CI status for the PR. Run: gh pr checks. If lint/format failures, auto-fix and push. Report test results.`,
-    review:    `Execute /pr-review`,
+    review:    `Use the skill tool to load the "pr-review" skill, then follow its workflow.\n${SKILL_TOOL_HINT}`,
   };
 
   // Prefer task-defined semantic instructions over hard-coded step map.
@@ -678,6 +680,24 @@ function buildStepMessage(envelope, upstreamArtifacts) {
     lines.push('');
   }
 
+  // Coding standards from skill files
+  const mgmt = require('./management');
+  const skillLines = mgmt.buildSkillContextSection();
+  if (skillLines.length > 0) lines.push(...skillLines);
+
+  // Completion criteria — prevent premature "done"
+  const completionLines = mgmt.buildCompletionCriteriaSection();
+  if (completionLines.length > 0) lines.push(...completionLines);
+
+  // Preflight lessons (previously missing from step pipeline)
+  if (board && task) {
+    const preflight = mgmt.buildPreflightSection(board, task);
+    if (preflight.lines.length > 0) {
+      lines.push('');
+      lines.push(...preflight.lines);
+    }
+  }
+
   if (envelope.retry_context) {
     lines.push('', '\u26a0 RETRY — this step previously failed:');
     lines.push(`  Attempt: ${envelope.retry_context.attempt}`);
@@ -693,7 +713,6 @@ function buildStepMessage(envelope, upstreamArtifacts) {
   }
 
   // Protected edda decisions — prevent agents from reverting critical fixes
-  const mgmt = require('./management');
   const protectedLines = mgmt.buildProtectedDecisionsSection();
   if (protectedLines.length > 0) {
     lines.push(...protectedLines);


### PR DESCRIPTION
## Summary

- **buildSkillContextSection()**: 從 `engineer-playbook` 和 `blackboard-basics` 萃取關鍵 coding standards，注入 dispatch message（有 hardcoded fallback）
- **buildCompletionCriteriaSection()**: 5 點 checklist 防止 agent 提前宣告完成
- **STEP_SKILL_MAP 修正**: 從 `Execute /issue-plan 202` 改成 `Use the skill tool to load the "issue-plan" skill`，明確引導 agent 使用 Skill tool
- **buildStepMessage 補上 preflight lessons**: 之前 step pipeline 完全沒有注入 lessons
- 兩個 builder 都注入新 sections: `buildGenericDispatchMessage` (legacy) + `buildStepMessage` (step pipeline)

## Root Cause

opencode 的 system prompt 不提 skill，LLM 只從 tool list 裡的 Skill tool 描述發現 skills。舊的 `Execute /issue-plan 202` 被模型當成一般文字指令，直接用 bash 自己做而不是呼叫 Skill tool。

## Test plan

- [x] `node -c server/management.js` — syntax OK
- [x] `node -c server/step-worker.js` — syntax OK
- [x] `node server/test-step-schema.js` — 29/29 passed
- [x] `node server/test-bridge.js` — 18/20 passed (2 failures pre-existing)
- [x] Verified generic dispatch message contains new sections
- [x] Verified skill context + completion criteria sections output correctly
- [ ] Live dispatch test with Gemini 3.1 Pro to verify Skill tool usage

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)