### PR TITLE
feat(controls): configurable step timeout with sensible defaults (GH-216)

### DIFF
--- a/index.html
+++ b/index.html
@@ -731,15 +731,32 @@
         </div>
         <div class="row" style="margin-top:6px;">
           <div>
-            <label>Timeout (sec)</label>
-            <input type="number" id="ctrl-timeout" min="30" max="600" value="180" style="width:100%;" />
+            <label>Plan Timeout (s)</label>
+            <input type="number" id="ctrl-timeout-plan" min="30" max="3600" value="300" style="width:100%;" />
+          </div>
+          <div>
+            <label>Implement Timeout (s)</label>
+            <input type="number" id="ctrl-timeout-implement" min="30" max="3600" value="600" style="width:100%;" />
+          </div>
+        </div>
+        <div class="row" style="margin-top:6px;">
+          <div>
+            <label>Review Timeout (s)</label>
+            <input type="number" id="ctrl-timeout-review" min="30" max="3600" value="300" style="width:100%;" />
           </div>
           <div>
             <label>Review Agent</label>
             <input type="text" id="ctrl-agent" value="engineer_lite" style="width:100%;" />
           </div>
         </div>
+        <div class="row" style="margin-top:6px;">
+          <div>
+            <label>LLM Review Timeout (s)</label>
+            <input type="number" id="ctrl-timeout" min="30" max="600" value="180" style="width:100%;" />
+          </div>
+        </div>
         <button class="secondary" id="save-controls-btn" style="margin-top:8px; width:100%;">儲存 Controls</button>
+
       </div>
 
       <hr style="border-color:#2a3862; opacity:.5; margin:14px 0;" />
@@ -962,6 +979,11 @@
           el('ctrl-max-attempts').value = ctrl.max_review_attempts || 3;
           el('ctrl-timeout').value = ctrl.review_timeout_sec || 180;
           el('ctrl-agent').value = ctrl.review_agent || 'engineer_lite';
+          if (ctrl.default_step_timeout_sec) {
+            if (ctrl.default_step_timeout_sec.plan) el('ctrl-timeout-plan').value = ctrl.default_step_timeout_sec.plan;
+            if (ctrl.default_step_timeout_sec.implement) el('ctrl-timeout-implement').value = ctrl.default_step_timeout_sec.implement;
+            if (ctrl.default_step_timeout_sec.review) el('ctrl-timeout-review').value = ctrl.default_step_timeout_sec.review;
+          }
         }
       } catch {}
     }
@@ -975,6 +997,11 @@
       if (ctrl.max_review_attempts !== undefined) el('ctrl-max-attempts').value = ctrl.max_review_attempts;
       if (ctrl.review_timeout_sec !== undefined) el('ctrl-timeout').value = ctrl.review_timeout_sec;
       if (ctrl.review_agent) el('ctrl-agent').value = ctrl.review_agent;
+      if (ctrl.default_step_timeout_sec) {
+        if (ctrl.default_step_timeout_sec.plan) el('ctrl-timeout-plan').value = ctrl.default_step_timeout_sec.plan;
+        if (ctrl.default_step_timeout_sec.implement) el('ctrl-timeout-implement').value = ctrl.default_step_timeout_sec.implement;
+        if (ctrl.default_step_timeout_sec.review) el('ctrl-timeout-review').value = ctrl.default_step_timeout_sec.review;
+      }
     }
 
     async function saveControls() {
@@ -986,10 +1013,16 @@
         max_review_attempts: Number(el('ctrl-max-attempts').value),
         review_timeout_sec: Number(el('ctrl-timeout').value),
         review_agent: el('ctrl-agent').value.trim(),
+        default_step_timeout_sec: {
+          plan: Number(el('ctrl-timeout-plan').value),
+          implement: Number(el('ctrl-timeout-implement').value),
+          review: Number(el('ctrl-timeout-review').value),
+        }
       };
       await post('/api/controls', payload);
       await loadBoard();
     }
