### PR TITLE
fix(GH-304):remove-empty-catch-blocks

### DIFF
--- a/app/app/(tabs)/reviews.tsx
+++ b/app/app/(tabs)/reviews.tsx
@@ -46,13 +46,17 @@ function ReviewCard({ task, theme: t }: { task: Task; theme: Theme }) {
   const handleApprove = async () => {
     try {
       await updateTaskStatus(task.id, 'approved');
-    } catch {}
+    } catch (err: any) {
+      console.warn(`[reviews] approve failed for ${task.id}:`, err?.message || err);
+    }
   };
 
   const handleReject = async () => {
     try {
       await updateTaskStatus(task.id, 'needs_revision');
-    } catch {}
+    } catch (err: any) {
+      console.warn(`[reviews] reject failed for ${task.id}:`, err?.message || err);
+    }
   };
 
   return (

--- a/app/hooks/useSSE.ts
+++ b/app/hooks/useSSE.ts
@@ -65,7 +65,9 @@ export function useSSE() {
       fetch(`${serverUrl}/api/board`, { headers })
         .then((r) => r.json())
         .then((b) => setBoard(b))
-        .catch(() => {});
+        .catch((err) => {
+          console.warn('[useSSE] initial board fetch failed:', err?.message || err);
+        });
     });
 
     es.addEventListener('board', (e) => {

--- a/brief-panel/index.html
+++ b/brief-panel/index.html
@@ -624,9 +624,13 @@ function startPoll() {
                 try {
                     const { taskId, data } = JSON.parse(e.data);
                     if (taskId === TASK_ID && data) { brief = data; render(); }
-                } catch {}
+                } catch (err) {
+                    console.warn('[brief-panel] invalid SSE payload:', err.message);
+                }
             });
-        } catch {}
+        } catch (err) {
+            console.warn('[brief-panel] SSE initialization failed:', err.message);
+        }
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -979,7 +979,9 @@
           el('ctrl-timeout').value = ctrl.review_timeout_sec || 180;
           el('ctrl-agent').value = ctrl.review_agent || 'engineer_lite';
         }
-      } catch {}
+      } catch (err) {
+        console.warn('[ui] failed to load controls:', err.message);
+      }
     }
 
     function renderControls() {
@@ -1196,7 +1198,10 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
-      const data = await res.json().catch(() => ({}));
+      const data = await res.json().catch((err) => {
+        console.warn('[ui] failed to parse POST response JSON:', err.message);
+        return {};
+      });
       if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
       return data;
     }

--- a/scripts/go.js
+++ b/scripts/go.js
@@ -244,7 +244,9 @@ function runLocalPreflight() {
       lines.push(`  ✓ Runtime CLI found: ${name}`);
       runtimeFound = true;
       break;
-    } catch {}
+    } catch (err) {
+      lines.push(`  - Runtime CLI not available: ${name} (${err.message})`);
+    }
   }
   
   if (!runtimeFound) {

--- a/server/instance-manager.js
+++ b/server/instance-manager.js
@@ -261,7 +261,11 @@ async function destroyInstance(instanceId, { graceful = true } = {}) {
   // Force kill if still alive
   const child = childProcesses.get(instanceId);
   if (child) {
-    try { child.kill(); } catch {}
+    try {
+      child.kill();
+    } catch (err) {
+      console.error(`[instance-manager] child.kill failed for ${instanceId}:`, err.message);
+    }
     childProcesses.delete(instanceId);
   }
 
@@ -391,7 +395,9 @@ async function destroyAll() {
   const ids = Object.keys(registry.instances).filter(
     id => registry.instances[id].status === 'running' || registry.instances[id].status === 'starting'
   );
-  await Promise.all(ids.map(id => destroyInstance(id).catch(() => {})));
+  await Promise.all(ids.map(id => destroyInstance(id).catch(err => {
+    console.error(`[instance-manager] destroyAll failed for ${id}:`, err.message);
+  })));
 }
 
 module.exports = {

--- a/server/integration-jira.js
+++ b/server/integration-jira.js
@@ -24,6 +24,14 @@ function isEnabled(board) {
   return !!(cfg?.enabled && process.env.JIRA_API_TOKEN && process.env.JIRA_EMAIL);
 }
 
+function safeJsonParse(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // HTTPS client (zero-dep)
 // ---------------------------------------------------------------------------
@@ -55,8 +63,7 @@ function jiraRequest(method, apiPath, body) {
       let d = '';
       res.on('data', c => (d += c));
       res.on('end', () => {
-        let parsed = null;
-        try { parsed = JSON.parse(d); } catch {}
+        const parsed = safeJsonParse(d);
         resolve({ status: res.statusCode, body: parsed, raw: d });
       });
     });

--- a/server/kill-tree.js
+++ b/server/kill-tree.js
@@ -10,7 +10,9 @@ function killTree(pid) {
     } else {
       process.kill(-pid, 'SIGKILL');
     }
-  } catch {}
+  } catch (err) {
+    console.error(`[kill-tree] failed to kill process tree for pid=${pid}:`, err.message);
+  }
 }
 
 module.exports = killTree;

