### PR TITLE
feat(runtime): upgrade codex adapter with NDJSON streaming and step pipeline support (GH-244)

### DIFF
--- a/server/management.js
+++ b/server/management.js
@@ -954,8 +954,8 @@ function buildDispatchPlan(board, task, options = {}) {
   // Compute lesson matching once, pass to message builders
   const lessonResult = matchLessonsForTask(board, task);
 
-  // CLI-based runtimes (opencode, claude) need English prompts
-  const usesGenericMessage = runtimeHint === 'opencode' || runtimeHint === 'claude';
+  // CLI-based runtimes (opencode, claude, codex) need English prompts
+  const usesGenericMessage = runtimeHint === 'opencode' || runtimeHint === 'claude' || runtimeHint === 'codex';
 
   const message = mode === 'redispatch'
     ? buildRedispatchMessage(board, task, { lessonResult })
@@ -990,7 +990,7 @@ function buildDispatchPlan(board, task, options = {}) {
     userId,
     agentId: task.assignee,
     // @protected decision:dispatch.modelHint — AGENT_MODEL_MAP has OpenClaw IDs that CLI runtimes don't recognize; passing them causes silent failure
-    modelHint: (runtimeHint === 'claude' || runtimeHint === 'opencode') ? null : preferredModelFor(task.assignee),
+    modelHint: (runtimeHint === 'claude' || runtimeHint === 'opencode' || runtimeHint === 'codex') ? null : preferredModelFor(task.assignee),
     timeoutSec: options.timeoutSec || 300,
     sessionId: task.childSessionKey || null,
     message,

--- a/server/runtime-codex.js
+++ b/server/runtime-codex.js
@@ -1,91 +1,306 @@
-const { spawn } = require('child_process');
+/**
+ * runtime-codex.js — Codex CLI runtime adapter
+ *
+ * Dispatches tasks via `codex exec --json --full-auto`.
+ * NDJSON stream: thread.started → turn.started → item.* → turn.completed.
+ * Supports session resume (exec resume), model selection (-m),
+ * and working directory (-C).
+ *
+ * Ref: https://developers.openai.com/codex/noninteractive
+ */
+const { spawn, execSync } = require('child_process');
 const path = require('path');
+const fs = require('fs');
+const os = require('os');
 
 const DIR = __dirname;
-const CODEX_CMD = process.env.CODEX_CMD || 'codex';
+const STEP_RESULT_RE = /STEP_RESULT:\s*(\{.*\})/;
 
+/**
+ * Resolve the absolute path to codex executable.
+ * On Windows, npm packages install as .cmd shims — we must use that,
+ * not the POSIX shell script that `where` returns first.
+ */
+function resolveCodexPath() {
+  if (process.env.CODEX_CMD) return process.env.CODEX_CMD;
+
+  if (process.platform === 'win32') {
+    try {
+      const lines = execSync('where codex', { encoding: 'utf8', timeout: 5000 })
+        .trim().split(/\r?\n/);
+      const cmd = lines.find(l => l.trim().endsWith('.cmd'));
+      if (cmd && fs.existsSync(cmd.trim())) return cmd.trim();
+      const first = lines[0]?.trim();
+      if (first && fs.existsSync(first)) return first;
+    } catch {}
+  }
+
+  return 'codex';
+}
+
+const CODEX_EXE = resolveCodexPath();
+
+/**
+ * Kill an entire process tree.
+ */
+function killTree(pid) {
+  try {
+    if (process.platform === 'win32') {
+      execSync(`taskkill /PID ${pid} /T /F`, { stdio: 'ignore' });
+    } else {
+      process.kill(-pid, 'SIGKILL');
+    }
+  } catch {}
+}
+
+/**
+ * Dispatch a plan to Codex headless CLI.
+ *
+ * Uses --json for NDJSON stream events.
+ * Events: thread.started, turn.started, item.started, item.completed,
+ *         turn.completed, turn.failed, error.
+ * Prompt is piped via stdin (using '-') to avoid cmd.exe multi-line truncation.
+ * Inactivity timer resets on every event.
+ */
 function dispatch(plan) {
   return new Promise((resolve, reject) => {
-    let args;
+    const args = ['exec'];
 
     if (plan.sessionId) {
-      // Resume existing session
-      args = ['exec', 'resume', plan.sessionId];
-    } else {
-      // New session
-      args = ['exec'];
+      args.push('resume', plan.sessionId);
     }
 
     args.push('--full-auto', '--json');
 
-    if (plan.modelHint) args.push('-m', plan.modelHint);
+    const model = plan.modelHint || process.env.CODEX_MODEL || null;
+    if (model) args.push('-m', model);
 
     if (!plan.workingDir) {
       return reject(new Error(
         `[codex-rt] CRITICAL: workingDir is null for task ${plan.taskId}. ` +
-        `Cannot dispatch agent without target directory. ` +
-        `This indicates a bug in the dispatch chain.`
+        `Cannot dispatch agent without target directory.`
       ));
     }
     const workDir = plan.workingDir;
-    args.push('-C', workDir);
+    if (!plan.sessionId) args.push('-C', workDir);
 
-    if (plan.codexRole) {
-      args.push('-c', `agents.default.config_file=agents/${plan.codexRole}.toml`);
+    // '-' tells codex to read the prompt from stdin (avoids cmd.exe multi-line truncation)
+    args.push('-');
+
+    // Write dispatch message to temp file for debugging/inspection (deleted after settle)
+    const msgFile = path.join(os.tmpdir(), `karvi-dispatch-${Date.now()}.md`);
+    fs.writeFileSync(msgFile, plan.message, 'utf8');
+
+    const timeoutMs = (plan.timeoutSec || 300) * 1000;
+    console.log('[codex-rt] spawn:', CODEX_EXE);
+    console.log('[codex-rt] model:', model || '(default)');
+    console.log('[codex-rt] message length:', plan.message?.length || 0);
+    console.log('[codex-rt] message file:', msgFile);
+    console.log('[codex-rt] cwd:', workDir, 'timeout:', timeoutMs);
+
+    let lastHeartbeat = 0;
+    const HEARTBEAT_INTERVAL_MS = 60_000;
+    function heartbeat() {
+      if (!plan.onActivity) return;
+      const now = Date.now();
+      if (now - lastHeartbeat < HEARTBEAT_INTERVAL_MS) return;
+      lastHeartbeat = now;
+      try { plan.onActivity(); } catch {}
     }
 
-    args.push('--', plan.message);
+    const env = { ...process.env };
 
-    const child = spawn(CODEX_CMD, args, {
+    // Windows: .cmd shims must be invoked via cmd.exe
+    const spawnCmd = process.platform === 'win32' ? 'cmd.exe' : CODEX_EXE;
+    const spawnArgs = process.platform === 'win32'
+      ? ['/d', '/s', '/c', CODEX_EXE, ...args]
+      : args;
+
+    const child = spawn(spawnCmd, spawnArgs, {
       cwd: workDir,
+      env,
       windowsHide: true,
       shell: false,
-      timeout: (plan.timeoutSec || 180) * 1000,
+      stdio: ['pipe', 'pipe', 'pipe'],
     });
 
-    let stdout = '';
+    // Pipe message via stdin then close (codex reads prompt from stdin when '-' is used)
+    child.stdin.write(plan.message);
+    child.stdin.end();
+
     let stderr = '';
+    let settled = false;
+    let lineBuf = '';
+    let threadId = null;
+    let lastText = '';
+    let totalTokens = { input: 0, output: 0 };
+    let totalCost = 0;
+    let toolCallCount = 0;
+
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
-    child.stdout.on('data', c => (stdout += c));
-    child.stderr.on('data', c => (stderr += c));
 
-    child.on('error', err => reject(err));
-    child.on('close', code => {
-      if (code !== 0) {
-        return reject(new Error(stderr || stdout || `codex exited ${code}`));
-      }
+    const heartbeatInterval = setInterval(() => heartbeat(), HEARTBEAT_INTERVAL_MS);
 
-      let lastMessage = null;
-      for (const line of stdout.trim().split('\n')) {
-        try {
-          const ev = JSON.parse(line);
-          if (ev.type === 'message' || ev.message) lastMessage = ev;
-        } catch {}
-      }
+    function settle(err, result) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(inactivityTimer);
+      clearInterval(heartbeatInterval);
+      try { fs.unlinkSync(msgFile); } catch {}
+      if (err) reject(err); else resolve(result);
+    }
 
-      resolve({
-        code,
-        stdout,
+    let inactivityTimer = null;
+    function resetInactivityTimer() {
+      if (settled) return;
+      clearTimeout(inactivityTimer);
+      inactivityTimer = setTimeout(() => {
+        console.log('[codex-rt] idle for %ds, killing', Math.round(timeoutMs / 1000));
+        settle(new Error(`codex idle for ${Math.round(timeoutMs / 1000)}s`));
+        killTree(child.pid);
+      }, timeoutMs);
+    }
+    resetInactivityTimer();
+
+    function buildResult(text) {
+      return {
+        code: 0,
+        stdout: text || lastText || '',
         stderr,
-        parsed: lastMessage,
-        sessionId: lastMessage?.session_id || null,
-      });
+        parsed: {
+          result: text || lastText || null,
+          session_id: threadId,
+          input_tokens: totalTokens.input || null,
+          output_tokens: totalTokens.output || null,
+          total_cost: totalCost || null,
+        },
+      };
+    }
+
+    // NDJSON parsing — codex event types:
+    // thread.started, turn.started, turn.completed, turn.failed,
+    // item.started, item.completed, error
+    child.stdout.on('data', chunk => {
+      lineBuf += chunk;
+      resetInactivityTimer();
+      heartbeat();
+
+      const lines = lineBuf.split('\n');
+      lineBuf = lines.pop();
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let obj;
+        try { obj = JSON.parse(line); } catch { continue; }
+
+        // thread.started — extract thread/session ID
+        if (obj.type === 'thread.started' && obj.thread_id) {
+          threadId = obj.thread_id;
+        }
+
+        // item.completed with agent_message — accumulate text
+        if (obj.type === 'item.completed' && obj.item?.type === 'agent_message') {
+          const text = obj.item.text || '';
+          if (text) {
+            lastText += text;
+
+            const m = STEP_RESULT_RE.exec(lastText);
+            if (m) {
+              console.log('[codex-rt] STEP_RESULT detected');
+              settle(null, buildResult(lastText));
+              killTree(child.pid);
+              return;
+            }
+          }
+        }
+
+        // item.started — track tool/command usage for progress
+        if (obj.type === 'item.started' && obj.item) {
+          toolCallCount++;
+          if (plan.onProgress) {
+            try {
+              plan.onProgress({
+                type: 'tool_call',
+                tool_name: obj.item.command || obj.item.type || null,
+                tool_calls: toolCallCount,
+                tokens: { ...totalTokens },
+              });
+            } catch {}
+          }
+        }
+
+        // turn.completed — accumulate tokens/cost
+        if (obj.type === 'turn.completed') {
+          const usage = obj.usage || {};
+          totalTokens.input += usage.input_tokens || 0;
+          totalTokens.output += usage.output_tokens || 0;
+          if (obj.cost) totalCost += obj.cost;
+          console.log('[codex-rt] turn.completed: tokens=%j (cumulative: %j)',
+            usage, totalTokens);
+        }
+
+        // turn.failed — log but don't settle (codex may have more turns)
+        if (obj.type === 'turn.failed') {
+          console.log('[codex-rt] turn.failed:', JSON.stringify(obj).slice(0, 500));
+        }
+
+        // error event — log
+        if (obj.type === 'error') {
+          console.log('[codex-rt] error event:', JSON.stringify(obj).slice(0, 500));
+        }
+
+        // Debug: log unknown event types
+        if (!['thread.started', 'turn.started', 'turn.completed', 'turn.failed',
+              'item.started', 'item.completed', 'error'].includes(obj.type)) {
+          console.log('[codex-rt] event type=%s keys=%s', obj.type, Object.keys(obj).join(','));
+        }
+      }
+    });
+
+    child.stderr.on('data', chunk => {
+      stderr += chunk;
+      resetInactivityTimer();
+      heartbeat();
+      if (stderr.length <= 1000) {
+        console.log('[codex-rt] stderr:', chunk.slice(0, 200));
+      }
+    });
+
+    child.on('error', err => {
+      console.log('[codex-rt] spawn error:', err.message);
+      settle(err);
+    });
+
+    child.on('close', code => {
+      console.log('[codex-rt] close: code=%d settled=%s lastText=%d totalOut=%d',
+        code, settled, lastText.length, totalTokens.output);
+      if (settled) return;
+
+      if (code !== 0) {
+        settle(new Error(stderr || `codex exited ${code}`));
+        return;
+      }
+
+      if (lastText) {
+        settle(null, buildResult(lastText));
+        return;
+      }
+
+      // Fallback: codex completed with output tokens but no agent_message events captured
+      if (totalTokens.output > 0) {
+        console.log('[codex-rt] no text events but %d output tokens — settling as success', totalTokens.output);
+        settle(null, buildResult(`[agent completed: ${totalTokens.output} output tokens, ${toolCallCount} tool calls]`));
+        return;
+      }
+
+      settle(new Error('codex exited 0 but no output received'));
     });
   });
 }
 
 function extractReplyText(parsed, stdout) {
-  if (parsed?.message) return parsed.message;
-  if (parsed?.content) return parsed.content;
-
-  const lines = (stdout || '').trim().split('\n');
-  for (let i = lines.length - 1; i >= 0; i--) {
-    try {
-      const ev = JSON.parse(lines[i]);
-      if (ev.message || ev.content) return ev.message || ev.content;
-    } catch {}
-  }
+  if (parsed?.result) return parsed.result;
   return stdout?.slice(-2000) || '';
 }
 
@@ -93,22 +308,25 @@ function extractSessionId(parsed) {
   return parsed?.session_id || null;
 }
 
+function extractUsage(parsed, _stdout) {
+  if (!parsed) return null;
+  const inp = parsed.input_tokens ?? null;
+  const out = parsed.output_tokens ?? null;
+  const cost = parsed.total_cost ?? null;
+  if (inp == null && out == null && cost == null) return null;
+  return { inputTokens: inp, outputTokens: out, totalCost: cost };
+}
+
 function capabilities() {
   return {
     runtime: 'codex',
     supportsReview: false,
     supportsSessionResume: true,
-    supportsRoles: true,
-    supportsMultiAgent: true,
+    supportsModelSelection: true,
+    supportsBudgetLimit: false,
+    supportsToolRestriction: false,
+    supportsEffortLevel: false,
   };
-}
-
-/**
- * Extract token usage from codex output.
- * Codex CLI does not report token usage — returns null.
- */
-function extractUsage(parsed, stdout) {
-  return null;
 }
 
 module.exports = { dispatch, extractReplyText, extractSessionId, extractUsage, capabilities };


### PR DESCRIPTION
## Summary

Closes #244

重寫 `runtime-codex.js` 以匹配 `runtime-opencode.js` 的品質，讓 Codex CLI 可以穩定用於 step pipeline dispatch。

### 改動

**`server/runtime-codex.js`** (114 → 306 行)
- NDJSON streaming 解析（`thread.started`, `item.*`, `turn.completed` 事件）
- STEP_RESULT 即時偵測 + killTree
- Heartbeat / onActivity 回呼（60s 間隔，防止 lock 過期）
- Inactivity timeout（可配置，每次有輸出重置）
- onProgress callback（tool_call 事件追蹤）
- Stdin piping（`-` flag）避免 Windows cmd.exe 多行截斷
- Windows .cmd shim 路徑解析 + `cmd.exe /d /s /c` 包裹
- Token/cost 累積追蹤
- 調試用暫存檔（settle 後自動刪除）

**`server/management.js`** (2 處)
- modelHint 邏輯加入 `codex`（防止 AGENT_MODEL_MAP 的 OpenClaw ID 傳給 CLI）
- usesGenericMessage 加入 `codex`（使用英文 prompt）

### Codex CLI 事件格式對照

| opencode 事件 | codex 事件 | 用途 |
|--------------|-----------|------|
| `sessionID` | `thread.started.thread_id` | Session ID |
| `text` + `part.text` | `item.completed` + `item.agent_message` | 文字輸出 |
| `tool_call` + `part.name` | `item.started` + `item.command` | 進度追蹤 |
| `step_finish` + `tokens` | `turn.completed` + `usage` | Token 計量 |

### 切換方式

```bash
curl -X POST http://localhost:3461/api/controls \
  -H "Content-Type: application/json" \
  -d '{"preferred_runtime": "codex"}'
```

## Test plan

- [x] `node -c` 語法檢查通過
- [x] `test-runtime-contract.js` — 23/23 passed
- [x] `test-step-worker.js` — 23/23 passed
- [x] `test-reliability-guards.js` — 6/6 passed
- [x] Runtime contract validation — codex adapter passes all 5 required methods
- [ ] 實際 dispatch 測試（需要 CODEX_API_KEY）
