### PR TITLE
fix(lifecycle): worktree cleanup on merge, budget reset on dispatch

### DIFF
--- a/server/kernel.js
+++ b/server/kernel.js
@@ -30,12 +30,27 @@ function createKernel(deps) {
   function cleanupWorktree(task, taskId, board) {
     if (!task?.worktreeDir) return;
     const repoRoot = resolveRepoRoot(task, board) || defaultRepoRoot;
-    try {
-      worktreeHelper.removeWorktree(repoRoot, taskId);
-      console.log(`[kernel] worktree cleaned up for ${taskId}`);
-    } catch (err) {
-      console.error(`[kernel] worktree cleanup failed for ${taskId}:`, err.message);
-    }
+
+    // Delay cleanup to let the runtime process fully exit and release file handles.
+    // On Windows, opencode may still hold locks when the kernel receives step_completed.
+    const CLEANUP_DELAY_MS = 5000;
+    setTimeout(() => {
+      try {
+        worktreeHelper.removeWorktree(repoRoot, taskId);
+        console.log(`[kernel] worktree cleaned up for ${taskId}`);
+      } catch (err) {
+        console.error(`[kernel] worktree cleanup failed for ${taskId}:`, err.message);
+        // Schedule one more retry after a longer delay
+        setTimeout(() => {
+          try {
+            worktreeHelper.removeWorktree(repoRoot, taskId);
+            console.log(`[kernel] worktree cleaned up for ${taskId} (retry)`);
+          } catch (err2) {
+            console.error(`[kernel] worktree cleanup retry failed for ${taskId}:`, err2.message);
+          }
+        }, 15000);
+      }
+    }, CLEANUP_DELAY_MS);
   }
 
   /**
@@ -298,7 +313,30 @@ function createKernel(deps) {
           // Step pipeline includes review as step[3] — all steps succeeded means approved
           latestTask.status = 'approved';
           latestTask.completedAt = helpers.nowIso();
-          cleanupWorktree(latestTask, taskId, latestBoard);
+          // Worktree stays alive — branch is needed until PR is merged or closed.
+          // Primary cleanup: routes/github.js on pr_merged / pr_closed webhook.
+          // Fallback: if no webhook fires within 30 min (dogfood / no webhook configured),
+          // clean up anyway. Remote branch + PR still exist; only local worktree removed.
+          if (latestTask.worktreeDir) {
+            const fallbackTaskId = taskId;
+            const fallbackTask = latestTask;
+            const fallbackBoard = latestBoard;
+            setTimeout(() => {
+              // Re-read board to check if webhook already cleaned up
+              try {
+                const freshBoard = helpers.readBoard();
+                const freshTask = (freshBoard.taskPlan?.tasks || []).find(t => t.id === fallbackTaskId);
+                if (freshTask?.worktreeDir) {
+                  cleanupWorktree(freshTask, fallbackTaskId, freshBoard);
+                  freshTask.worktreeDir = null;
+                  freshTask.worktreeBranch = null;
+                  helpers.writeBoard(freshBoard);
+                }
+              } catch (err) {
+                console.error(`[kernel] fallback worktree cleanup failed for ${fallbackTaskId}:`, err.message);
+              }
+            }, 30 * 60 * 1000); // 30 minutes
+          }
           // Preserve payload from last step's artifact for downstream access
           const lastStepOutput = artifactStore.readArtifact(step.run_id, stepId, 'output');
           latestTask.result = {

--- a/server/route-engine.js
+++ b/server/route-engine.js
@@ -22,7 +22,7 @@ const FAILURE_MODES = {
 
 const BUDGET_DEFAULTS = {
   max_llm_calls: 50,       // was 12 — too low for 3-step pipeline with retries
-  max_tokens: 500_000,     // was 40000 — single plan step can use 20K tokens
+  max_tokens: 2_000_000,   // large-context models (Gemini) use 130K+ per tool call; 500K too tight for 3-step pipeline
   max_wall_clock_ms: 1_800_000,  // 30 min (was 20 min)
   max_steps: 20,
 };

--- a/server/routes/github.js
+++ b/server/routes/github.js
@@ -21,6 +21,9 @@
  */
 const bb = require('../blackboard-server');
 const { json } = bb;
+const worktreeHelper = require('../worktree');
+const { resolveRepoRoot } = require('../repo-resolver');
+const path = require('path');
 
 module.exports = function githubRoutes(req, res, helpers, deps) {
   const { vault, githubApi, githubIntegration, mgmt, push, jiraIntegration, PUSH_TOKENS_PATH } = deps;
@@ -103,6 +106,24 @@ module.exports = function githubRoutes(req, res, helpers, deps) {
                 outcome: result.outcome,
                 source: 'github-webhook',
               });
+
+              // Worktree cleanup — branch no longer needed after PR merged/closed
+              if (task.worktreeDir) {
+                const repoRoot = resolveRepoRoot(task, board) || path.resolve(__dirname, '..');
+                const cleanTaskId = result.taskId;
+                // Clear worktreeDir immediately so kernel fallback timer won't double-clean
+                task.worktreeDir = null;
+                task.worktreeBranch = null;
+                helpers.writeBoard(board);
+                setTimeout(() => {
+                  try {
+                    worktreeHelper.removeWorktree(repoRoot, cleanTaskId);
+                    console.log(`[github-webhook] worktree cleaned up for ${cleanTaskId} (${result.outcome})`);
+                  } catch (err) {
+                    console.error(`[github-webhook] worktree cleanup failed for ${cleanTaskId}:`, err.message);
+                  }
+                }, 3000);
+              }
 
               // Jira notification (fire-and-forget)
               if (jiraIntegration?.isEnabled(board)) {

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -199,9 +199,9 @@ function dispatchTask(task, board, deps, helpers, opts = {}) {
     task.history.push({ ts: helpers.nowIso(), status: 'in_progress', by: source, runtime: 'step-pipeline' });
     if (board.taskPlan) board.taskPlan.phase = 'executing';
 
-    if (!task.budget) {
-      task.budget = { limits: { ...routeEngine.BUDGET_DEFAULTS }, used: { llm_calls: 0, tokens: 0, wall_clock_ms: 0, steps: 0 } };
-    }
+    // Always reset budget on (re-)dispatch — previous run's usage must not carry over
+    task.budget = { limits: { ...routeEngine.BUDGET_DEFAULTS, ...task.budget?.limits }, used: { llm_calls: 0, tokens: 0, wall_clock_ms: 0, steps: 0 } };
+
 
     mgmt.ensureEvolutionFields(board);
     board.signals.push({

--- a/server/step-schema.js
+++ b/server/step-schema.js
@@ -10,14 +10,15 @@ const crypto = require('crypto');
 
 const STEP_TYPES = ['plan', 'implement', 'test', 'review'];
 
-const STEP_STATES = ['queued', 'running', 'succeeded', 'failed', 'dead'];
+const STEP_STATES = ['queued', 'running', 'succeeded', 'failed', 'dead', 'cancelled'];
 
 const ALLOWED_STEP_TRANSITIONS = {
   queued:    ['running'],
-  running:   ['succeeded', 'failed'],
+  running:   ['succeeded', 'failed', 'cancelled'],
   failed:    ['queued', 'dead'],       // queued = retry, dead = give up
   succeeded: [],
   dead:      [],
+  cancelled: [],
 };
 
 const DEFAULT_RETRY_POLICY = {
@@ -95,6 +96,13 @@ function transitionStep(step, newState, extra = {}) {
       step.scheduled_at = new Date(Date.now() + delay).toISOString();
       step.state = 'queued';   // auto-requeue for retry
     }
+    step.locked_by = null;
+    step.lock_expires_at = null;
+  }
+
+  if (newState === 'cancelled') {
+    step.completed_at = new Date().toISOString();
+    step.error = extra.error || 'step cancelled';
     step.locked_by = null;
     step.lock_expires_at = null;
   }

--- a/server/test-bridge.js
+++ b/server/test-bridge.js
@@ -143,8 +143,8 @@ function createFullDeps(runtimeOverrides = {}) {
     const t = currentBoard.taskPlan.tasks[0];
     t.steps = mgmt.generateStepsForTask(t, runId);
 
-    assert.strictEqual(t.steps.length, 4);
-    assert.deepStrictEqual(t.steps.map(s => s.type), ['plan', 'implement', 'test', 'review']);
+    assert.strictEqual(t.steps.length, mgmt.DEFAULT_STEP_PIPELINE.length);
+    assert.deepStrictEqual(t.steps.map(s => s.type), mgmt.DEFAULT_STEP_PIPELINE.map(e => typeof e === 'string' ? e : e.type));
     assert.ok(t.steps.every(s => s.state === 'queued'));
 
     // Build envelope for step[0]
@@ -226,14 +226,14 @@ function createFullDeps(runtimeOverrides = {}) {
     t1.budget = { limits: { ...require('./route-engine').BUDGET_DEFAULTS }, used: { llm_calls: 0, tokens: 0, wall_clock_ms: 0, steps: 0 } };
 
     // Manually succeed all steps except last (review)
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < t1.steps.length - 1; i++) {
       stepSchema.transitionStep(t1.steps[i], 'running');
       stepSchema.transitionStep(t1.steps[i], 'succeeded');
       artifactStore.writeArtifact(runId, t1.steps[i].step_id, 'output', { status: 'succeeded', summary: 'done', tokens_used: 100 });
     }
 
     // Review step: run through kernel which should mark done
-    const reviewStep = t1.steps[3];
+    const reviewStep = t1.steps[t1.steps.length - 1];
     stepSchema.transitionStep(reviewStep, 'running');
     stepSchema.transitionStep(reviewStep, 'succeeded');
     artifactStore.writeArtifact(runId, reviewStep.step_id, 'output', { status: 'succeeded', summary: 'review passed', tokens_used: 100 });


### PR DESCRIPTION
## Summary
- Worktree stays alive after pipeline `done` — only deleted on PR merge/close webhook or 30-min fallback timer
- Budget.used reset on every dispatch (was accumulating across re-dispatches → false `budget_exceeded` dead_letter)
- max_tokens 500K → 2M for large-context models (Gemini uses 130K+ per tool call)
- Worktree removal delayed 5s + 15s retry to handle Windows file locks
- Fix 2 broken tests (pipeline 4→3 steps)

## Test plan
- [x] `node server/test-bridge.js` — 20 passed, 0 failed (was 18/2)
- [x] `node server/test-step-schema.js` — 29 passed, 0 failed
- [ ] End-to-end: dispatch task, verify worktree persists after `done`, verify cleanup on PR merge webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)