### PR TITLE
refactor(api): consolidate POST /api/project into POST /api/projects (GH-251)

### DIFF
--- a/server/docs/opencode-dispatch-guide.md
+++ b/server/docs/opencode-dispatch-guide.md
@@ -6,7 +6,7 @@
 
 ```
 Karvi Server (port 3461)
-  ├── POST /api/project       ← 建立 task（auto_dispatch 自動接手）
+  ├── POST /api/projects      ← 建立 task（auto_dispatch 自動接手）
   ├── POST /api/tasks/:id/dispatch  ← 手動 dispatch 單一 task
   │
   ├── tryAutoDispatch()        ← 自動流程
@@ -49,7 +49,8 @@ Karvi Server (port 3461)
 curl -s http://localhost:3461/api/controls | node -e "const d=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log('worktrees:', d.use_worktrees, 'auto_dispatch:', d.auto_dispatch, 'step_pipeline:', d.use_step_pipeline, 'auto_merge:', d.auto_merge_on_approve)"
 
 # 建立任務（auto_dispatch 自動接手）
-curl -X POST http://localhost:3461/api/project \
+# 注意：/api/project (singular) 仍可用但已 deprecated
+curl -X POST http://localhost:3461/api/projects \
   -H "Content-Type: application/json" \
   -d '{
     "title":"GH-XXX: 任務標題",

--- a/server/routes/projects.js
+++ b/server/routes/projects.js
@@ -1,24 +1,26 @@
 /**
  * routes/projects.js — Project Orchestrator API
  *
- * POST   /api/projects          — create project (batch of GH tasks with deps)
+ * POST   /api/projects          — create/add tasks (unified endpoint)
  * GET    /api/projects          — list all projects with progress
  * GET    /api/projects/:id      — single project with progress
  * POST   /api/projects/:id/pause  — pause project
  * POST   /api/projects/:id/resume — resume project
  */
+const fs = require('fs');
+const path = require('path');
 const bb = require('../blackboard-server');
 const { json } = bb;
 
 /**
- * Detect circular dependencies in a task graph.
- * @param {Array<{issue: number, depends: number[]}>} tasks
- * @returns {boolean} true if a cycle exists
+ * Detect circular dependencies using string task IDs.
+ * @param {Array<{id: string, depends: string[]}>} normalizedTasks
+ * @returns {boolean}
  */
-function hasCycle(tasks) {
+function hasCycle(normalizedTasks) {
   const adj = new Map();
-  for (const t of tasks) {
-    adj.set(t.issue, t.depends || []);
+  for (const t of normalizedTasks) {
+    adj.set(t.id, t.depends || []);
   }
   const visited = new Set();
   const inStack = new Set();
@@ -35,10 +37,53 @@ function hasCycle(tasks) {
     return false;
   }
 
-  for (const t of tasks) {
-    if (dfs(t.issue)) return true;
+  for (const t of normalizedTasks) {
+    if (dfs(t.id)) return true;
   }
   return false;
+}
+
+/**
+ * Normalize task entry — supports both legacy (issue-based) and unified (id-based) formats.
+ */
+function normalizeTask(entry, repo) {
+  if (entry.issue && typeof entry.issue === 'number') {
+    return {
+      id: `GH-${entry.issue}`,
+      title: entry.title || `Issue #${entry.issue}`,
+      assignee: entry.assignee || null,
+      depends: (entry.depends || []).map(d => typeof d === 'number' ? `GH-${d}` : d),
+      type: 'gh',
+      source: repo || null,
+      githubIssue: entry.issue,
+      description: entry.description || '',
+      spec: entry.spec || null,
+      skill: entry.skill || null,
+      estimate: entry.estimate || null,
+      target_repo: entry.target_repo || null,
+    };
+  }
+  if (entry.id && typeof entry.id === 'string') {
+    return {
+      id: entry.id,
+      title: entry.title || entry.id,
+      assignee: entry.assignee || null,
+      depends: entry.depends || [],
+      description: entry.description || '',
+      spec: entry.spec || null,
+      skill: entry.skill || null,
+      estimate: entry.estimate || null,
+      target_repo: entry.target_repo || null,
+    };
+  }
+  throw new Error(`task must have either 'issue' (number) or 'id' (string): ${JSON.stringify(entry)}`);
+}
+
+const SKILLS_NEEDING_BRIEF = new Set(['conversapix-storyboard']);
+
+function ensureBriefsDir(dataDir) {
+  const d = path.join(dataDir, 'briefs');
+  if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true });
 }
 
 /**
@@ -66,109 +111,166 @@ function computeProgress(board, project) {
 
 module.exports = function projectsRoutes(req, res, helpers, deps) {
   const { mgmt } = deps;
+  const DATA_DIR = path.resolve(__dirname, '..');
 
-  // POST /api/projects — create project
-  if (req.method === 'POST' && req.url === '/api/projects') {
+  // POST /api/projects (canonical) + POST /api/project (deprecated alias)
+  if (req.method === 'POST' && (req.url === '/api/projects' || req.url === '/api/project')) {
+    if (req.url === '/api/project') {
+      helpers.appendLog({ ts: helpers.nowIso(), event: 'deprecated_api', endpoint: '/api/project', message: 'Use POST /api/projects instead' });
+    }
     let body = '';
     req.on('data', c => (body += c));
     req.on('end', () => {
       try {
         const input = JSON.parse(body || '{}');
-        const { title, repo, concurrency, completionTrigger, tasks } = input;
+        const { title, repo, concurrency, completionTrigger, autoStart } = input;
+        const rawTasks = input.tasks;
 
-        // Validation
         if (!title || typeof title !== 'string') return json(res, 400, { error: 'title is required' });
-        if (!repo || typeof repo !== 'string') return json(res, 400, { error: 'repo is required' });
-        if (!Array.isArray(tasks) || tasks.length === 0) return json(res, 400, { error: 'tasks array is required and must not be empty' });
+        if (!Array.isArray(rawTasks) || rawTasks.length === 0) return json(res, 400, { error: 'tasks array is required and must not be empty' });
 
-        // Validate completion trigger
+        // Normalize tasks — supports both { issue } and { id } formats
+        const normalized = rawTasks.map(t => normalizeTask(t, repo));
+
+        // Validate: no duplicate IDs
+        const ids = new Set();
+        for (const t of normalized) {
+          if (ids.has(t.id)) return json(res, 400, { error: `duplicate task id: ${t.id}` });
+          ids.add(t.id);
+        }
+
+        // Validate completion trigger (only when creating a project entity)
         const trigger = completionTrigger || 'pr_merged';
-        if (trigger !== 'pr_merged' && trigger !== 'approved') {
+        if (repo && trigger !== 'pr_merged' && trigger !== 'approved') {
           return json(res, 400, { error: 'completionTrigger must be pr_merged or approved' });
         }
 
-        // Validate task entries
-        for (const entry of tasks) {
-          if (!entry.issue || typeof entry.issue !== 'number') {
-            return json(res, 400, { error: 'each task must have a numeric issue field' });
-          }
-        }
-
         // Cycle detection
-        if (hasCycle(tasks)) {
+        if (hasCycle(normalized)) {
           return json(res, 400, { error: 'circular dependency detected in tasks' });
         }
 
         const board = helpers.readBoard();
         board.projects = board.projects || [];
         board.taskPlan = board.taskPlan || { tasks: [] };
+        board.taskPlan.tasks = board.taskPlan.tasks || [];
 
-        const projectId = helpers.uid('PROJ');
-        const taskIds = [];
+        if (input.goal || title) board.taskPlan.goal = input.goal || title;
+        if (title) board.taskPlan.title = title;
+        if (!board.taskPlan.phase) board.taskPlan.phase = 'planning';
+        if (!board.taskPlan.createdAt) board.taskPlan.createdAt = helpers.nowIso();
+        if (input.spec) board.taskPlan.spec = input.spec;
 
-        for (const entry of tasks) {
-          const taskId = `GH-${entry.issue}`;
-          const depIds = (entry.depends || []).map(d => `GH-${d}`);
-          const existing = board.taskPlan.tasks.find(t => t.id === taskId);
-
-          if (existing) {
-            // Update existing task
-            existing.depends = depIds;
-            existing.projectId = projectId;
-            existing.completionTrigger = trigger;
-            if (depIds.length === 0 && existing.status === 'pending') {
-              existing.status = 'dispatched';
-              existing.history = existing.history || [];
-              existing.history.push({ ts: helpers.nowIso(), status: 'dispatched', reason: 'project_no_deps' });
-            }
-          } else {
-            // Create new GH task
-            const newTask = {
-              id: taskId,
-              title: entry.title || `Issue #${entry.issue}`,
-              status: depIds.length > 0 ? 'pending' : 'dispatched',
-              assignee: entry.assignee || null,
-              depends: depIds,
-              type: 'gh',
-              source: repo,
-              githubIssue: entry.issue,
-              projectId,
-              completionTrigger: trigger,
-              history: [{ ts: helpers.nowIso(), status: depIds.length > 0 ? 'pending' : 'dispatched', reason: 'project_created' }],
-            };
-            board.taskPlan.tasks.push(newTask);
-          }
-          taskIds.push(taskId);
+        // Create project entity only when repo is provided
+        let projectId = null;
+        if (repo) {
+          projectId = helpers.uid('PROJ');
         }
 
-        const project = {
-          id: projectId,
-          title,
-          repo,
-          status: 'executing',
-          concurrency: concurrency || 3,
-          completionTrigger: trigger,
-          taskIds,
-          createdAt: helpers.nowIso(),
-        };
-        board.projects.push(project);
+        const ACTIVE_STATUSES = ['in_progress', 'dispatched'];
+        const SAFE_FIELDS = ['title', 'description', 'assignee', 'depends', 'spec', 'skill', 'estimate', 'target_repo'];
+        const existingIds = new Set(board.taskPlan.tasks.map(t => t.id));
+        const newTasks = [];
+        const taskIds = [];
 
-        // Signal
-        mgmt.ensureEvolutionFields(board);
-        board.signals.push({
-          id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'project-orchestrator',
-          type: 'project_created',
-          content: `Project "${title}" created with ${taskIds.length} tasks`,
-          refs: taskIds,
-          data: { projectId, taskIds },
-        });
-        if (board.signals.length > 500) board.signals = board.signals.slice(-500);
+        for (const t of normalized) {
+          taskIds.push(t.id);
+          const existing = existingIds.has(t.id) ? board.taskPlan.tasks.find(e => e.id === t.id) : null;
+
+          if (existing) {
+            if (projectId) {
+              existing.projectId = projectId;
+              existing.completionTrigger = trigger;
+            }
+            if (!ACTIVE_STATUSES.includes(existing.status)) {
+              for (const k of SAFE_FIELDS) { if (t[k] !== undefined) existing[k] = t[k]; }
+              if (t.depends?.length === 0 && existing.status === 'pending') {
+                existing.status = 'dispatched';
+              }
+              existing.history = existing.history || [];
+              existing.history.push({ ts: helpers.nowIso(), status: 'updated', by: 'api' });
+            }
+          } else {
+            const newTask = {
+              id: t.id,
+              title: t.title,
+              assignee: t.assignee || null,
+              status: (t.depends?.length > 0) ? 'pending' : 'dispatched',
+              depends: t.depends || [],
+              description: t.description || '',
+              spec: t.spec || null,
+              skill: t.skill || null,
+              estimate: t.estimate || null,
+              target_repo: t.target_repo || null,
+              history: [{ ts: helpers.nowIso(), status: (t.depends?.length > 0) ? 'pending' : 'dispatched', reason: 'project_created' }],
+            };
+            if (t.type) newTask.type = t.type;
+            if (t.source) newTask.source = t.source;
+            if (t.githubIssue) newTask.githubIssue = t.githubIssue;
+            if (projectId) {
+              newTask.projectId = projectId;
+              newTask.completionTrigger = trigger;
+            }
+            newTasks.push(newTask);
+            board.taskPlan.tasks.push(newTask);
+          }
+        }
+
+        // S8: Auto-create scoped boards (briefs) for new tasks with matching skills
+        for (const t of newTasks) {
+          if (t.skill && SKILLS_NEEDING_BRIEF.has(t.skill)) {
+            ensureBriefsDir(DATA_DIR);
+            const briefPath = `briefs/${t.id}.json`;
+            t.briefPath = briefPath;
+            const emptyBrief = {
+              meta: { boardType: 'brief', version: 1, taskId: t.id },
+              project: { name: title },
+              shotspec: { status: 'pending', shots: [] },
+              refpack: { status: 'empty', assets: {} },
+              controls: { auto_retry: true, max_retries: 3, quality_threshold: 85, paused: false },
+              log: [{ time: helpers.nowIso(), agent: 'system', action: 'brief_created', detail: `auto-created for ${t.id}` }],
+            };
+            fs.writeFileSync(path.resolve(DATA_DIR, briefPath), JSON.stringify(emptyBrief, null, 2));
+          }
+        }
+
+        // Create project entity if repo was provided
+        let project = null;
+        if (projectId) {
+          project = {
+            id: projectId,
+            title,
+            repo,
+            status: 'executing',
+            concurrency: concurrency || 3,
+            completionTrigger: trigger,
+            taskIds,
+            createdAt: helpers.nowIso(),
+          };
+          board.projects.push(project);
+
+          mgmt.ensureEvolutionFields(board);
+          board.signals.push({
+            id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'project-orchestrator',
+            type: 'project_created',
+            content: `Project "${title}" created with ${taskIds.length} tasks`,
+            refs: taskIds,
+            data: { projectId, taskIds },
+          });
+          if (board.signals.length > 500) board.signals = board.signals.slice(-500);
+        }
 
         helpers.writeBoard(board);
-        helpers.appendLog({ ts: helpers.nowIso(), event: 'project_created', projectId, taskIds });
+        helpers.appendLog({ ts: helpers.nowIso(), event: 'project_created', title, projectId, taskCount: taskIds.length });
         helpers.broadcastSSE('board', board);
 
-        // Auto-dispatch no-dep tasks
+        const result = { ok: true, title, taskCount: taskIds.length };
+        if (project) {
+          result.project = project;
+          result.progress = computeProgress(board, project);
+        }
+
+        // Auto-dispatch
         if (deps.tryAutoDispatch) {
           const dispatchable = taskIds.filter(tid => {
             const t = board.taskPlan.tasks.find(tt => tt.id === tid);
@@ -179,7 +281,17 @@ module.exports = function projectsRoutes(req, res, helpers, deps) {
           }
         }
 
-        json(res, 201, { ok: true, project, progress: computeProgress(board, project) });
+        // autoStart: dispatch first ready task via dispatchTask
+        if (autoStart && deps.dispatchTask) {
+          const nextTask = mgmt.pickNextTask(board);
+          if (nextTask) {
+            const dr = deps.dispatchTask(nextTask, board, { source: 'project-autostart' });
+            result.autoStarted = nextTask.id;
+            if (dr) result.planId = dr.planId;
+          }
+        }
+
+        json(res, 201, result);
       } catch (error) {
         json(res, 400, { error: error.message });
       }

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -13,7 +13,6 @@
  * GET/POST /api/tasks/:id/digest — L2 digest
  * POST /api/dispatch-next — S6 atomic dispatch-next
  * POST /api/retro — trigger retro
- * POST /api/project — create project
  *
  * Also contains: redispatchTask, tryAutoDispatch, logDispatchPreflight, tryEddaSync
  */
