### PR TITLE
feat(board): add cancelled task status (GH-274)

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,6 +384,10 @@
       box-shadow: 0 0 8px #ff6b6b;
     }
 
+    .task-card.cancelled::before {
+      background: #666;
+    }
+
     @keyframes pulse {
       0%, 100% { opacity: 1; }
       50% { opacity: 0.4; }
@@ -442,6 +446,12 @@
       background: #31191b;
       border-color: #b44;
       color: #ff9999;
+    }
+
+    .t-status.cancelled {
+      background: #1a1a1a;
+      border-color: #555;
+      color: #999;
     }
 
     .t-depends {
@@ -1061,6 +1071,13 @@
         }
         if (t.status === 'approved') {
           actionsHtml += `<span class="t-btn-done">✅ Approved</span>`;
+        }
+        if (t.status === 'cancelled') {
+          actionsHtml += `<span style="color:#999; font-size:12px;">🚫 Cancelled</span>`;
+        }
+        // Cancel button for non-terminal statuses
+        if (!['approved', 'cancelled', 'completed', 'reviewing', 'needs_revision'].includes(t.status)) {
+          actionsHtml += `<button class="t-btn block" onclick="if(confirm('Cancel task ${t.id}?')) setTaskStatus('${t.id}','cancelled')" style="background:#333;">🚫 Cancel</button>`;
         }
         actionsHtml += '</div>';
 

