### PR TITLE
feat(dispatch): template-based step prompts

### DIFF
--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -15,6 +15,23 @@ const mgmt = require('./management');
 const { resolveRepoRoot } = require('./repo-resolver');
 const LOCK_GRACE_MS = 30_000; // 30s grace on top of step timeout
 
+const TEMPLATES_DIR = path.join(__dirname, 'templates');
+
+function renderTemplate(template, vars) {
+  return template.replace(/\{\{(\w+(?:\.\w+)*)\}\}/g, (_, pathStr) => {
+    return pathStr.split('.').reduce((o, k) => o?.[k], vars) ?? '';
+  });
+}
+
+function loadTemplate(stepType) {
+  const tplPath = path.join(TEMPLATES_DIR, `${stepType}.md`);
+  try {
+    return fs.readFileSync(tplPath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
 const ERROR_PATTERNS = [
   // Environment errors — non-retryable (fix environment before retrying)
   { pattern: /ENOENT/i, kind: 'CONFIG' },
@@ -987,11 +1004,19 @@ function buildStepMessage(envelope, upstreamArtifacts, board, task) {
     ].join('\n'),
   };
 
-  // Prefer task-defined semantic instructions over hard-coded step map.
-  const skillMsg = (typeof envelope.instruction === 'string' && envelope.instruction.trim())
-    || (typeof envelope.skill === 'string' && envelope.skill.trim() ? `Execute ${envelope.skill.trim()}` : null)
-    || STEP_SKILL_MAP[envelope.step_type]
-    || `Complete the ${envelope.step_type} step for task ${envelope.task_id}.`;
+  // Prefer external template, then task-defined instructions, then hardcoded map.
+  const tplContent = loadTemplate(envelope.step_type);
+  let skillMsg;
+  if (tplContent) {
+    skillMsg = renderTemplate(tplContent, { issueNumber, step_type: envelope.step_type });
+  } else if (typeof envelope.instruction === 'string' && envelope.instruction.trim()) {
+    skillMsg = envelope.instruction.trim();
+  } else if (typeof envelope.skill === 'string' && envelope.skill.trim()) {
+    skillMsg = `Execute ${envelope.skill.trim()}`;
+  } else {
+    skillMsg = STEP_SKILL_MAP[envelope.step_type]
+      || `Complete the ${envelope.step_type} step for task ${envelope.task_id}.`;
+  }
 
   const stepHeader = String(envelope.step_type || '').toUpperCase();
   const objective = envelope.objective || `Execute step: ${envelope.step_type}`;
@@ -1137,4 +1162,4 @@ function recoverExpiredLocks(board) {
   return recovered;
 }
 
-module.exports = { createStepWorker, parseStepResult, buildStepMessage, recoverExpiredLocks, runPreflight, extractPreflightTargets, validateContract, classifyError, applyScopeGuard, isOutOfScope, revertFile };
+module.exports = { createStepWorker, parseStepResult, buildStepMessage, recoverExpiredLocks, runPreflight, extractPreflightTargets, validateContract, classifyError, applyScopeGuard, isOutOfScope, revertFile, renderTemplate, loadTemplate };

--- a/server/templates/implement.md
+++ b/server/templates/implement.md
@@ -1,0 +1,28 @@
+## Role
+Your role is to implement the plan and deliver a pull request. You MUST complete ALL of the following actions.
+
+## Instructions
+Load the "issue-action" skill for issue #{{issueNumber}}:
+You have a "Skill" tool available. Use it to load the skill by name (e.g., Skill("issue-plan")), then follow its instructions.
+The plan has been posted as a comment on the issue — read it from there.
+
+## Required Actions (in order)
+1. Read the plan: `gh issue view {{issueNumber}} --comments`
+2. Implement EVERY item in the plan — do not skip any requirement
+3. Verify syntax on each modified file: `node -c <file>`
+4. Run tests to verify nothing is broken (e.g., `npm test` or individual test files)
+5. Commit all changes: `git add <files> && git commit -m "feat(scope): description (GH-{{issueNumber}})"`
+6. Push the branch: `git push -u origin $(git branch --show-current)`
+7. Create a pull request: `gh pr create --title "..." --body "Closes #{{issueNumber}}"`
+
+## Deliverable
+A merged-ready pull request on GitHub. The pipeline verifies the PR exists — if you skip step 6 or 7, the step WILL fail and retry.
+
+## STEP_RESULT Output
+Your final STEP_RESULT MUST include a "prUrl" field with the full PR URL:
+STEP_RESULT:{"status":"succeeded","summary":"...","prUrl":"https://github.com/owner/repo/pull/123"}
+
+## STRICTLY PROHIBITED
+- Skipping any requirement from the plan
+- Reporting success without pushing and creating a PR
+- Adding features or changes not described in the plan

--- a/server/templates/plan.md
+++ b/server/templates/plan.md
@@ -1,0 +1,19 @@
+## Role
+Your role is EXCLUSIVELY to research and plan. You are STRICTLY PROHIBITED from:
+- Modifying any source code files
+- Running git commit, git push, or gh pr create
+- Making implementation changes of any kind
+
+## Instructions
+Load the "issue-plan" skill for issue #{{issueNumber}}:
+You have a "Skill" tool available. Use it to load the skill by name (e.g., Skill("issue-plan")), then follow its instructions.
+
+## Required Actions (in order)
+1. Read the full GitHub issue: `gh issue view {{issueNumber}}`
+2. Research the codebase — read relevant files, grep for patterns, understand existing code
+3. For each requirement in the issue, identify the exact files and line numbers to change
+4. Write a concrete plan with specific code changes (not vague descriptions)
+5. Post the plan as a comment on the issue: `gh issue comment {{issueNumber}} --body "..."`
+
+## Deliverable
+A plan comment posted on issue #{{issueNumber}}. The plan must list every file to modify, what to change, and why.

--- a/server/templates/review.md
+++ b/server/templates/review.md
@@ -1,0 +1,25 @@
+## Role
+Your role is EXCLUSIVELY to review code quality. You are STRICTLY PROHIBITED from:
+- Modifying any source code files
+- Running git commit or git push
+- Making implementation changes of any kind
+
+## Instructions
+Load the "pr-review" skill:
+You have a "Skill" tool available. Use it to load the skill by name (e.g., Skill("issue-plan")), then follow its instructions.
+
+## Required Actions (in order)
+1. Find the PR: `gh pr list --head "$(git branch --show-current)" --json number,url`
+2. Read the full diff: `gh pr diff <number>`
+3. Run the four-point check: Scope, Reality, Testing, YAGNI
+4. Post your review as a PR comment: `gh pr comment <number> --body "..."`
+5. Include a clear verdict: **LGTM** or **Changes Requested**
+
+## STEP_RESULT Mapping
+Your final STEP_RESULT status MUST match your verdict:
+- LGTM (no blocking issues): STEP_RESULT:{"status":"succeeded","summary":"LGTM — ..."}
+- Changes Requested: STEP_RESULT:{"status":"needs_revision","summary":"Changes Requested — ...","revision_notes":"what to fix"}
+- Critical blocker (security, data loss): STEP_RESULT:{"status":"failed","summary":"Blocker — ..."}
+
+## Deliverable
+A review comment posted on the PR with a clear verdict.


### PR DESCRIPTION
## Summary

- Replace hardcoded `buildStepMessage()` prompts with external template files
- Create `server/templates/{plan,implement,review}.md` with Mustache-style `{{issueNumber}}` variables
- Add `renderTemplate()` and `loadTemplate()` helper functions (zero external dependencies)
- Fallback to existing `STEP_SKILL_MAP` if template file missing

Closes #276

## Changes

| File | Action |
|------|--------|
| `server/templates/plan.md` | Create |
| `server/templates/implement.md` | Create |
| `server/templates/review.md` | Create |
| `server/step-worker.js` | Modify |

## Testing

All 47 tests pass in `server/test-step-worker.js`

## Verification Checklist

- [x] `plan.md`, `implement.md`, `review.md` exist in `server/templates/`
- [x] Templates use `{{issueNumber}}` variable syntax
- [x] `renderTemplate()` interpolates variables correctly
- [x] `buildStepMessage()` falls back to `STEP_SKILL_MAP` if template missing
- [x] Existing tests pass
- [x] Editing a template file takes effect on next dispatch (no restart needed)