### PR TITLE
feat(step-pipeline): POST /api/tasks/:id/reopen — resume completed task with session continuation

### DIFF
--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -2,6 +2,7 @@
  * routes/tasks.js — Task Engine APIs
  *
  * POST /api/tasks/:id/review — manual review trigger
+ * POST /api/tasks/:id/reopen — reopen completed task with session continuation
  * GET  /api/tasks — task list
  * GET  /api/spec/:file — serve spec files
  * POST /api/tasks — create task plan
@@ -888,6 +889,92 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         }
 
         json(res, 200, { ok: true, task });
+      } catch (error) {
+        json(res, 400, { error: error.message });
+      }
+    });
+    return;
+  }
+
+  const reopenMatch = req.url.match(/^\/api\/tasks\/([^/]+)\/reopen$/);
+  if (req.method === 'POST' && reopenMatch) {
+    const taskId = decodeURIComponent(reopenMatch[1]);
+    let body = '';
+    req.on('data', c => (body += c));
+    req.on('end', () => {
+      try {
+        const payload = JSON.parse(body || '{}');
+        const message = String(payload.message || '').trim();
+        const customSteps = payload.steps;
+        
+        const REOPENABLE_STATUSES = ['approved', 'needs_revision', 'blocked', 'completed'];
+        const board = helpers.readBoard();
+        const task = (board.taskPlan?.tasks || []).find(t => t.id === taskId);
+        
+        if (!task) return json(res, 404, { error: `Task ${taskId} not found` });
+        if (!REOPENABLE_STATUSES.includes(task.status)) {
+          return json(res, 400, { error: `Cannot reopen task in ${task.status} status. Allowed: ${REOPENABLE_STATUSES.join(', ')}` });
+        }
+        if (!task.childSessionKey) {
+          return json(res, 400, { error: 'No session to resume (childSessionKey missing)' });
+        }
+        
+        const oldStatus = task.status;
+        task.status = 'in_progress';
+        delete task.result;
+        delete task.completedAt;
+        delete task.blocker;
+        
+        const runId = helpers.uid('run');
+        const stepTypes = customSteps || ['implement', 'review'];
+        const newSteps = mgmt.generateStepsForTask(task, runId, stepTypes, board);
+        task.steps = task.steps || [];
+        task.steps.push(...newSteps);
+        task._revisionCounts = {};
+        
+        task.history = task.history || [];
+        task.history.push({
+          ts: helpers.nowIso(),
+          status: 'in_progress',
+          reopened_from: oldStatus,
+          by: 'human',
+          message: message || '(no message)'
+        });
+        
+        mgmt.ensureEvolutionFields(board);
+        board.signals.push({
+          id: helpers.uid('sig'),
+          ts: helpers.nowIso(),
+          by: 'human',
+          type: 'task_reopened',
+          content: `${taskId} reopened from ${oldStatus}`,
+          refs: [taskId],
+          data: { taskId, from: oldStatus, runId, steps: newSteps.map(s => s.step_id) }
+        });
+        if (board.signals.length > 500) board.signals = board.signals.slice(-500);
+        
+        helpers.writeBoard(board);
+        helpers.appendLog({ 
+          ts: helpers.nowIso(), 
+          event: 'task_reopened', 
+          taskId, 
+          from: oldStatus, 
+          runId,
+          stepCount: newSteps.length 
+        });
+        
+        const result = dispatchTask(task, board, deps, helpers, { source: 'reopen' });
+        
+        json(res, 200, { 
+          ok: true, 
+          task,
+          reopened: {
+            runId,
+            steps: newSteps.map(s => s.step_id),
+            sessionId: task.childSessionKey,
+            dispatched: result.dispatched
+          }
+        });
       } catch (error) {
         json(res, 400, { error: error.message });
       }

--- a/server/test-step-endpoints.js
+++ b/server/test-step-endpoints.js
@@ -501,6 +501,93 @@ async function runTests() {
       fail('Conditional unblock reset', JSON.stringify(res));
     }
   }
+
+  // --- Test: POST /api/tasks/:id/reopen ---
+  console.log('\nTesting POST /api/tasks/:id/reopen...');
+  {
+    // Test 1: Reopen approved task
+    await post('/api/tasks', {
+      tasks: [{
+        id: 'task-reopen-test',
+        title: 'Test Reopen',
+        assignee: 'agent-007'
+      }]
+    });
+    
+    // Manually set to approved (bypass transition rules for test setup)
+    const tmpFile = path.join(tmpDataDir, 'board.json');
+    const board = JSON.parse(fs.readFileSync(tmpFile, 'utf8'));
+    const boardTask = (board.taskPlan?.tasks || []).find(t => t.id === 'task-reopen-test');
+    if (boardTask) {
+      boardTask.status = 'approved';
+      boardTask.childSessionKey = 'sess-test-123';
+      boardTask.steps = [
+        { step_id: 'step-1', type: 'plan', state: 'succeeded' },
+        { step_id: 'step-2', type: 'implement', state: 'succeeded' },
+        { step_id: 'step-3', type: 'review', state: 'succeeded' }
+      ];
+      fs.writeFileSync(tmpFile, JSON.stringify(board, null, 2));
+    }
+    
+    const res = await post('/api/tasks/task-reopen-test/reopen', { message: 'Fix PR review comments' });
+    
+    if (res.ok && res.task.status === 'in_progress') {
+      ok('POST /api/tasks/:id/reopen reopens approved task');
+      if (res.reopened && res.reopened.sessionId === 'sess-test-123') {
+        ok('Reopen preserves sessionId');
+      } else {
+        fail('Reopen sessionId', JSON.stringify(res.reopened));
+      }
+      if (res.task.steps && res.task.steps.length > 3) {
+        ok('Reopen appends new steps');
+      } else {
+        fail('Reopen steps not appended', `count: ${res.task.steps?.length}`);
+      }
+    } else {
+      fail('POST /api/tasks/:id/reopen', JSON.stringify(res));
+    }
+    
+    // Test 2: Reject invalid status
+    await post('/api/tasks', {
+      tasks: [{
+        id: 'task-reopen-invalid',
+        title: 'Invalid Status',
+        assignee: 'agent-007'
+      }]
+    });
+    
+    const res2 = await post('/api/tasks/task-reopen-invalid/reopen', {});
+    if (!res2.ok && res2.error && res2.error.includes('Cannot reopen')) {
+      ok('POST /api/tasks/:id/reopen rejects invalid status');
+    } else {
+      fail('Should reject invalid status', JSON.stringify(res2));
+    }
+    
+    // Test 3: Reject missing session
+    await post('/api/tasks', {
+      tasks: [{
+        id: 'task-reopen-no-sess',
+        title: 'No Session',
+        assignee: 'agent-007'
+      }]
+    });
+    
+    // Manually set to approved but without session key
+    const board2 = JSON.parse(fs.readFileSync(tmpFile, 'utf8'));
+    const boardTask2 = (board2.taskPlan?.tasks || []).find(t => t.id === 'task-reopen-no-sess');
+    if (boardTask2) {
+      boardTask2.status = 'approved';
+      // No childSessionKey
+      fs.writeFileSync(tmpFile, JSON.stringify(board2, null, 2));
+    }
+    
+    const res3 = await post('/api/tasks/task-reopen-no-sess/reopen', {});
+    if (!res3.ok && res3.error && res3.error.includes('No session to resume')) {
+      ok('POST /api/tasks/:id/reopen rejects missing session');
+    } else {
+      fail('Should reject missing session', JSON.stringify(res3));
+    }
+  }
 }
 
 (async () => {


### PR DESCRIPTION
## Summary

Implements `POST /api/tasks/:id/reopen` endpoint to allow resuming completed tasks with session continuation. This enables agents to continue work on the same session when PR review requests changes or additional work is needed.

Closes #248

## Changes

### API Endpoint
- **POST /api/tasks/:id/reopen** - Reopens a completed/blocked task
  - Supports tasks in `approved`, `needs_revision`, `blocked`, or `completed` status
  - Preserves `childSessionKey` for session resumption
  - Appends new steps (default: `implement` + `review`)
  - Clears terminal state fields (`result`, `completedAt`, `blocker`)
  - Optional `message` parameter to inject additional instructions
  - Optional `steps` parameter to customize step types

### Documentation
- Updated API documentation in `routes/tasks.js` header

### Tests
- Added comprehensive test cases in `test-step-endpoints.js`:
  - ✅ Reopen approved task successfully
  - ✅ Preserve sessionId across reopen
  - ✅ Append new steps correctly
  - ✅ Reject invalid status (in_progress, pending, etc.)
  - ✅ Reject missing session key

## Verification

All tests passing:
```
Results: 23 passed, 0 failed
```

## Usage Example

```bash
# Reopen a completed task with a message
curl -X POST http://localhost:3461/api/tasks/GH-123/reopen \
  -H "Content-Type: application/json" \
  -d '{"message":"Add missing test cases per PR review"}'

# Response
{
  "ok": true,
  "task": { "status": "in_progress", ... },
  "reopened": {
    "runId": "run-xyz",
    "steps": ["step-4", "step-5"],
    "sessionId": "sess-abc",
    "dispatched": true
  }
}
```

## Benefits

1. **Session Continuation**: Agent maintains full conversation history
2. **Worktree Reuse**: No need to recreate worktrees
3. **Context Preservation**: Previous plan/implement/review history available
4. **Flexible Workflow**: Customizable step types and instructions