--- a/server/management.js
+++ b/server/management.js
@@ -703,25 +703,28 @@ function buildSkillContextSection(projectRoot) {
     const skillDir = candidates.find(d => fs.existsSync(d)) || path.join(__dirname, 'skills');
 
     // Extract coding rules from engineer-playbook
-    try {
-      const ep = fs.readFileSync(path.join(skillDir, 'engineer-playbook', 'SKILL.md'), 'utf8');
+    const epPath = path.join(skillDir, 'engineer-playbook', 'SKILL.md');
+    if (fs.existsSync(epPath)) {
+      const ep = fs.readFileSync(epPath, 'utf8');
       const match = ep.match(/## (?:Step 4|Code Style|代碼規範|coding|執行任務)[\s\S]*?(?=\n## |\n---)/i);
       if (match) excerpts.push(match[0].trim().slice(0, 600));
-    } catch {}
+    }
 
     // Extract constraints from blackboard-basics
-    try {
-      const bb = fs.readFileSync(path.join(skillDir, 'blackboard-basics', 'SKILL.md'), 'utf8');
+    const bbPath = path.join(skillDir, 'blackboard-basics', 'SKILL.md');
+    if (fs.existsSync(bbPath)) {
+      const bb = fs.readFileSync(bbPath, 'utf8');
       const match = bb.match(/## (?:設計約束|Design Constraints|6 大約束)[\s\S]*?(?=\n## |\n---)/i);
       if (match) excerpts.push(match[0].trim().slice(0, 400));
-    } catch {}
+    }
 
     // Extract from project-principles skill (common across projects)
-    try {
-      const pp = fs.readFileSync(path.join(skillDir, 'project-principles', 'SKILL.md'), 'utf8');
+    const ppPath = path.join(skillDir, 'project-principles', 'SKILL.md');
+    if (fs.existsSync(ppPath)) {
+      const pp = fs.readFileSync(ppPath, 'utf8');
       const match = pp.match(/## (?:Core Principles|核心原則|Architecture)[\s\S]*?(?=\n## |\n---)/i);
       if (match) excerpts.push(match[0].trim().slice(0, 400));
-    } catch {}
+    }
 
     if (excerpts.length === 0) {
       if (!projectRoot) {

--- a/server/process-review.js
+++ b/server/process-review.js
@@ -56,6 +56,14 @@ function uid(prefix) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+function safeJsonParse(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    return null;
+  }
+}
+
 function appendLog(entry) {
   storageBackend.appendLog(LOG_PATH, entry);
 }
@@ -85,11 +93,12 @@ function inferTargetDir(board, task) {
   let targetDir = '';
 
   if (specPath) {
-    try {
-      const specContent = fs.readFileSync(path.join(DIR, specPath), 'utf8');
+    const resolvedSpecPath = path.join(DIR, specPath);
+    if (fs.existsSync(resolvedSpecPath)) {
+      const specContent = fs.readFileSync(resolvedSpecPath, 'utf8');
       const m = specContent.match(/^project\/([a-z0-9-]+)\/$/m);
       if (m) targetDir = path.join(WORKSPACE, 'project', m[1]);
-    } catch {}
+    }
   }
 
   if (!targetDir && task.description) {
@@ -109,7 +118,9 @@ function inferTargetDir(board, task) {
           }
         }
       }
-    } catch {}
+    } catch (err) {
+      console.error('[process-review] inferTargetDir project scan failed:', err.message);
+    }
   }
 
   return targetDir;
@@ -166,7 +177,9 @@ function runDeterministicChecks(targetDir) {
         ? lines.slice(0, 40).join('\n') + `\n... (${lines.length - 80} lines omitted) ...\n` + lines.slice(-40).join('\n')
         : content;
       excerpts.push({ name: f, excerpt: excerpt.slice(0, MAX_CHARS) });
-    } catch {}
+    } catch (err) {
+      console.error(`[process-review] deterministic check failed for ${f}:`, err.message);
+    }
   }
 
   return { issues, files, excerpts };
