### PR TITLE
test: import production helpers in step concurrency test

### DIFF
--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -2033,3 +2033,6 @@ module.exports.init = function(deps, helpers) {
   deps.redispatchTask = (board, task) => redispatchTask(board, task, deps, helpers);
   deps.dispatchTask = (task, board2, opts) => dispatchTask(task, board2, deps, helpers, opts);
 };
+
+module.exports.countRunningStepsByType = countRunningStepsByType;
+module.exports.canDispatchStepType = canDispatchStepType;

--- a/server/test-step-concurrency.js
+++ b/server/test-step-concurrency.js
@@ -3,30 +3,10 @@
  */
 
 const assert = require('assert');
-
-// Helper functions copied from tasks.js for testing
-function countRunningStepsByType(stepType, board) {
-  let count = 0;
-  const tasks = board?.taskPlan?.tasks || [];
-  for (let i = 0; i < tasks.length; i++) {
-    const steps = tasks[i].steps;
-    if (!steps) continue;
-    for (let j = 0; j < steps.length; j++) {
-      if (steps[j].type === stepType && steps[j].state === 'running') {
-        count++;
-      }
-    }
-  }
-  return count;
-}
-
-function canDispatchStepType(stepType, board, mgmt) {
-  const ctrl = mgmt.getControls(board);
-  const limit = ctrl.max_concurrent_by_type?.[stepType];
-  if (!limit) return true;
-  const running = countRunningStepsByType(stepType, board);
-  return running < limit;
-}
+const {
+  countRunningStepsByType,
+  canDispatchStepType,
+} = require('./routes/tasks');
 
 // Mock mgmt for testing
 const mockMgmt = {


### PR DESCRIPTION
## Summary
- export `countRunningStepsByType` and `canDispatchStepType` from `server/routes/tasks.js`
- remove duplicated helper implementations in `server/test-step-concurrency.js`
- import helper functions from production module so tests follow runtime logic

## Verification
- node -c server/routes/tasks.js
- node -c server/test-step-concurrency.js
- node server/test-step-concurrency.js

Closes #307