### PR TITLE
fix(api): harden discovery endpoints — CRLF, URL matching, cache TTL, tests (GH-262)

### DIFF
--- a/server/routes/discovery.js
+++ b/server/routes/discovery.js
@@ -13,6 +13,8 @@ const bb = require('../blackboard-server');
 const { json } = bb;
 
 let _skillsCache = null;
+let _skillsCacheTs = 0;
+const SKILLS_TTL_MS = 300_000;
 let _preflightCache = null;
 let _preflightCacheTs = 0;
 const PREFLIGHT_TTL_MS = 30_000;
@@ -32,7 +34,8 @@ function listRuntimes(deps) {
 }
 
 function listSkills(projectRoot) {
-  if (_skillsCache) return _skillsCache;
+  const now = Date.now();
+  if (_skillsCache && (now - _skillsCacheTs) < SKILLS_TTL_MS) return _skillsCache;
   const skillsDir = path.join(projectRoot, '.claude', 'skills');
   if (!fs.existsSync(skillsDir)) return [];
 
@@ -51,11 +54,13 @@ function listSkills(projectRoot) {
     });
   }
   _skillsCache = skills;
+  _skillsCacheTs = now;
   return skills;
 }
 
 function parseFrontmatter(content) {
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  const normalized = content.replace(/\r\n/g, '\n');
+  const match = normalized.match(/^---\n([\s\S]*?)\n---/);
   if (!match) return {};
   const result = {};
   for (const line of match[1].split('\n')) {
@@ -135,8 +140,12 @@ function getVersion() {
   }
 }
 
+function urlMatch(url, pattern) {
+  return url === pattern || url.startsWith(pattern + '?');
+}
+
 module.exports = function discoveryRoutes(req, res, helpers, deps) {
-  if (req.method === 'GET' && req.url === '/api/runtimes') {
+  if (req.method === 'GET' && urlMatch(req.url, '/api/runtimes')) {
     const runtimes = listRuntimes(deps);
     return json(res, 200, {
       runtimes,
@@ -145,13 +154,13 @@ module.exports = function discoveryRoutes(req, res, helpers, deps) {
     });
   }
 
-  if (req.method === 'GET' && req.url === '/api/skills') {
+  if (req.method === 'GET' && urlMatch(req.url, '/api/skills')) {
     const projectRoot = deps.ctx.dir;
     const skills = listSkills(projectRoot);
     return json(res, 200, { skills });
   }
 
-  if (req.method === 'GET' && req.url === '/api/health/preflight') {
+  if (req.method === 'GET' && urlMatch(req.url, '/api/health/preflight')) {
     const result = runPreflight(deps);
     return json(res, 200, result);
   }
@@ -162,3 +171,5 @@ module.exports = function discoveryRoutes(req, res, helpers, deps) {
 module.exports.listRuntimes = listRuntimes;
 module.exports.listSkills = listSkills;
 module.exports.runPreflight = runPreflight;
+module.exports.parseFrontmatter = parseFrontmatter;
+module.exports._resetCaches = () => { _skillsCache = null; _skillsCacheTs = 0; _preflightCache = null; _preflightCacheTs = 0; };

--- a/server/server.js
+++ b/server/server.js
@@ -383,7 +383,7 @@ process.on('SIGINT', gracefulShutdown);
 // --- Boot banner ---
 {
   const runtimeNames = Object.keys(RUNTIMES);
-  const allRt = ['openclaw', 'claude', 'codex', 'opencode'];
+  const allRt = ['openclaw', 'claude', 'claude-api', 'codex', 'opencode'];
   const rtLine = allRt.map(r => runtimeNames.includes(r) ? `${r} ✅` : `${r} ❌`).join('  ');
   const tokenStatus = process.env.KARVI_API_TOKEN ? 'token set ✅' : 'no token (local only)';
   const addr = HOST || 'localhost';

--- a/server/test-discovery.js
+++ b/server/test-discovery.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * test-discovery.js — Unit tests for routes/discovery.js
+ *
+ * Usage: node server/test-discovery.js
+ */
+const assert = require('assert');
+const { listRuntimes, listSkills, runPreflight, parseFrontmatter, _resetCaches } = require('./routes/discovery');
+
+let passed = 0;
+let failed = 0;
+
+function ok(label) { passed++; console.log(`  \u2705 ${label}`); }
+function fail(label, reason) { failed++; console.log(`  \u274c ${label}: ${reason}`); process.exitCode = 1; }
+
+function test(label, fn) {
+  try { fn(); ok(label); } catch (err) { fail(label, err.message); }
+}
+
+console.log('\n\uD83E\uDDEA test-discovery.js — Discovery API\n');
+
+// --- parseFrontmatter ---
+
+console.log('=== parseFrontmatter ===\n');
+
+test('parses LF frontmatter', () => {
+  const result = parseFrontmatter('---\nname: test\ndescription: hello world\n---\nbody');
+  assert.strictEqual(result.name, 'test');
+  assert.strictEqual(result.description, 'hello world');
+});
+
+test('parses CRLF frontmatter', () => {
+  const result = parseFrontmatter('---\r\nname: test\r\ndescription: hello world\r\n---\r\nbody');
+  assert.strictEqual(result.name, 'test');
+  assert.strictEqual(result.description, 'hello world');
+});
+
+test('handles quoted values', () => {
+  const result = parseFrontmatter('---\nname: "quoted"\ndescription: \'single\'\n---\n');
+  assert.strictEqual(result.name, 'quoted');
+  assert.strictEqual(result.description, 'single');
+});
+
+test('returns empty object for missing frontmatter', () => {
+  const result = parseFrontmatter('no frontmatter here');
+  assert.deepStrictEqual(result, {});
+});
+
+test('returns empty object for empty content', () => {
+  const result = parseFrontmatter('');
+  assert.deepStrictEqual(result, {});
+});
+
+// --- listRuntimes ---
+
+console.log('\n=== listRuntimes ===\n');
+
+test('lists runtimes from deps.RUNTIMES', () => {
+  const deps = {
+    RUNTIMES: {
+      openclaw: { capabilities: () => ({ runtime: 'openclaw', supportsSessionResume: false, supportsModelSelection: false }) },
+      claude: { capabilities: () => ({ runtime: 'claude', supportsSessionResume: true, supportsModelSelection: true }) },
+    },
+  };
+  const result = listRuntimes(deps);
+  assert.strictEqual(result.length, 2);
+  assert.strictEqual(result[0].id, 'openclaw');
+  assert.strictEqual(result[0].supportsSessionResume, false);
+  assert.strictEqual(result[1].id, 'claude');
+  assert.strictEqual(result[1].supportsSessionResume, true);
+});
+
+test('handles runtime without capabilities function', () => {
+  const deps = { RUNTIMES: { bare: {} } };
+  const result = listRuntimes(deps);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].id, 'bare');
+  assert.strictEqual(result[0].supportsSessionResume, false);
+});
+
+test('empty RUNTIMES returns empty array', () => {
+  const deps = { RUNTIMES: {} };
+  const result = listRuntimes(deps);
+  assert.strictEqual(result.length, 0);
+});
+
+// --- listSkills ---
+
+console.log('\n=== listSkills ===\n');
+
+_resetCaches();
+
+test('lists skills from .claude/skills directory', () => {
+  const path = require('path');
+  const projectRoot = path.resolve(__dirname, '..');
+  const result = listSkills(projectRoot);
+  assert.ok(Array.isArray(result));
+  assert.ok(result.length > 0, 'should find at least one skill');
+  const commitSkill = result.find(s => s.id === 'commit');
+  assert.ok(commitSkill, 'should find commit skill');
+  assert.strictEqual(commitSkill.name, 'commit');
+  assert.ok(commitSkill.description.length > 0, 'description should not be empty');
+});
+
+test('returns empty array for non-existent directory', () => {
+  _resetCaches();
+  const result = listSkills('/non/existent/path');
+  assert.deepStrictEqual(result, []);
+});
+
+// --- runPreflight ---
+
+console.log('\n=== runPreflight ===\n');
+
+_resetCaches();
+
+test('returns preflight with expected structure', () => {
+  const deps = {
+    RUNTIMES: { openclaw: { capabilities: () => ({}) } },
+  };
+  const result = runPreflight(deps);
+  assert.ok(result.version);
+  assert.ok(result.checks);
+  assert.ok(result.checks.node);
+  assert.ok(result.checks.git);
+  assert.ok(result.checks.runtimes);
+  assert.ok(result.checks.env);
+  assert.strictEqual(typeof result.ready, 'boolean');
+  assert.ok(Array.isArray(result.warnings));
+});
+
+_resetCaches();
+
+test('ready=false when no runtimes', () => {
+  const deps = { RUNTIMES: {} };
+  const result = runPreflight(deps);
+  assert.strictEqual(result.ready, false);
+  assert.ok(result.warnings.some(w => w.includes('No agent runtimes')));
+});
+
+// --- summary ---
+console.log(`\n${'─'.repeat(40)}`);
+console.log(`Results: ${passed} passed, ${failed} failed\n`);


### PR DESCRIPTION
## Summary

Follow-up to #264 — addresses all findings from post-merge code review.

### Fixes

| Finding | Fix |
|---------|-----|
| `parseFrontmatter` CRLF regex fails on Windows | Normalize `\r\n` → `\n` before matching |
| URL matching ignores query strings | Add `urlMatch()` helper: `url === p \|\| url.startsWith(p + '?')` |
| Skills cache never invalidates | Add 5-minute TTL (`SKILLS_TTL_MS = 300_000`) |
| Boot banner misses `claude-api` | Add to `allRt` array |
| Zero test coverage | Add `test-discovery.js` with 12 unit tests |

### New: `test-discovery.js`

- `parseFrontmatter`: LF, CRLF, quoted values, missing frontmatter, empty content
- `listRuntimes`: normal, no-capabilities, empty
- `listSkills`: real directory scan, non-existent path
- `runPreflight`: structure validation, no-runtimes → ready=false

## Test plan

- [x] `node -c server/routes/discovery.js`
- [x] `node -c server/server.js`
- [x] `node server/test-discovery.js` — 12/12 passed
- [x] `node server/test-step-schema.js` — 39/39 passed
- [x] `node server/test-route-engine.js` — 14/14 passed