@@ -235,8 +248,8 @@ Score guide:
   if (result.status !== 0) throw new Error(result.stderr || result.stdout || `exit code ${result.status}`);
 
   let replyText = '';
-  try {
-    const parsed = JSON.parse(result.stdout.trim());
+  const parsed = safeJsonParse(result.stdout.trim());
+  if (parsed) {
     const payloads = parsed?.result?.payloads;
     if (Array.isArray(payloads) && payloads.length > 0) {
       replyText = payloads.map(p => p?.text).filter(Boolean).join('\n\n').trim();
@@ -244,7 +257,7 @@ Score guide:
     if (!replyText) {
       replyText = parsed?.reply || parsed?.text || parsed?.result?.reply || parsed?.result?.text || '';
     }
-  } catch {}
+  }
 
   if (!replyText) replyText = result.stdout.trim();
 
@@ -262,7 +275,11 @@ function parseReviewResult(text) {
   for (let i = lines.length - 1; i >= 0; i--) {
     const m = lines[i].trim().match(/^REVIEW_RESULT:\s*(\{.*\})$/);
     if (m) {
-      try { result = JSON.parse(m[1]); source = 'line'; } catch {}
+      const parsed = safeJsonParse(m[1]);
+      if (parsed) {
+        result = parsed;
+        source = 'line';
+      }
       break;
     }
   }
@@ -270,24 +287,37 @@ function parseReviewResult(text) {
   // Strategy 2: inline
   if (!result) {
     const m = text.match(/REVIEW_RESULT:\s*(\{[^\n]*\})/);
-    if (m) try { result = JSON.parse(m[1]); source = 'inline'; } catch {}
+    if (m) {
+      const parsed = safeJsonParse(m[1]);
+      if (parsed) {
+        result = parsed;
+        source = 'inline';
+      }
+    }
   }
 
   // Strategy 3: JSON code block
   if (!result) {
     const m = text.match(/```(?:json)?\s*\n(\{[\s\S]*?\})\s*\n```/);
     if (m) {
-      try {
-        const p = JSON.parse(m[1]);
-        if (typeof p.score === 'number' || typeof p.pass === 'boolean') { result = p; source = 'code_block'; }
-      } catch {}
+      const parsed = safeJsonParse(m[1]);
+      if (parsed && (typeof parsed.score === 'number' || typeof parsed.pass === 'boolean')) {
+        result = parsed;
+        source = 'code_block';
+      }
     }
   }
 
   // Strategy 4: bare JSON with score or pass
   if (!result) {
     const m = text.match(/\{[^{}]*"(?:score|pass)"\s*:[^{}]*\}/);
-    if (m) try { result = JSON.parse(m[0]); source = 'bare_json'; } catch {}
+    if (m) {
+      const parsed = safeJsonParse(m[0]);
+      if (parsed) {
+        result = parsed;
+        source = 'bare_json';
+      }
+    }
   }
 
   // Strategy 5: keyword inference
@@ -360,7 +390,11 @@ function main() {
 
   // Backup
   if (!args.dryRun) {
-    try { fs.copyFileSync(boardPath, boardPath + '.bak'); } catch {}
+    try {
+      fs.copyFileSync(boardPath, boardPath + '.bak');
+    } catch (err) {
+      console.error('[process-review] board backup failed:', err.message);
+    }
   }
 
   const conv = board.conversations?.[0];

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -140,7 +140,9 @@ function cancelTaskFlow(task, board, deps, helpers, opts = {}) {
       try {
         const killResult = deps.stepWorker?.killStep?.(step.step_id);
         if (killResult?.ok) killedSteps++;
-      } catch {}
+      } catch (err) {
+        console.error(`[tasks] cancel killStep failed for ${task.id}/${step.step_id}:`, err.message);
+      }
       deps.stepSchema.transitionStep(step, 'cancelled', { error: reason });
       cancelledSteps++;
     } else if (step.state === 'queued' || step.state === 'failed') {

--- a/server/runtime-claude.js
+++ b/server/runtime-claude.js
@@ -21,7 +21,9 @@ function resolveClaudePath() {
       const p = execSync('where claude', { encoding: 'utf8', timeout: 5000 })
         .trim().split('\n')[0].trim();
       if (p && fs.existsSync(p)) return p;
-    } catch {}
+    } catch (err) {
+      console.warn('[claude-rt] unable to resolve claude via "where":', err.message);
+    }
     // Fallback: common install location
     const local = path.join(process.env.USERPROFILE || '', '.local/bin/claude.exe');
     if (fs.existsSync(local)) return local;
@@ -127,7 +129,11 @@ function dispatch(plan) {
       const now = Date.now();
       if (now - lastHeartbeat < HEARTBEAT_INTERVAL_MS) return;
       lastHeartbeat = now;
-      try { plan.onActivity(); } catch {}
+      try {
+        plan.onActivity();
+      } catch (err) {
+        console.error('[claude-rt] onActivity callback failed:', err.message);
+      }
     }
 
     // --- Inactivity timeout: resets on every stream event ---

--- a/server/runtime-codex.js
+++ b/server/runtime-codex.js
@@ -32,7 +32,9 @@ function resolveCodexPath() {
       if (cmd && fs.existsSync(cmd.trim())) return cmd.trim();
       const first = lines[0]?.trim();
       if (first && fs.existsSync(first)) return first;
-    } catch {}
+    } catch (err) {
+      console.warn('[codex-rt] unable to resolve codex via "where":', err.message);
+    }
   }
 
   return 'codex';
@@ -107,7 +109,11 @@ function dispatch(plan) {
       const now = Date.now();
       if (now - lastHeartbeat < HEARTBEAT_INTERVAL_MS) return;
       lastHeartbeat = now;
-      try { plan.onActivity(); } catch {}
+      try {
+        plan.onActivity();
+      } catch (err) {
+        console.error('[codex-rt] onActivity callback failed:', err.message);
+      }
     }
 
     // Validate cwd exists before spawn (fail immediately, not after 300s timeout)
@@ -123,7 +129,9 @@ function dispatch(plan) {
       try {
         const token = execSync('gh auth token', { encoding: 'utf8', timeout: 5000 }).trim();
         if (token) env.GH_TOKEN = token;
-      } catch {}
+      } catch (err) {
+        console.warn('[codex-rt] unable to read gh auth token:', err.message);
+      }
     }
 
     // Windows: .cmd shims must be invoked via cmd.exe