@@ -449,13 +448,7 @@ function tryAutoDispatch(taskId, deps, helpers) {
   dispatchTask(task, board, deps, helpers, { source: 'auto-dispatch' });
 }
 
-// Brief helper functions (used by project creation)
-const SKILLS_NEEDING_BRIEF = new Set(['conversapix-storyboard']);
-
-function ensureBriefsDir(DATA_DIR) {
-  const BRIEFS_DIR = path.join(DATA_DIR, 'briefs');
-  if (!fs.existsSync(BRIEFS_DIR)) fs.mkdirSync(BRIEFS_DIR, { recursive: true });
-}
+// Brief helpers moved to routes/projects.js (GH-251)
 
 function summarizeBriefAsSignal(taskId, helpers, DIR) {
   const board = helpers.readBoard();
@@ -1507,126 +1500,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
     return;
   }
 
-  if (req.method === 'POST' && req.url === '/api/project') {
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
-        const title = String(payload.title || '').trim();
-        if (!title) return json(res, 400, { error: 'title is required' });
-
-        const tasks = Array.isArray(payload.tasks) ? payload.tasks : [];
-        if (tasks.length === 0) return json(res, 400, { error: 'tasks array is required and must not be empty' });
-
-        // Validate task structure
-        const ids = new Set();
-        for (const t of tasks) {
-          if (!t.id || !t.title) return json(res, 400, { error: `task missing id or title: ${JSON.stringify(t)}` });
-          if (ids.has(t.id)) return json(res, 400, { error: `duplicate task id: ${t.id}` });
-          ids.add(t.id);
-        }
-
-        // Validate dependencies
-        for (const t of tasks) {
-          for (const dep of (t.depends || [])) {
-            if (!ids.has(dep)) return json(res, 400, { error: `task ${t.id} depends on unknown task ${dep}` });
-          }
-        }
-
-        // Write to board — merge into existing taskPlan (never overwrite running tasks)
-        const board = helpers.readBoard();
-        board.taskPlan = board.taskPlan || { tasks: [] };
-        board.taskPlan.tasks = board.taskPlan.tasks || [];
-
-        if (payload.goal || title) board.taskPlan.goal = payload.goal || title;
-        if (title) board.taskPlan.title = title;
-        if (!board.taskPlan.phase) board.taskPlan.phase = 'planning';
-        if (!board.taskPlan.createdAt) board.taskPlan.createdAt = helpers.nowIso();
-        if (payload.spec) board.taskPlan.spec = payload.spec;
-
-        const PROJ_ACTIVE = ['in_progress', 'dispatched'];
-        const PROJ_SAFE = ['title', 'description', 'assignee', 'depends', 'spec', 'skill', 'estimate', 'target_repo'];
-        const existingIds = new Set(board.taskPlan.tasks.map(t => t.id));
-        const newTasks = [];
-        for (const t of tasks) {
-          if (existingIds.has(t.id)) {
-            const existing = board.taskPlan.tasks.find(e => e.id === t.id);
-            if (existing && !PROJ_ACTIVE.includes(existing.status)) {
-              for (const k of PROJ_SAFE) { if (t[k] !== undefined) existing[k] = t[k]; }
-              existing.history = existing.history || [];
-              existing.history.push({ ts: helpers.nowIso(), status: 'updated', by: 'api' });
-            }
-            continue;
-          }
-          const newTask = {
-            id: t.id,
-            title: t.title,
-            assignee: t.assignee || null,
-            status: (t.depends?.length > 0) ? 'pending' : 'dispatched',
-            depends: t.depends || [],
-            description: t.description || '',
-            spec: t.spec || null,
-            skill: t.skill || null,
-            estimate: t.estimate || null,
-            target_repo: t.target_repo || null,
-            history: [{ ts: helpers.nowIso(), status: 'created', by: 'api' }],
-          };
-          newTasks.push(newTask);
-          board.taskPlan.tasks.push(newTask);
-        }
-
-        // S8: Auto-create scoped boards (briefs) for NEW tasks with matching skills
-        for (const t of newTasks) {
-          if (t.skill && SKILLS_NEEDING_BRIEF.has(t.skill)) {
-            ensureBriefsDir(DATA_DIR);
-            const briefPath = `briefs/${t.id}.json`;
-            t.briefPath = briefPath;
-            const emptyBrief = {
-              meta: { boardType: 'brief', version: 1, taskId: t.id },
-              project: { name: title },
-              shotspec: { status: 'pending', shots: [] },
-              refpack: { status: 'empty', assets: {} },
-              controls: { auto_retry: true, max_retries: 3, quality_threshold: 85, paused: false },
-              log: [{ time: helpers.nowIso(), agent: 'system', action: 'brief_created', detail: `auto-created for ${t.id}` }],
-            };
-            fs.writeFileSync(path.resolve(DIR, briefPath), JSON.stringify(emptyBrief, null, 2));
-          }
-        }
-
-        helpers.writeBoard(board);
-        helpers.appendLog({ ts: helpers.nowIso(), event: 'project_created', title, taskCount: tasks.length });
-        helpers.broadcastSSE('board', board);
-
-        const result = { ok: true, title, taskCount: tasks.length };
-
-        // Auto-dispatch: check all dispatched tasks when auto_dispatch is enabled
-        const projCtrl = mgmt.getControls(board);
-        if (projCtrl.auto_dispatch) {
-          for (const t of board.taskPlan.tasks) {
-            if (t.status === 'dispatched') {
-              setImmediate(() => tryAutoDispatch(t.id, deps, helpers));
-            }
-          }
-        }
-
-        // autoStart: dispatch first ready task
-        if (payload.autoStart) {
-          const nextTask = mgmt.pickNextTask(board);
-          if (nextTask) {
-            const dr = dispatchTask(nextTask, board, deps, helpers, { source: 'project-autostart' });
-            result.autoStarted = nextTask.id;
-            result.planId = dr.planId;
-          }
-        }
-
-        json(res, 201, result);
-      } catch (error) {
-        json(res, 400, { error: error.message });
-      }
-    });
-    return;
-  }
+  // POST /api/project — DEPRECATED: handled by routes/projects.js
 
   // --- Pipeline Templates ---
 

