### PR TITLE
feat(monitoring): add GET /api/status with field groups (GH-240)

### DIFF
--- a/server/routes/status.js
+++ b/server/routes/status.js
@@ -1,0 +1,171 @@
+/**
+ * routes/status.js — Status Aggregation API
+ *
+ * GET /api/status — returns core only (default)
+ * GET /api/status?fields=core,steps,errors,metrics,events — specific groups
+ * GET /api/status?fields=all — all groups
+ *
+ * Field Groups:
+ *   - core: summary + task list
+ *   - steps: all step details
+ *   - errors: failed signals + failed steps
+ *   - metrics: aggregated budget usage
+ *   - events: recent signals
+ */
+const os = require('os');
+const bb = require('../blackboard-server');
+const { json } = bb;
+
+function formatAge(ms) {
+  if (ms == null) return null;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+function buildCore(board) {
+  const tasks = board.taskPlan?.tasks || [];
+  const summary = {
+    active: tasks.filter(t => t.status === 'in_progress').length,
+    succeeded: tasks.filter(t => ['completed', 'approved'].includes(t.status)).length,
+    failed: tasks.filter(t => ['blocked', 'needs_revision'].includes(t.status)).length,
+  };
+  
+  const taskList = tasks.map(task => {
+    const runningStep = (task.steps || []).find(s => s.state === 'running');
+    const completedSteps = (task.steps || []).filter(s => s.state === 'succeeded').length;
+    const totalSteps = (task.steps || []).length;
+    const startedAt = task.startedAt || task.history?.[0]?.ts;
+    const ageMs = startedAt ? Date.now() - new Date(startedAt).getTime() : null;
+    
+    return {
+      id: task.id,
+      title: task.title || '',
+      status: task.status,
+      step: runningStep?.type || null,
+      progress: totalSteps > 0 ? `${completedSteps}/${totalSteps}` : null,
+      age: formatAge(ageMs),
+    };
+  });
+  
+  return { summary, tasks: taskList };
+}
+
+function buildSteps(board) {
+  const steps = [];
+  for (const task of (board.taskPlan?.tasks || [])) {
+    for (const step of (task.steps || [])) {
+      steps.push({
+        task_id: task.id,
+        step_id: step.step_id,
+        type: step.type,
+        state: step.state,
+        attempt: step.attempt || 0,
+        duration_ms: step.duration_ms || null,
+      });
+    }
+  }
+  return steps;
+}
+
+function buildErrors(board, helpers) {
+  const errors = [];
+  
+  // From signals
+  for (const sig of (board.signals || []).filter(s => s.type === 'error')) {
+    errors.push({
+      ts: sig.ts,
+      type: 'signal',
+      task_id: sig.data?.taskId || null,
+      step_id: null,
+      message: sig.content,
+    });
+  }
+  
+  // From failed/dead steps
+  for (const task of (board.taskPlan?.tasks || [])) {
+    for (const step of (task.steps || []).filter(s => s.state === 'failed' || s.state === 'dead')) {
+      errors.push({
+        ts: helpers.nowIso(), // Step doesn't have timestamp, use current time
+        type: 'step',
+        task_id: task.id,
+        step_id: step.step_id,
+        message: `Step ${step.step_id} ${step.state}`,
+      });
+    }
+  }
+  
+  return errors.sort((a, b) => b.ts.localeCompare(a.ts)).slice(0, 50);
+}
+
+function buildMetrics(board) {
+  const metrics = {
+    total_tokens: 0,
+    total_wall_clock_ms: 0,
+    total_llm_calls: 0,
+    total_steps: 0,
+  };
+  
+  for (const task of (board.taskPlan?.tasks || [])) {
+    const used = task.budget?.used || {};
+    metrics.total_tokens += used.tokens || 0;
+    metrics.total_wall_clock_ms += used.wall_clock_ms || 0;
+    metrics.total_llm_calls += used.llm_calls || 0;
+    metrics.total_steps += used.steps || 0;
+  }
+  
+  return metrics;
+}
+
+function buildEvents(board) {
+  return (board.signals || [])
+    .slice(-50)
+    .reverse()
+    .map(sig => ({
+      ts: sig.ts,
+      type: sig.type,
+      content: sig.content,
+      refs: sig.refs || [],
+    }));
+}
+
+module.exports = function statusRoutes(req, res, helpers, deps) {
+  if (req.method !== 'GET') return false;
+  
+  const urlMatch = req.url.match(/^\/api\/status(\?|$)/);
+  if (!urlMatch) return false;
+  
+  try {
+    const url = new URL(req.url, 'http://localhost');
+    const fieldsParam = url.searchParams.get('fields') || 'core';
+    
+    const requestedFields = new Set(
+      fieldsParam === 'all'
+        ? ['core', 'steps', 'errors', 'metrics', 'events']
+        : fieldsParam.split(',').map(f => f.trim()).filter(Boolean)
+    );
+    
+    const board = helpers.readBoard();
+    const instance_id = process.env.KARVI_INSTANCE_ID || os.hostname();
+    
+    const response = {
+      instance_id,
+      ts: helpers.nowIso(),
+    };
+    
+    if (requestedFields.has('core')) response.core = buildCore(board);
+    if (requestedFields.has('steps')) response.steps = buildSteps(board);
+    if (requestedFields.has('errors')) response.errors = buildErrors(board, helpers);
+    if (requestedFields.has('metrics')) response.metrics = buildMetrics(board);
+    if (requestedFields.has('events')) response.events = buildEvents(board);
+    
+    return json(res, 200, response);
+  } catch (error) {
+    return json(res, 500, { error: error.message });
+  }
+};

--- a/server/server.js
+++ b/server/server.js
@@ -147,6 +147,7 @@ const jiraRoutes = require('./routes/jira');
 const villageRoutes = require('./routes/village');
 const projectsRoutes = require('./routes/projects');
 const tasksRoutes = require('./routes/tasks');
+const statusRoutes = require('./routes/status');
 
 // --- Route chain ---
 const routes = [
@@ -162,6 +163,7 @@ const routes = [
   villageRoutes,
   projectsRoutes,
   tasksRoutes,
+  statusRoutes,
 ];
 
 const { json } = bb;


### PR DESCRIPTION
## Summary

Implements `GET /api/status` endpoint with field groups for Village→Nation observability.

## Changes

- **New route**: `server/routes/status.js` (~170 lines)
  - Aggregates status data from board.json
  - Supports field groups: core, steps, errors, metrics, events
  - `instance_id` from `KARVI_INSTANCE_ID` env var or hostname
  
- **Modified**: `server/server.js`
  - Import and register statusRoutes

## API Usage

```bash
# Default (core only)
GET /api/status

# Specific field groups
GET /api/status?fields=core,steps
GET /api/status?fields=core,errors,metrics

# All field groups
GET /api/status?fields=all
```

## Field Groups

- **core** (default): summary + task list with status, progress, age
- **steps**: all step details across tasks
- **errors**: failed signals + failed/dead steps (last 50)
- **metrics**: aggregated budget usage (tokens, wall_clock_ms, llm_calls, steps)
- **events**: recent signals (last 50)

## Testing

- ✅ Syntax checks pass (`node -c`)
- ✅ Follows existing route patterns
- ✅ Zero external dependencies

## Related

Closes #240