@@ -169,7 +177,11 @@ function dispatch(plan) {
       settled = true;
       clearTimeout(inactivityTimer);
       clearInterval(heartbeatInterval);
-      try { fs.unlinkSync(msgFile); } catch {}
+      try {
+        fs.unlinkSync(msgFile);
+      } catch (err) {
+        console.warn('[codex-rt] temp message cleanup failed:', err.message);
+      }
       if (err) reject(err); else resolve(result);
     }
 
@@ -274,7 +286,9 @@ function dispatch(plan) {
                 tool_calls: toolCallCount,
                 tokens: { ...totalTokens },
               });
-            } catch {}
+            } catch (err) {
+              console.error('[codex-rt] onProgress callback failed:', err.message);
+            }
           }
         }
 

--- a/server/runtime-openclaw.js
+++ b/server/runtime-openclaw.js
@@ -83,7 +83,11 @@ function runOpenclawTurn({ agentId, sessionId, message, timeoutSec = 180, onActi
       const now = Date.now();
       if (now - lastHeartbeat < HEARTBEAT_INTERVAL_MS) return;
       lastHeartbeat = now;
-      try { onActivity(); } catch {}
+      try {
+        onActivity();
+      } catch (err) {
+        console.error('[openclaw-rt] onActivity callback failed:', err.message);
+      }
     }
 
     child.stdout.setEncoding('utf8');

--- a/server/runtime-opencode.js
+++ b/server/runtime-opencode.js
@@ -34,7 +34,9 @@ function resolveOpencodePath() {
       // Fallback to first result
       const first = lines[0]?.trim();
       if (first && fs.existsSync(first)) return first;
-    } catch {}
+    } catch (err) {
+      console.warn('[opencode-rt] unable to resolve opencode via "where":', err.message);
+    }
   }
 
   return 'opencode';