--- a/server/management.js
+++ b/server/management.js
@@ -330,14 +330,15 @@ function getControls(board) {
 }
 
 const ALLOWED_TASK_TRANSITIONS = {
-  pending: ['dispatched'],
-  dispatched: ['in_progress', 'pending'],
-  in_progress: ['blocked', 'completed', 'dispatched'],
-  blocked: ['in_progress', 'dispatched'],
+  pending: ['dispatched', 'cancelled'],
+  dispatched: ['in_progress', 'pending', 'cancelled'],
+  in_progress: ['blocked', 'completed', 'dispatched', 'cancelled'],
+  blocked: ['in_progress', 'dispatched', 'cancelled'],
   completed: ['reviewing', 'approved', 'needs_revision'],
   reviewing: ['approved', 'needs_revision'],
   needs_revision: ['in_progress', 'approved'],
   approved: [],
+  cancelled: [],
 };
 
 function canTransitionTaskStatus(fromStatus, toStatus) {

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -652,7 +652,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         const oldStatus = task.status;
         if (payload.status) {
           const nextStatus = String(payload.status).trim();
-          const validStatuses = ['pending', 'dispatched', 'in_progress', 'blocked', 'completed', 'reviewing', 'approved', 'needs_revision'];
+          const validStatuses = ['pending', 'dispatched', 'in_progress', 'blocked', 'completed', 'reviewing', 'approved', 'needs_revision', 'cancelled'];
           if (!validStatuses.includes(nextStatus)) {
             return json(res, 400, { error: `Invalid status. Must be one of: ${validStatuses.join(', ')}` });
           }
@@ -885,7 +885,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
       try {
         const payload = JSON.parse(body || '{}');
         const newStatus = String(payload.status || '').trim();
-        const validStatuses = ['pending', 'dispatched', 'in_progress', 'blocked', 'completed', 'reviewing', 'approved', 'needs_revision'];
+        const validStatuses = ['pending', 'dispatched', 'in_progress', 'blocked', 'completed', 'reviewing', 'approved', 'needs_revision', 'cancelled'];
         if (!validStatuses.includes(newStatus)) {
           return json(res, 400, { error: `Invalid status. Must be one of: ${validStatuses.join(', ')}` });
         }
@@ -926,6 +926,19 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         }
         if (newStatus !== 'blocked') task.blocker = null;
 
+        // Cancel: kill running steps, transition queued/running steps to cancelled
+        if (newStatus === 'cancelled') {
+          task.completedAt = helpers.nowIso();
+          for (const step of (task.steps || [])) {
+            if (step.state === 'running') {
+              try { deps.stepWorker.killStep(step.step_id); } catch {}
+              deps.stepSchema.transitionStep(step, 'cancelled', { error: 'Task cancelled' });
+            } else if (step.state === 'queued' || step.state === 'failed') {
+              deps.stepSchema.transitionStep(step, 'cancelled', { error: 'Task cancelled' });
+            }
+          }
+        }
+
         // Strict gate: only approved can unlock dependents
         if (newStatus === 'approved') {
           const unlocked = mgmt.autoUnlockDependents(board);
@@ -940,8 +953,8 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
           setImmediate(() => tryAutoDispatch(task.id, deps, helpers));
         }
 
-        // Update phase if all tasks approved
-        const allApproved = board.taskPlan.tasks.every(t => t.status === 'approved');
+        // Update phase if all tasks approved (cancelled tasks don't block)
+        const allApproved = board.taskPlan.tasks.every(t => t.status === 'approved' || t.status === 'cancelled');
         if (allApproved) board.taskPlan.phase = 'done';
 
         // Evolution Layer: emit status_change signal
@@ -967,7 +980,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         }
 
         // Push notification: fire-and-forget
-        if (['completed', 'blocked', 'needs_revision', 'approved'].includes(newStatus)) {
+        if (['completed', 'blocked', 'needs_revision', 'approved', 'cancelled'].includes(newStatus)) {
           push.notifyTaskEvent(PUSH_TOKENS_PATH, task, `task.${newStatus}`)
             .catch(err => console.error('[push] notify failed:', err.message));
         }

--- a/server/test-step-worker.js
+++ b/server/test-step-worker.js
@@ -508,6 +508,37 @@ function createMockEnvelope(overrides = {}) {
     assert.strictEqual(execs.length, 0);
   });
 
+  // Test 21: ALLOWED_TASK_TRANSITIONS includes cancelled
+  console.log('\n=== Task Cancel Transitions (#274) ===\n');
+
+  await test('cancelled is a terminal state with no outbound transitions', () => {
+    assert.deepStrictEqual(mgmt.ALLOWED_TASK_TRANSITIONS.cancelled, []);
+  });
+
+  await test('blocked → cancelled is allowed', () => {
+    assert.ok(mgmt.canTransitionTaskStatus('blocked', 'cancelled'));
+  });
+
+  await test('dispatched → cancelled is allowed', () => {
+    assert.ok(mgmt.canTransitionTaskStatus('dispatched', 'cancelled'));
+  });
+
+  await test('in_progress → cancelled is allowed', () => {
+    assert.ok(mgmt.canTransitionTaskStatus('in_progress', 'cancelled'));
+  });
+
+  await test('pending → cancelled is allowed', () => {
+    assert.ok(mgmt.canTransitionTaskStatus('pending', 'cancelled'));
+  });
+
+  await test('approved → cancelled is NOT allowed', () => {
+    assert.ok(!mgmt.canTransitionTaskStatus('approved', 'cancelled'));
+  });
+
+  await test('cancelled → dispatched is NOT allowed (terminal)', () => {
+    assert.ok(!mgmt.canTransitionTaskStatus('cancelled', 'dispatched'));
+  });
+
   // Cleanup
   try {
     fs.rmSync(path.join(artifactStore.ARTIFACT_DIR, testRunId), { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Add `cancelled` as terminal task state in `ALLOWED_TASK_TRANSITIONS`
- Non-terminal statuses (pending, dispatched, in_progress, blocked) can transition to cancelled
- Cancel kills all running steps and transitions queued/failed steps to cancelled
- UI: grey status bar, cancel button for non-terminal tasks
- 7 new tests covering transition rules

Closes #274

## Test plan
- [x] `blocked → cancelled` succeeds
- [x] `dispatched → cancelled` succeeds
- [x] `approved → cancelled` rejected (terminal)
- [x] `cancelled → dispatched` rejected (terminal)
- [x] Running steps killed on cancel
- [x] UI cancel button visible for non-terminal statuses
- [x] 38 tests pass (7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)