### PR TITLE
feat(tasks): complete scope config passthrough

### DIFF
--- a/index.html
+++ b/index.html
@@ -388,6 +388,12 @@
       background: #666;
     }
 
+    .t-scope-indicator {
+      font-size: 14px;
+      cursor: help;
+      margin: 0 4px;
+    }
+
     @keyframes pulse {
       0%, 100% { opacity: 1; }
       50% { opacity: 0.4; }
@@ -1114,20 +1120,21 @@
           replyHtml = `<div class="t-reply"><div class="t-reply-label">Last reply (${fmtTime(t.lastReplyAt)}):</div><div class="t-reply-text">${escapeHtml(preview)}</div></div>`;
         }
 
-        return `
-           <div class="task-card ${t.status}">
-              <div class="t-meta">
-                <span>#${t.id} · ${participantName(t.assignee)}</span>
-                <span class="t-status ${t.status}">${t.status}</span>
-              </div>
-              <div class="t-title">${escapeHtml(t.title)}</div>
-              ${dependsHtml}
-              ${blockerHtml}
-              ${reviewHtml}
-              ${replyHtml}
-              ${actionsHtml}
-           </div>
-         `;
+         return `
+            <div class="task-card ${t.status}">
+               <div class="t-meta">
+                 <span>#${t.id} · ${participantName(t.assignee)}</span>
+                 ${t.scope ? `<span class="t-scope-indicator" title="Scope: allow=${t.scope.allow?.join(',') || 'none'}, deny=${t.scope.deny?.join(',') || 'none'}">🔒</span>` : ''}
+                 <span class="t-status ${t.status}">${t.status}</span>
+               </div>
+               <div class="t-title">${escapeHtml(t.title)}</div>
+               ${dependsHtml}
+               ${blockerHtml}
+               ${reviewHtml}
+               ${replyHtml}
+               ${actionsHtml}
+            </div>
+          `;
       }).join('');
     }
 

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -605,7 +605,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         if (!board.taskPlan.createdAt) board.taskPlan.createdAt = payload.createdAt || helpers.nowIso();
 
         const ACTIVE_STATUSES = ['in_progress', 'dispatched'];
-        const SAFE_FIELDS = ['title', 'description', 'assignee', 'depends', 'spec', 'skill', 'estimate', 'target_repo'];
+        const SAFE_FIELDS = ['title', 'description', 'assignee', 'depends', 'spec', 'skill', 'estimate', 'target_repo', 'scope'];
         const incomingTasks = Array.isArray(payload.tasks) ? payload.tasks : [];
         const existingIds = new Set(board.taskPlan.tasks.map(t => t.id));
         for (const t of incomingTasks) {
@@ -618,7 +618,21 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
             }
             continue;
           }
-          board.taskPlan.tasks.push(t);
+          const newTask = {
+            id: t.id,
+            title: t.title,
+            description: t.description || '',
+            assignee: t.assignee || null,
+            depends: t.depends || [],
+            status: (t.depends?.length > 0) ? 'pending' : 'dispatched',
+            spec: t.spec || null,
+            skill: t.skill || null,
+            estimate: t.estimate || null,
+            target_repo: t.target_repo || null,
+            history: [{ ts: helpers.nowIso(), status: (t.depends?.length > 0) ? 'pending' : 'dispatched', reason: 'api_created' }],
+          };
+          if (t.scope) newTask.scope = t.scope;
+          board.taskPlan.tasks.push(newTask);
         }
 
         helpers.writeBoard(board);


### PR DESCRIPTION
## Summary
Fix scope config passthrough across all task APIs to ensure scope field is properly accepted, preserved, and visualized.

## Changes

### Backend (server/routes/tasks.js)
1. **Add scope to SAFE_FIELDS** (line 608) - Ensures scope is preserved when updating tasks via PATCH/PUT
2. **Normalize task creation** (lines 611-637) - Accept and store scope field when creating new tasks via POST /api/tasks

### Frontend (index.html)
3. **Add scope indicator** (line 1121) - Display 🔒 icon in task cards when scope is configured, with hover tooltip showing allow/deny lists
4. **Add CSS styling** (line 391) - Style the scope indicator for consistent UI

## Acceptance Criteria ✅
- [x] POST /api/tasks 支援 scope 欄位
- [x] 更新任務時 scope 不被 strip (added to SAFE_FIELDS)
- [x] UI task card 顯示 scope 狀態 (icon/badge with hover)

## Testing
- Syntax verification: `node -c server/routes/tasks.js` ✅
- Manual verification: Task cards display scope indicator with proper tooltip
- Backward compatible: Tasks without scope continue to work normally

Closes #288