+
 
     // Task Board rendering logic
     function renderTaskBoard() {

--- a/server/context-compiler.js
+++ b/server/context-compiler.js
@@ -83,8 +83,9 @@ function buildEnvelope(decision, runState, deps) {
     budget_remaining: budgetRemaining,
     retry_policy: targetStep.retry_policy,
     idempotency_key: idempotencyKey,
-    timeout_ms: targetStep.retry_policy?.timeout_ms || 300_000,
+    timeout_ms: targetStep.retry_policy?.timeout_ms || (runState.controls?.default_step_timeout_sec?.[stepType] * 1000) || 300_000,
     model_hint: null,
+
     contract: task.contract || null,
   };
 

--- a/server/kernel.js
+++ b/server/kernel.js
@@ -87,8 +87,9 @@ function createKernel(deps) {
     }
 
     // Route
-    const runState = { task, steps: task.steps, run_id: step.run_id, budget: task.budget };
+    const runState = { task, steps: task.steps, run_id: step.run_id, budget: task.budget, controls: mgmt.getControls(board) };
     const decision = routeEngine.decideNext(agentOutput, runState);
+
 
     // Log decision
     helpers.appendLog({
@@ -162,7 +163,8 @@ function createKernel(deps) {
           console.log(`[kernel] revision: ${sourceStep.step_id} → ${targetStep.step_id} (cycle ${latestTask._revisionCounts[targetStepId]})`);
         }
 
-        const freshRunState = { task: latestTask, steps: latestTask.steps, run_id: runState.run_id, budget: latestTask.budget };
+        const freshRunState = { task: latestTask, steps: latestTask.steps, run_id: runState.run_id, budget: latestTask.budget, controls: mgmt.getControls(latestBoard) };
+
         const revEnvelope = contextCompiler.buildEnvelope(decision, freshRunState, deps);
         if (revEnvelope && targetStep) {
           artifactStore.writeArtifact(revEnvelope.run_id, revEnvelope.step_id, 'input', revEnvelope);

--- a/server/management.js
+++ b/server/management.js
@@ -19,7 +19,13 @@ const DEFAULT_CONTROLS = {
   review_timeout_sec: 180,
   review_agent: 'engineer_lite',
   auto_apply_insights: true,
+  default_step_timeout_sec: {
+    plan: 300,
+    implement: 600,
+    review: 300,
+  },
   use_step_pipeline: false,       // when true, tryAutoDispatch creates steps instead of legacy single-shot dispatch
+
   telemetry_enabled: true,
   usage_limits: null,            // { dispatches_per_month, runtime_sec_per_month, tokens_per_month }
   usage_alert_threshold: 0.8,    // Alert when usage > 80% of limit

--- a/server/routes/controls.js
+++ b/server/routes/controls.js
@@ -40,7 +40,17 @@ module.exports = function controlsRoutes(req, res, helpers, deps) {
             else if (key === 'usage_alert_threshold' && Number.isFinite(val)) board.controls[key] = Math.max(0, Math.min(1, val));
             else if (key === 'max_concurrent_tasks' && Number.isFinite(val)) board.controls[key] = Math.max(1, Math.min(10, val));
             else if (key === 'target_repo' && (val === null || typeof val === 'string')) board.controls[key] = val ? val.trim() : null;
+            else if (key === 'default_step_timeout_sec' && typeof val === 'object' && val !== null) {
+              const cleaned = {};
+              for (const [type, sec] of Object.entries(val)) {
+                if (Number.isFinite(sec)) {
+                  cleaned[type] = Math.max(30, Math.min(3600, sec));
+                }
+              }
+              board.controls[key] = cleaned;
+            }
           }
+
         }
         helpers.writeBoard(board);
         helpers.appendLog({ ts: helpers.nowIso(), event: 'controls_updated', controls: board.controls });

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -212,8 +212,9 @@ function dispatchTask(task, board, deps, helpers, opts = {}) {
     if (board.signals.length > 500) board.signals = board.signals.slice(-500);
 
     const firstStep = task.steps[0];
-    const runState = { task, steps: task.steps, run_id: runId, budget: task.budget };
+    const runState = { task, steps: task.steps, run_id: runId, budget: task.budget, controls: mgmt.getControls(board) };
     const decision = { action: 'next_step', next_step: { step_id: firstStep.step_id, step_type: firstStep.type } };
+
     const envelope = deps.contextCompiler.buildEnvelope(decision, runState, deps);
 
     if (envelope) {
@@ -1168,7 +1169,8 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
           try {
             const currentBoard = helpers.readBoard();
             const currentTask = (currentBoard.taskPlan?.tasks || []).find(t => t.id === taskId);
-            const runState = { task: currentTask, steps: currentTask.steps, run_id: step.run_id, budget: currentTask.budget };
+            const runState = { task: currentTask, steps: currentTask.steps, run_id: step.run_id, budget: currentTask.budget, controls: mgmt.getControls(currentBoard) };
+
             const decision = { action: 'next_step', next_step: { step_id: step.step_id, step_type: step.type } };
             const envelope = deps.contextCompiler.buildEnvelope(decision, runState, deps);
             if (!envelope) throw new Error(`Cannot build envelope for ${step.step_id}`);

--- a/server/server.js
+++ b/server/server.js
@@ -214,7 +214,13 @@ bb.ensureBoardExists(ctx, {
     review_timeout_sec: 180,
     review_agent: 'engineer_lite',
     auto_apply_insights: true,
+    default_step_timeout_sec: {
+      plan: 300,
+      implement: 600,
+      review: 300,
+    },
     cycle_stall_timeout_hours: 4,
+
   },
 });
 
@@ -269,8 +275,9 @@ const retryPoller = setInterval(() => {
         }
         if (step.state === 'queued' && step.attempt > 0 && step.scheduled_at && step.scheduled_at <= now) {
           console.log(`[retry-poller] re-dispatching ${step.step_id} (attempt ${step.attempt})`);
-          const runState = { task, steps: task.steps, run_id: step.run_id, budget: task.budget };
+          const runState = { task, steps: task.steps, run_id: step.run_id, budget: task.budget, controls: mgmt.getControls(board) };
           const decision = { action: 'next_step', next_step: { step_id: step.step_id, step_type: step.type } };
+
           const envelope = deps.contextCompiler.buildEnvelope(decision, runState, deps);
           if (!envelope) continue;
           deps.artifactStore.writeArtifact(envelope.run_id, envelope.step_id, 'input', envelope);

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -36,8 +36,11 @@ function createStepWorker(deps) {
     if (!task) throw new Error(`Task ${envelope.task_id} not found`);
 
     // 1. Build dispatch plan — compute timeout once, share between lock and runtime
-    const timeoutMs = envelope.timeout_ms || 300_000;
+    const controls = mgmt.getControls(board);
+    const typeDefaultSec = controls.default_step_timeout_sec?.[envelope.step_type] || 300;
+    const timeoutMs = envelope.timeout_ms || (typeDefaultSec * 1000);
     const timeoutSec = Math.ceil(timeoutMs / 1000);
+
     const plan = mgmt.buildDispatchPlan(board, task, {
       mode: 'dispatch',
       timeoutSec,

--- a/server/test-context-compiler.js
+++ b/server/test-context-compiler.js
@@ -139,7 +139,35 @@ test('buildEnvelope returns null for null steps', () => {
   assert.strictEqual(contextCompiler.buildEnvelope(decision, runState, { artifactStore, stepSchema }), null);
 });
 
+test('buildEnvelope uses per-step-type timeout from controls', () => {
+  const decision = { action: 'next_step', next_step: { step_id: 'T-1:plan', step_type: 'plan' } };
+  const steps = [{ step_id: 'T-1:plan', type: 'plan', state: 'queued', run_id: testRunId, attempt: 0 }];
+  const runState = {
+    task: { id: 'T-1' },
+    steps,
+    run_id: testRunId,
+    controls: { default_step_timeout_sec: { plan: 123 } }
+  };
+  const deps = { artifactStore, stepSchema };
+
+  const env = contextCompiler.buildEnvelope(decision, runState, deps);
+  assert.strictEqual(env.timeout_ms, 123000);
+
+  // Check fallback when step type missing in controls
+  const decision2 = { action: 'next_step', next_step: { step_id: 'T-1:other', step_type: 'other' } };
+  const steps2 = [{ step_id: 'T-1:other', type: 'other', state: 'queued', run_id: testRunId, attempt: 0 }];
+  const runState2 = {
+    task: { id: 'T-1' },
+    steps: steps2,
+    run_id: testRunId,
+    controls: { default_step_timeout_sec: { plan: 123 } }
+  };
+  const env2 = contextCompiler.buildEnvelope(decision2, runState2, deps);
+  assert.strictEqual(env2.timeout_ms, 300000); // hardcoded fallback
+});
+
 // Cleanup
+
 try {
   fs.rmSync(path.join(artifactStore.ARTIFACT_DIR, testRunId), { recursive: true, force: true });
 } catch {}

--- a/server/test-step-worker.js
+++ b/server/test-step-worker.js
@@ -317,7 +317,49 @@ function createMockEnvelope(overrides = {}) {
     assert.strictEqual(targets[0].step_id, 'T-B1:impl');
   });
 
+  // Test 12: executeStep uses per-step-type defaults for timeout
+  await test('executeStep uses per-step-type defaults for timeout', async () => {
+    let capturedPlan = null;
+    const mockRt = createMockRuntime({
+      dispatch: async (plan) => {
+        capturedPlan = plan;
+        return { code: 0, stdout: '', stderr: '', parsed: {} };
+      },
+    });
+    const deps = {
+      artifactStore, stepSchema, mgmt,
+      getRuntime: () => mockRt,
+      kernel: null,
+    };
+    const worker = createStepWorker(deps);
+
+    const board = createMockBoard();
+    // Set custom defaults in board
+    board.controls.default_step_timeout_sec = { plan: 123, implement: 456 };
+    const helpers = createMockHelpers(board);
+
+    // 1. Check 'plan' step
+    const planStep = currentBoard.taskPlan.tasks[0].steps[0];
+    stepSchema.transitionStep(planStep, 'running');
+    const envelopePlan = createMockEnvelope({ step_type: 'plan', timeout_ms: null });
+    await worker.executeStep(envelopePlan, currentBoard, helpers);
+    assert.strictEqual(capturedPlan.timeoutSec, 123);
+
+    // 2. Check 'implement' step
+    const implStep = currentBoard.taskPlan.tasks[0].steps[1];
+    stepSchema.transitionStep(implStep, 'running');
+    const envelopeImpl = createMockEnvelope({ step_id: 'T-W1:impl', step_type: 'implement', timeout_ms: null });
+    await worker.executeStep(envelopeImpl, currentBoard, helpers);
+    assert.strictEqual(capturedPlan.timeoutSec, 456);
+
+    // 3. Check explicit timeout_ms in envelope still takes precedence
+    const envelopeExplicit = createMockEnvelope({ step_id: 'T-W1:explicit', step_type: 'plan', timeout_ms: 99000 });
+    await worker.executeStep(envelopeExplicit, currentBoard, helpers);
+    assert.strictEqual(capturedPlan.timeoutSec, 99);
+  });
+
   // Cleanup
+
   try {
     fs.rmSync(path.join(artifactStore.ARTIFACT_DIR, testRunId), { recursive: true, force: true });
   } catch {}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -252,9 +252,11 @@ export interface Controls {
   review_timeout_sec: number;
   review_agent: string;
   auto_apply_insights: boolean;
+  default_step_timeout_sec?: Record<string, number>;
   dispatch_hints?: DispatchHint[];
   preferred_runtime?: string;
 }
+
 
 export interface DispatchHint {
   [key: string]: unknown;


### PR DESCRIPTION
## Summary
- Added `default_step_timeout_sec` mapping to `board.controls` (`plan`, `implement`, `review`).
- `context-compiler.js` looks up `default_step_timeout_sec[step.type]` when building envelope.
- Updates defaults to be 600s for implement, 300s for plan/review/fallback.
- Integrated into `step-worker.js` and `management.js` to share timeout configurations.
- Added GUI inputs for step-specific timeouts in `index.html`.

Closes #216.