--- a/server/smoke-test.js
+++ b/server/smoke-test.js
@@ -703,13 +703,12 @@ async function runSuite(target) {
       ok('POST /api/tasks → 200 + taskPlan created + restored');
     } catch (e) { fail('POST /api/tasks', e.message); }
 
-    // ── Project API ──
-    // POST /api/project (valid project)
+    // ── Project API (unified /api/projects) ──
+    // POST /api/projects (valid — unified format with id-based tasks)
     try {
-      // Save board backup
       const backupR = await get(port, '/api/board');
       const backup = JSON.parse(backupR.body);
-      const r = await post(port, '/api/project', {
+      const r = await post(port, '/api/projects', {
         title: 'Smoke Project 77', goal: 'Test project creation',
         tasks: [
           { id: 'SP77-1', title: 'Task A' },
@@ -721,28 +720,41 @@ async function runSuite(target) {
       if (body.ok !== true) throw new Error('expected ok: true');
       if (body.title !== 'Smoke Project 77') throw new Error(`wrong title: ${body.title}`);
       if (body.taskCount !== 2) throw new Error(`expected taskCount 2, got ${body.taskCount}`);
-      // Restore original board
       await post(port, '/api/board', backup);
-      ok('POST /api/project (valid) → 201 + project created + restored');
-    } catch (e) { fail('POST /api/project (valid)', e.message); }
+      ok('POST /api/projects (valid) → 201 + tasks created + restored');
+    } catch (e) { fail('POST /api/projects (valid)', e.message); }
 
-    // POST /api/project (missing title → 400)
+    // POST /api/projects (missing title → 400)
     try {
-      const r = await post(port, '/api/project', { tasks: [{ id: 'x', title: 'y' }] });
+      const r = await post(port, '/api/projects', { tasks: [{ id: 'x', title: 'y' }] });
       if (r.status !== 400) throw new Error(`expected 400, got ${r.status}`);
       const body = JSON.parse(r.body);
       if (!body.error || !body.error.includes('title')) throw new Error(`wrong error: ${body.error}`);
-      ok('POST /api/project (no title) → 400');
-    } catch (e) { fail('POST /api/project (no title)', e.message); }
+      ok('POST /api/projects (no title) → 400');
+    } catch (e) { fail('POST /api/projects (no title)', e.message); }
 
-    // POST /api/project (empty tasks → 400)
+    // POST /api/projects (empty tasks → 400)
     try {
-      const r = await post(port, '/api/project', { title: 'Bad Project', tasks: [] });
+      const r = await post(port, '/api/projects', { title: 'Bad Project', tasks: [] });
       if (r.status !== 400) throw new Error(`expected 400, got ${r.status}`);
       const body = JSON.parse(r.body);
       if (!body.error || !body.error.includes('tasks')) throw new Error(`wrong error: ${body.error}`);
-      ok('POST /api/project (empty tasks) → 400');
-    } catch (e) { fail('POST /api/project (empty tasks)', e.message); }
+      ok('POST /api/projects (empty tasks) → 400');
+    } catch (e) { fail('POST /api/projects (empty tasks)', e.message); }
+
+    // POST /api/project (deprecated alias still works)
+    try {
+      const backupR = await get(port, '/api/board');
+      const backup = JSON.parse(backupR.body);
+      const r = await post(port, '/api/project', {
+        title: 'Deprecated Test', tasks: [{ id: 'DEP-1', title: 'Task via deprecated' }],
+      });
+      if (r.status !== 201) throw new Error(`expected 201, got ${r.status}: ${r.body}`);
+      const body = JSON.parse(r.body);
+      if (body.ok !== true) throw new Error('expected ok: true');
+      await post(port, '/api/board', backup);
+      ok('POST /api/project (deprecated alias) → 201 still works');
+    } catch (e) { fail('POST /api/project (deprecated alias)', e.message); }
 
     // ── Dispatch Next (safe path) ──
     // POST /api/dispatch-next — no ready tasks in clean state

--- a/server/test-projects.js
+++ b/server/test-projects.js
@@ -58,9 +58,9 @@ function createMockHelpers(board) {
 // ---------------------------------------------------------------------------
 test('1. hasCycle — no cycle returns false', async () => {
   const tasks = [
-    { issue: 1, depends: [] },
-    { issue: 2, depends: [1] },
-    { issue: 3, depends: [1, 2] },
+    { id: 'GH-1', depends: [] },
+    { id: 'GH-2', depends: ['GH-1'] },
+    { id: 'GH-3', depends: ['GH-1', 'GH-2'] },
   ];
   assert.strictEqual(hasCycle(tasks), false);
 });
@@ -70,9 +70,9 @@ test('1. hasCycle — no cycle returns false', async () => {
 // ---------------------------------------------------------------------------
 test('2. hasCycle — cycle returns true', async () => {
   const tasks = [
-    { issue: 1, depends: [3] },
-    { issue: 2, depends: [1] },
-    { issue: 3, depends: [2] },
+    { id: 'GH-1', depends: ['GH-3'] },
+    { id: 'GH-2', depends: ['GH-1'] },
+    { id: 'GH-3', depends: ['GH-2'] },
   ];
   assert.strictEqual(hasCycle(tasks), true);
 });
@@ -358,6 +358,168 @@ test('15. POST /api/projects — existing GH task gets updated with deps + proje
   assert.deepStrictEqual(t5.depends, ['GH-6']);
   assert.ok(t5.projectId);
   assert.strictEqual(t5.completionTrigger, 'pr_merged');
+});
+
+// ---------------------------------------------------------------------------
+// Test 16: POST /api/projects — unified format (id-based tasks, no repo)
+// ---------------------------------------------------------------------------
+test('16. POST /api/projects — id-based tasks without repo (no project entity)', async () => {
+  const projectsRoutes = require('./routes/projects');
+  const board = createBoard([]);
+  const helpers = createMockHelpers(board);
+  const deps = { mgmt, tryAutoDispatch: null };
+
+  const input = {
+    title: 'Ad-hoc Tasks',
+    tasks: [
+      { id: 'GH-248', title: 'feat: reopen API' },
+      { id: 'GH-249', title: 'fix: needs_revision mapping' },
+    ],
+  };
+  const req = createMockReq('POST', '/api/projects', JSON.stringify(input));
+  const res = createMockRes();
+
+  projectsRoutes(req, res, helpers, deps);
+  req.emit('data', JSON.stringify(input));
+  req.emit('end');
+
+  await tick();
+  assert.strictEqual(res._statusCode, 201);
+  const body = JSON.parse(res._body);
+  assert.strictEqual(body.ok, true);
+  assert.strictEqual(body.taskCount, 2);
+  assert.strictEqual(body.project, undefined);
+
+  const b = helpers._state.board;
+  assert.strictEqual(b.taskPlan.tasks.length, 2);
+  assert.strictEqual(b.taskPlan.tasks[0].id, 'GH-248');
+  assert.strictEqual(b.taskPlan.tasks[1].id, 'GH-249');
+  assert.strictEqual(b.projects.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Test 17: POST /api/projects — merge mode (don't overwrite active tasks)
+// ---------------------------------------------------------------------------
+test('17. POST /api/projects — merges new tasks, preserves active ones', async () => {
+  const projectsRoutes = require('./routes/projects');
+  const existingTask = { id: 'GH-100', title: 'Running', status: 'dispatched', depends: [] };
+  const board = createBoard([existingTask]);
+  const helpers = createMockHelpers(board);
+  const deps = { mgmt, tryAutoDispatch: null };
+
+  const input = {
+    title: 'Wave 2',
+    tasks: [
+      { id: 'GH-100', title: 'Should NOT overwrite' },
+      { id: 'GH-200', title: 'New task' },
+    ],
+  };
+  const req = createMockReq('POST', '/api/projects', JSON.stringify(input));
+  const res = createMockRes();
+
+  projectsRoutes(req, res, helpers, deps);
+  req.emit('data', JSON.stringify(input));
+  req.emit('end');
+
+  await tick();
+  assert.strictEqual(res._statusCode, 201);
+
+  const b = helpers._state.board;
+  assert.strictEqual(b.taskPlan.tasks.length, 2);
+  const t100 = b.taskPlan.tasks.find(t => t.id === 'GH-100');
+  assert.strictEqual(t100.title, 'Running');
+  assert.strictEqual(t100.status, 'dispatched');
+  const t200 = b.taskPlan.tasks.find(t => t.id === 'GH-200');
+  assert.strictEqual(t200.title, 'New task');
+});
+
+// ---------------------------------------------------------------------------
+// Test 18: POST /api/projects — mixed format (issue + id based)
+// ---------------------------------------------------------------------------
+test('18. POST /api/projects — mixed task formats (issue + id)', async () => {
+  const projectsRoutes = require('./routes/projects');
+  const board = createBoard([]);
+  const helpers = createMockHelpers(board);
+  const deps = { mgmt, tryAutoDispatch: null };
+
+  const input = {
+    title: 'Mixed',
+    repo: 'owner/repo',
+    tasks: [
+      { issue: 10, title: 'Issue-based' },
+      { id: 'CUSTOM-1', title: 'Id-based' },
+    ],
+  };
+  const req = createMockReq('POST', '/api/projects', JSON.stringify(input));
+  const res = createMockRes();
+
+  projectsRoutes(req, res, helpers, deps);
+  req.emit('data', JSON.stringify(input));
+  req.emit('end');
+
+  await tick();
+  assert.strictEqual(res._statusCode, 201);
+
+  const b = helpers._state.board;
+  assert.strictEqual(b.taskPlan.tasks.length, 2);
+  assert.strictEqual(b.taskPlan.tasks[0].id, 'GH-10');
+  assert.strictEqual(b.taskPlan.tasks[1].id, 'CUSTOM-1');
+  assert.ok(b.projects.length > 0);
+});
+
+// ---------------------------------------------------------------------------
+// Test 19: POST /api/project (deprecated alias) still works
+// ---------------------------------------------------------------------------
+test('19. POST /api/project (deprecated alias) → 201', async () => {
+  const projectsRoutes = require('./routes/projects');
+  const board = createBoard([]);
+  const helpers = createMockHelpers(board);
+  const deps = { mgmt, tryAutoDispatch: null };
+
+  const input = { title: 'Via Deprecated', tasks: [{ id: 'DEP-1', title: 'Test' }] };
+  const req = createMockReq('POST', '/api/project', JSON.stringify(input));
+  const res = createMockRes();
+
+  projectsRoutes(req, res, helpers, deps);
+  req.emit('data', JSON.stringify(input));
+  req.emit('end');
+
+  await tick();
+  assert.strictEqual(res._statusCode, 201);
+  const body = JSON.parse(res._body);
+  assert.strictEqual(body.ok, true);
+  assert.strictEqual(body.taskCount, 1);
+
+  const logEntry = helpers._state.log.find(e => e.event === 'deprecated_api');
+  assert.ok(logEntry, 'should log deprecation warning');
+});
+
+// ---------------------------------------------------------------------------
+// Test 20: POST /api/projects — target_repo passes through
+// ---------------------------------------------------------------------------
+test('20. POST /api/projects — target_repo is set on task', async () => {
+  const projectsRoutes = require('./routes/projects');
+  const board = createBoard([]);
+  const helpers = createMockHelpers(board);
+  const deps = { mgmt, tryAutoDispatch: null };
+
+  const input = {
+    title: 'Multi-repo',
+    tasks: [{ id: 'EDDA-1', title: 'Edda task', target_repo: 'C:\\ai_agent\\edda' }],
+  };
+  const req = createMockReq('POST', '/api/projects', JSON.stringify(input));
+  const res = createMockRes();
+
+  projectsRoutes(req, res, helpers, deps);
+  req.emit('data', JSON.stringify(input));
+  req.emit('end');
+
+  await tick();
+  assert.strictEqual(res._statusCode, 201);
+
+  const b = helpers._state.board;
+  const task = b.taskPlan.tasks[0];
+  assert.strictEqual(task.target_repo, 'C:\\ai_agent\\edda');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #251 — Consolidated the confusingly-named `POST /api/project` (singular) and `POST /api/projects` (plural) into a single unified endpoint at `POST /api/projects`.

## Changes

### `routes/projects.js` — Unified endpoint
- **Dual task format**: supports both `{ issue: 248 }` (legacy, auto-adds `GH-` prefix) and `{ id: "GH-248", title: "..." }` (unified, direct ID)
- **`repo` is now optional**: when omitted, no project entity is created — tasks are added directly to `board.taskPlan`
- **Merge mode** (from GH-250): new tasks are appended, active tasks (`in_progress`/`dispatched`) are protected from updates
- **Migrated features from singular**: S8 briefs auto-creation, `autoStart`, `target_repo`, `spec`/`description`/`estimate` fields
- **`hasCycle()`** updated to work with string IDs instead of numeric issue numbers

### `routes/tasks.js` — Handler removed
- Deleted ~120 line `POST /api/project` handler
- Comment in place: `// POST /api/project — DEPRECATED: handled by routes/projects.js`

### `routes/projects.js` — Deprecated alias
- `POST /api/project` (singular) still works as alias → logs deprecation warning

### Tests
- `test-projects.js`: 5 new tests (16-20), total 20/20 passing
  - id-based tasks without repo
  - merge mode (preserve active tasks)
  - mixed format (issue + id)
  - deprecated alias
  - target_repo passthrough
- `smoke-test.js`: updated 3 tests to use `/api/projects`, added deprecated alias test

### Docs
- `opencode-dispatch-guide.md`: updated architecture diagram and curl examples

## Test plan

- [x] `node -c` all modified files — syntax OK
- [x] `node server/test-projects.js` — 20/20 passed
- [x] `node server/test-step-schema.js` — 39/39 passed
- [x] `node server/test-route-engine.js` — 14/14 passed
- [x] `node server/test-repo-resolver.js` — 13/13 passed