@@ -89,7 +91,11 @@ function dispatch(plan) {
       const now = Date.now();
       if (now - lastHeartbeat < HEARTBEAT_INTERVAL_MS) return;
       lastHeartbeat = now;
-      try { plan.onActivity(); } catch {}
+      try {
+        plan.onActivity();
+      } catch (err) {
+        console.error('[opencode-rt] onActivity callback failed:', err.message);
+      }
     }
 
     // Validate cwd exists before spawn (fail immediately, not after 300s timeout)
@@ -141,7 +147,11 @@ function dispatch(plan) {
       settled = true;
       clearTimeout(inactivityTimer);
       clearInterval(heartbeatInterval);
-      try { fs.unlinkSync(msgFile); } catch {}
+      try {
+        fs.unlinkSync(msgFile);
+      } catch (err) {
+        console.warn('[opencode-rt] temp message cleanup failed:', err.message);
+      }
       if (err) reject(err); else resolve(result);
     }
 
@@ -265,7 +275,9 @@ function dispatch(plan) {
                 tool_calls: toolCallCount,
                 tokens: { ...totalTokens },
               });
-            } catch {}
+            } catch (err) {
+              console.error('[opencode-rt] onProgress callback failed:', err.message);
+            }
           }
         }
 

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -216,7 +216,9 @@ function createStepWorker(deps) {
             elapsed_ms: now - startMs,
           };
           helpers.writeBoard(pgBoard);
-        } catch {}
+        } catch (err) {
+          console.error(`[step-worker] onProgress write failed for ${envelope.step_id}:`, err.message);
+        }
       };
       // Write initial progress before spawn (so progress is never undefined)
       try {
@@ -236,7 +238,9 @@ function createStepWorker(deps) {
           };
           helpers.writeBoard(initBoard);
         }
-      } catch {}
+      } catch (err) {
+        console.error(`[step-worker] initial progress write failed for ${envelope.step_id}:`, err.message);
+      }
 
       let result;
       const ac = new AbortController();

