### PR TITLE
docs(env): add env.template and auto .env loader (GH-254)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ npm start
 
 No `npm install` needed — zero dependencies.
 
+## Configuration
+
+Copy the environment template and adjust as needed:
+
+```bash
+cp env.template .env
+```
+
+For local development, the defaults work out of the box — no configuration required. The server auto-loads `.env` on startup.
+
+For remote access or production, set at minimum:
+
+| Variable | Purpose |
+|----------|---------|
+| `KARVI_API_TOKEN` | Protect API with Bearer token |
+| `KARVI_VAULT_KEY` | Enable encrypted secret storage (GitHub PAT, etc.) |
+
+See [`env.template`](env.template) for the full list of 35+ available options.
+
 ### Remote Access
 
 Want to access Karvi from your phone or another device? See the **[Self-Hosting Guide](docs/self-hosting.md)** — set up a free Cloudflare Tunnel in under 10 minutes.

--- a/env.template
+++ b/env.template
@@ -1,0 +1,61 @@
+# ============================================================
+# Karvi Environment Configuration
+# Copy this file:  cp env.template .env
+# The server auto-loads .env from the project root on startup.
+# Environment variables already set in your shell take priority.
+# ============================================================
+
+# --- Server Core ---
+# PORT=3461
+# HOST=0.0.0.0
+# PROJECT_ROOT=                # defaults to repo root
+# DATA_DIR=                    # defaults to server/ directory
+# KARVI_STORAGE=json           # json or sqlite
+
+# --- Security ---
+# KARVI_API_TOKEN=             # Bearer token for API auth; unset = no auth (local only)
+# KARVI_VAULT_KEY=             # 64-char hex key to enable encrypted vault
+# KARVI_CORS_ORIGINS=          # comma-separated, e.g. https://app.example.com
+# KARVI_RATE_LIMIT=120         # requests per IP per minute; 0 or off to disable
+# KARVI_MAX_BODY=1048576       # max request body in bytes (default 1 MB)
+# KARVI_TRUST_PROXY=false      # set true behind a reverse proxy
+
+# --- Agent Runtime CLI ---
+# Override the command used to spawn each agent runtime.
+# Leave unset to auto-detect from PATH.
+# OPENCLAW_CMD=openclaw
+# CLAUDE_CMD=claude
+# CODEX_CMD=codex
+# CODEX_MODEL=                 # model hint for Codex runtime
+# OPENCODE_CMD=opencode
+# OPENCODE_MODEL=              # model hint for OpenCode runtime
+# EDDA_CMD=edda
+
+# --- AI / Anthropic ---
+# ANTHROPIC_API_KEY=           # enables digest tasks + L1 summaries
+# KARVI_DIGEST_MODEL=claude-sonnet-4-20250514
+
+# --- SSE / Monitoring ---
+# KARVI_SSE_LIMIT=50           # max concurrent SSE connections
+# KARVI_TELEMETRY=             # 0 / off / false / no to disable
+# KARVI_INSTANCE_ID=           # defaults to os.hostname()
+
+# --- Jira Integration (optional) ---
+# JIRA_HOST=company.atlassian.net
+# JIRA_EMAIL=user@company.com
+# JIRA_API_TOKEN=
+# JIRA_WEBHOOK_SECRET=
+
+# --- Expo App (optional) ---
+# EXPO_PUBLIC_API_URL=         # default API URL baked into mobile app build
+
+# ============================================================
+# GATEWAY — only needed when running: npm run gateway
+# ============================================================
+# GATEWAY_PORT=3460
+# GATEWAY_DATA_ROOT=./data
+# GATEWAY_SECRET=              # REQUIRED for gateway mode
+# GATEWAY_ADMIN_TOKEN=         # REQUIRED for gateway admin API
+# GATEWAY_SESSION_TTL_HOURS=168
+# KARVI_PORT_MIN=4000
+# KARVI_PORT_MAX=4999

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,0 @@
-# Jira Integration (optional — server works without these)
-JIRA_HOST=company.atlassian.net
-JIRA_EMAIL=user@company.com
-JIRA_API_TOKEN=your-api-token
-JIRA_WEBHOOK_SECRET=your-webhook-secret

--- a/server/load-env.js
+++ b/server/load-env.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const envPath = path.resolve(__dirname, '..', '.env');
+if (fs.existsSync(envPath)) {
+  for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx < 1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const val = trimmed.slice(eqIdx + 1).trim().replace(/^["']|["']$/g, '');
+    if (!process.env[key]) process.env[key] = val;
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+require('./load-env');
 /**
  * server.js — Karvi Task Engine HTTP Server
  *
@@ -65,7 +66,9 @@ function getRuntime(hint) {
 }
 
 const DIR = __dirname;
-const ROOT = path.resolve(DIR, '..');
+const ROOT = process.env.PROJECT_ROOT
+  ? path.resolve(process.env.PROJECT_ROOT)
+  : path.resolve(DIR, '..');
 const DATA_DIR = process.env.DATA_DIR || DIR;
 const PUSH_TOKENS_PATH = path.join(DATA_DIR, 'push-tokens.json');
 


### PR DESCRIPTION
## Summary

Closes #254 — Complete env.template with all server environment variables.

- **`env.template`** — Lists all 36 environment variables organized into 8 categories (Server Core, Security, Agent Runtime, AI, SSE/Monitoring, Jira, Expo, Gateway). Each variable has inline comments explaining purpose and defaults.
- **`server/load-env.js`** — Zero-dependency `.env` loader (~15 lines). Reads `<project-root>/.env` on startup, only sets vars not already present in the environment (shell takes priority).
- **`server/server.js`** — Added `require('./load-env')` as the very first line, before all other imports.
- **`README.md`** — Added "Configuration" section between Quick Start and Remote Access, with `cp env.template .env` instructions and a table of the two most important variables.
- **Removed `server/.env.example`** — Superseded by the root `env.template`.

## Test plan

- [x] `node -c server/load-env.js` — syntax OK
- [x] `node -c server/server.js` — syntax OK
- [x] `test-projects.js` — 20/20 passed
- [x] `test-step-schema.js` — 39/39 passed
- [x] `test-route-engine.js` — 14/14 passed
- [ ] Manual: server starts normally without `.env` (uses defaults)
- [ ] Manual: server reads `PORT` from `.env` when present
