### PR TITLE
feat(step-worker): expose kill() from dispatch — precise step cancellation (GH-214)

### DIFF
--- a/server/kill-tree.js
+++ b/server/kill-tree.js
@@ -1,0 +1,16 @@
+/**
+ * kill-tree.js — Kill an entire process tree (cross-platform).
+ */
+const { execSync } = require('child_process');
+
+function killTree(pid) {
+  try {
+    if (process.platform === 'win32') {
+      execSync(`taskkill /PID ${pid} /T /F`, { stdio: 'ignore' });
+    } else {
+      process.kill(-pid, 'SIGKILL');
+    }
+  } catch {}
+}
+
+module.exports = killTree;

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -1150,6 +1150,44 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
     return;
   }
 
+  // POST /api/tasks/:id/steps/:stepId/kill — kill a running step
+  const stepKillMatch = req.url.match(/^\/api\/tasks\/([^/]+)\/steps\/([^/]+)\/kill$/);
+  if (req.method === 'POST' && stepKillMatch) {
+    const taskId = decodeURIComponent(stepKillMatch[1]);
+    const stepId = decodeURIComponent(stepKillMatch[2]);
+
+    const board = helpers.readBoard();
+    const task = (board.taskPlan?.tasks || []).find(t => t.id === taskId);
+    if (!task) return json(res, 404, { error: `Task ${taskId} not found` });
+
+    const step = (task.steps || []).find(s => s.step_id === stepId);
+    if (!step) return json(res, 404, { error: `Step ${stepId} not found` });
+    if (step.state !== 'running') return json(res, 409, { error: `Step is ${step.state}, not running` });
+
+    // Kill the agent process
+    const killResult = deps.stepWorker.killStep(stepId);
+    if (!killResult.ok) return json(res, 409, { error: killResult.reason });
+
+    // Transition to cancelled
+    deps.stepSchema.transitionStep(step, 'cancelled', { error: 'Killed by user' });
+
+    // Emit signal
+    mgmt.ensureEvolutionFields(board);
+    board.signals.push({
+      id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'user',
+      type: 'step_cancelled',
+      content: `${taskId} step ${stepId} running → cancelled (killed)`,
+      refs: [taskId],
+      data: { taskId, stepId, from: 'running', to: 'cancelled' },
+    });
+    if (board.signals.length > 500) board.signals = board.signals.slice(-500);
+
+    helpers.writeBoard(board);
+    helpers.appendLog({ ts: helpers.nowIso(), event: 'step_killed', taskId, stepId });
+
+    return json(res, 200, { ok: true, step_id: stepId, new_state: 'cancelled' });
+  }
+
   // POST /api/tasks/:id/steps/dispatch-batch — dispatch multiple steps in parallel
   const batchDispatchMatch = req.url.match(/^\/api\/tasks\/([^/]+)\/steps\/dispatch-batch$/);
   if (req.method === 'POST' && batchDispatchMatch) {

--- a/server/runtime-claude.js
+++ b/server/runtime-claude.js
@@ -32,19 +32,7 @@ function resolveClaudePath() {
 
 const CLAUDE_EXE = resolveClaudePath();
 
-/**
- * Kill an entire process tree.
- * Windows: taskkill /T /F (tree kill). Unix: negative pid (process group).
- */
-function killTree(pid) {
-  try {
-    if (process.platform === 'win32') {
-      execSync(`taskkill /PID ${pid} /T /F`, { stdio: 'ignore' });
-    } else {
-      process.kill(-pid, 'SIGKILL');
-    }
-  } catch {}
-}
+const killTree = require('./kill-tree');
 
 /**
  * Extract all text from a Claude assistant message content array.
@@ -104,6 +92,11 @@ function dispatch(plan) {
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],  // stdin MUST be ignored on Windows
     });
+
+    // Allow external abort (kill step)
+    if (plan.signal) {
+      plan.signal.addEventListener('abort', () => killTree(child.pid), { once: true });
+    }
 
     let stderr = '';
     let settled = false;

--- a/server/runtime-codex.js
+++ b/server/runtime-codex.js
@@ -40,18 +40,7 @@ function resolveCodexPath() {
 
 const CODEX_EXE = resolveCodexPath();
 
-/**
- * Kill an entire process tree.
- */
-function killTree(pid) {
-  try {
-    if (process.platform === 'win32') {
-      execSync(`taskkill /PID ${pid} /T /F`, { stdio: 'ignore' });
-    } else {
-      process.kill(-pid, 'SIGKILL');
-    }
-  } catch {}
-}
+const killTree = require('./kill-tree');
 
 /**
  * Dispatch a plan to Codex headless CLI.
@@ -128,6 +117,11 @@ function dispatch(plan) {
       shell: false,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
+
+    // Allow external abort (kill step)
+    if (plan.signal) {
+      plan.signal.addEventListener('abort', () => killTree(child.pid), { once: true });
+    }
 
     // Pipe message via stdin then close (codex reads prompt from stdin when '-' is used)
     child.stdin.write(plan.message);

--- a/server/runtime-opencode.js
+++ b/server/runtime-opencode.js
@@ -42,18 +42,7 @@ function resolveOpencodePath() {
 
 const OPENCODE_EXE = resolveOpencodePath();
 
-/**
- * Kill an entire process tree.
- */
-function killTree(pid) {
-  try {
-    if (process.platform === 'win32') {
-      execSync(`taskkill /PID ${pid} /T /F`, { stdio: 'ignore' });
-    } else {
-      process.kill(-pid, 'SIGKILL');
-    }
-  } catch {}
-}
+const killTree = require('./kill-tree');
 
 /**
  * Dispatch a plan to OpenCode headless CLI.
@@ -118,6 +107,11 @@ function dispatch(plan) {
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+
+    // Allow external abort (kill step)
+    if (plan.signal) {
+      plan.signal.addEventListener('abort', () => killTree(child.pid), { once: true });
+    }
 
     let stderr = '';
     let settled = false;

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -47,6 +47,8 @@ const UPSTREAM_RELEVANCE = {
 function createStepWorker(deps) {
   const { artifactStore, stepSchema, mgmt } = deps;
 
+  const activeExecutions = new Map(); // stepId → { abort(), startedAt }
+
   /**
    * Execute a single step: build plan, acquire lock, dispatch to runtime,
    * parse output, write artifact, transition state, emit signal.
@@ -160,9 +162,13 @@ function createStepWorker(deps) {
         } catch {}
       };
       let result;
+      const ac = new AbortController();
+      activeExecutions.set(envelope.step_id, { abort: () => ac.abort(), startedAt: Date.now() });
+      plan.signal = ac.signal;
       try {
         result = await rt.dispatch(plan);
       } catch (dispatchErr) {
+        activeExecutions.delete(envelope.step_id);
         const dispatchDurationMs = Date.now() - startMs;
         // Transition step to failed instead of leaving it stuck in 'running'
         const failBoard = helpers.readBoard();
@@ -201,6 +207,7 @@ function createStepWorker(deps) {
         }
         throw dispatchErr;
       }
+      activeExecutions.delete(envelope.step_id);
       durationMs = Date.now() - startMs;
 
       // 5. Parse output — try STEP_RESULT from extracted reply first (critical for
@@ -377,7 +384,19 @@ function createStepWorker(deps) {
     return agentOutput;
   }
 
-  return { executeStep };
+  function killStep(stepId) {
+    const exec = activeExecutions.get(stepId);
+    if (!exec) return { ok: false, reason: 'not_running' };
+    exec.abort();
+    activeExecutions.delete(stepId);
+    return { ok: true };
+  }
+
+  function getActiveExecutions() {
+    return Array.from(activeExecutions.entries()).map(([stepId, { startedAt }]) => ({ stepId, startedAt }));
+  }
+
+  return { executeStep, killStep, getActiveExecutions };
 }
 
 // --- Helpers (module-level, testable) ---

--- a/server/test-step-worker.js
+++ b/server/test-step-worker.js
@@ -492,6 +492,22 @@ function createMockEnvelope(overrides = {}) {
     assert.strictEqual(decision.review_feedback, 'Add unit tests', 'should use revision_notes as feedback');
   });
 
+  // Test 20: killStep / getActiveExecutions
+  console.log('\n=== killStep / getActiveExecutions ===\n');
+
+  await test('killStep returns not_running for unknown stepId', () => {
+    const worker = createStepWorker({ artifactStore, stepSchema, mgmt });
+    const result = worker.killStep('nonexistent:step');
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.reason, 'not_running');
+  });
+
+  await test('getActiveExecutions returns empty when no active steps', () => {
+    const worker = createStepWorker({ artifactStore, stepSchema, mgmt });
+    const execs = worker.getActiveExecutions();
+    assert.strictEqual(execs.length, 0);
+  });
+
   // Cleanup
   try {
     fs.rmSync(path.join(artifactStore.ARTIFACT_DIR, testRunId), { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Extract shared `kill-tree.js` from 3 runtime adapters (deduplicates identical `killTree` function)
- Add `AbortController` signal to dispatch plan — runtimes listen for abort to kill process tree
- Add `activeExecutions` Map in step-worker with `killStep()` / `getActiveExecutions()` methods
- Add `POST /api/tasks/:taskId/steps/:stepId/kill` endpoint — kills agent process, transitions step to `cancelled`
- 2 new tests for killStep/getActiveExecutions

Closes #214

## Test plan

- [x] killStep returns `not_running` for unknown stepId
- [x] getActiveExecutions returns empty when no active steps
- [x] All 31 step-worker tests pass
- [x] All 14 route-engine tests pass
- [x] Syntax check passes on all 7 modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)