--- a/server/storage-json.js
+++ b/server/storage-json.js
@@ -42,7 +42,7 @@ function boardExists(boardPath) {
 
 function ensureLogFile(logPath) {
   if (!fs.existsSync(logPath)) {
-    try { fs.writeFileSync(logPath, '', 'utf8'); } catch {}
+    fs.writeFileSync(logPath, '', 'utf8');
   }
 }
 

--- a/server/test-context-compiler.js
+++ b/server/test-context-compiler.js
@@ -191,7 +191,9 @@ test('buildEnvelope respects retry_policy timeout over controls', () => {
 // Cleanup
 try {
   fs.rmSync(path.join(artifactStore.ARTIFACT_DIR, testRunId), { recursive: true, force: true });
-} catch {}
+} catch (err) {
+  console.warn('[test-context-compiler] cleanup skipped:', err.message);
+}
 
 console.log(`\n${'─'.repeat(40)}`);
 console.log(`Results: ${passed} passed, ${failed} failed`);

--- a/server/test-evolution-loop.js
+++ b/server/test-evolution-loop.js
@@ -102,7 +102,11 @@ function cleanState() {
   // Clean temp data dir — server's ensureBoardExists() creates a fresh default.
   // Uses TEST_DATA_DIR (temp) instead of __dirname to avoid clobbering production board.json.
   for (const f of ['board.json', 'board.json.bak', 'task-log.jsonl']) {
-    try { fs.unlinkSync(path.join(TEST_DATA_DIR, f)); } catch {}
+    try {
+      fs.unlinkSync(path.join(TEST_DATA_DIR, f));
+    } catch (err) {
+      console.warn(`[test-evolution-loop] cleanup skipped for ${f}:`, err.message);
+    }
   }
 }
 

--- a/server/test-instance-manager.js
+++ b/server/test-instance-manager.js
@@ -43,7 +43,11 @@ function httpGet(url, timeoutMs = 5000) {
 function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
 
 function cleanTestData() {
-  try { fs.rmSync(TEST_DATA_ROOT, { recursive: true, force: true }); } catch {}
+  try {
+    fs.rmSync(TEST_DATA_ROOT, { recursive: true, force: true });
+  } catch (err) {
+    console.warn('[test-instance-manager] cleanup skipped:', err.message);
+  }
 }
 
 async function main() {

--- a/server/test-kernel-e2e.js
+++ b/server/test-kernel-e2e.js
@@ -434,7 +434,9 @@ function createKernelStack(runtimeOverrides = {}) {
   // ------------------------------------------------------------------
   try {
     fs.rmSync(path.join(artifactStore.ARTIFACT_DIR, testRunId), { recursive: true, force: true });
-  } catch {}
+  } catch (err) {
+    console.warn('[test-kernel-e2e] cleanup skipped:', err.message);
+  }
 
   console.log(`\n${'─'.repeat(40)}`);
   console.log(`Results: ${passed} passed, ${failed} failed`);

--- a/server/test-kernel-integration.js
+++ b/server/test-kernel-integration.js
@@ -229,7 +229,9 @@ const kernel = deps.kernel;
   // Cleanup
   try {
     fs.rmSync(path.join(artifactStore.ARTIFACT_DIR, testRunId), { recursive: true, force: true });
-  } catch {}
+  } catch (err) {
+    console.warn('[test-kernel-integration] cleanup skipped:', err.message);
+  }
 
   console.log(`\n${'─'.repeat(40)}`);
   console.log(`Results: ${passed} passed, ${failed} failed`);

--- a/server/test-reliability-guards.js
+++ b/server/test-reliability-guards.js
@@ -63,7 +63,9 @@ describe('worktree idempotent cleanup (F8)', () => {
       execFileSync('git', ['worktree', 'remove', result.worktreePath, '--force'], {
         cwd: repoRoot, stdio: 'pipe', timeout: 10000,
       });
-    } catch {}
+    } catch (err) {
+      console.warn('[test-reliability-guards] worktree remove skipped:', err.message);
+    }
 
     // Create just the branch (simulates ghost branch left behind)
     try {
@@ -77,7 +79,9 @@ describe('worktree idempotent cleanup (F8)', () => {
     try {
       execFileSync('git', ['rev-parse', '--verify', branch], { cwd: repoRoot, stdio: 'pipe', timeout: 5000 });
       branchExists = true;
-    } catch {}
+    } catch (err) {
+      console.warn('[test-reliability-guards] pre-check branch missing:', err.message);
+    }
 
     // removeWorktree should clean up the ghost branch
     worktree.removeWorktree(repoRoot, taskId);
@@ -87,7 +91,9 @@ describe('worktree idempotent cleanup (F8)', () => {
     try {
       execFileSync('git', ['rev-parse', '--verify', branch], { cwd: repoRoot, stdio: 'pipe', timeout: 5000 });
       branchStillExists = true;
-    } catch {}
+    } catch (err) {
+      console.warn('[test-reliability-guards] post-check branch missing:', err.message);
+    }
 
     assert.equal(branchStillExists, false, 'ghost branch should be cleaned up');
   });

--- a/server/test-step-observability.js
+++ b/server/test-step-observability.js
@@ -282,10 +282,14 @@ async function cleanup() {
       if (task.worktreeDir && fs.existsSync(task.worktreeDir)) {
         try {
           fs.rmSync(task.worktreeDir, { recursive: true, force: true });
-        } catch {}
+        } catch (err) {
+          console.warn(`[test-step-observability] worktree cleanup skipped for ${task.id}:`, err.message);
+        }
       }
     }
-  } catch {}
+  } catch (err) {
+    console.warn('[test-step-observability] global cleanup skipped:', err.message);
+  }
 }
 
 async function main() {

--- a/server/test-step-schema.js
+++ b/server/test-step-schema.js
@@ -477,7 +477,9 @@ test('buildDispatchPlan workingDir defaults to null', () => {
 // Clean up test artifacts
 try {
   fs.rmSync(path.join(artifactStore.ARTIFACT_DIR, testRunId), { recursive: true, force: true });
-} catch {}
+} catch (err) {
+  console.warn('[test-step-schema] cleanup skipped:', err.message);
+}
 
 console.log(`\n${'─'.repeat(40)}`);
 console.log(`Results: ${passed} passed, ${failed} failed`);

--- a/server/test-step-worker.js
+++ b/server/test-step-worker.js
@@ -644,7 +644,9 @@ function createMockEnvelope(overrides = {}) {
   // Cleanup
   try {
     fs.rmSync(path.join(artifactStore.ARTIFACT_DIR, testRunId), { recursive: true, force: true });
-  } catch {}
+  } catch (err) {
+    console.warn('[test-step-worker] cleanup skipped:', err.message);
+  }
 
   console.log(`\n${'─'.repeat(40)}`);
   console.log(`Results: ${passed} passed, ${failed} failed`);

--- a/server/test-usage.js
+++ b/server/test-usage.js
@@ -243,7 +243,11 @@ function test_cache_rebuild() {
   assertEqual(result.tokens.output, 2000, 'rebuilt tokens.output should be 2000');
   assertEqual(result.events, 5, 'rebuilt events should be 5');
 
-  try { fs.rmSync(freshDir, { recursive: true, force: true }); } catch {}
+  try {
+    fs.rmSync(freshDir, { recursive: true, force: true });
+  } catch (err) {
+    console.warn('[test-usage] cleanup skipped:', err.message);
+  }
 }
 
 // --- Test 10: SSE connect event tracking ---

--- a/server/worktree.js
+++ b/server/worktree.js
@@ -87,7 +87,11 @@ function createWorktree(repoRoot, taskId) {
     }
     // Broken worktree — remove empty dir and recreate
     console.log(`[worktree] broken worktree detected for ${taskId} (no .git marker), recreating`);
-    try { fs.rmSync(worktreePath, { recursive: true, force: true }); } catch {}
+    try {
+      fs.rmSync(worktreePath, { recursive: true, force: true });
+    } catch (err) {
+      console.error(`[worktree] failed to remove broken worktree dir for ${taskId}:`, err.message);
+    }
   }
 
   // Ensure parent dir exists
@@ -100,15 +104,17 @@ function createWorktree(repoRoot, taskId) {
   try {
     execFileSync('git', ['branch', '-D', branch], { cwd: repoRoot, stdio: 'pipe', timeout: 5000 });
     console.log(`[worktree] cleaned up ghost branch ${branch}`);
-  } catch {
+  } catch (err) {
     // Branch doesn't exist — expected for first run
+    console.log(`[worktree] ghost branch cleanup skipped for ${branch}:`, err.message);
   }
 
   // Prune stale worktree references that point to deleted directories
   try {
     execFileSync('git', ['worktree', 'prune'], { cwd: repoRoot, stdio: 'pipe', timeout: 5000 });
-  } catch {
+  } catch (err) {
     // Non-fatal
+    console.warn('[worktree] prune before add failed:', err.message);
   }
 
   execFileSync('git', ['worktree', 'add', worktreePath, '-b', branch], {
@@ -134,7 +140,9 @@ function removeWorktree(repoRoot, taskId) {
   // Prune stale worktree references first
   try {
     execFileSync('git', ['worktree', 'prune'], { cwd: repoRoot, stdio: 'pipe', timeout: 5000 });
-  } catch {}
+  } catch (err) {
+    console.warn('[worktree] prune before remove failed:', err.message);
+  }
 
   // Remove worktree directory if it exists
   if (fs.existsSync(worktreePath)) {
@@ -147,13 +155,19 @@ function removeWorktree(repoRoot, taskId) {
     } catch (err) {
       console.error(`[worktree] git worktree remove failed for ${taskId}:`, err.message);
       // Fallback: force-delete the directory so no broken empty dir remains
-      try { fs.rmSync(worktreePath, { recursive: true, force: true }); } catch {}
+      try {
+        fs.rmSync(worktreePath, { recursive: true, force: true });
+      } catch (cleanupErr) {
+        console.error(`[worktree] fallback directory cleanup failed for ${taskId}:`, cleanupErr.message);
+      }
     }
   } else {
     // Directory doesn't exist but git might still have a stale worktree ref
     try {
       execFileSync('git', ['worktree', 'prune'], { cwd: repoRoot, stdio: 'pipe', timeout: 5000 });
-    } catch {}
+    } catch (err) {
+      console.warn('[worktree] prune for missing worktree failed:', err.message);
+    }
   }
 
   // Always try to delete branch (even if worktree remove failed/skipped)
@@ -163,8 +177,9 @@ function removeWorktree(repoRoot, taskId) {
       stdio: 'pipe',
       timeout: 5000,
     });
-  } catch {
+  } catch (err) {
     // Branch may not exist or already deleted
+    console.log(`[worktree] branch delete skipped for ${branch}:`, err.message);
   }
 }
 


### PR DESCRIPTION
Closes #304

## Summary
- audit empty catch blocks across app, scripts, server, and tests
- replace no-op catches with explicit error/warn logging and safe fallback behavior
- preserve existing control flow while making failures observable
