### PR TITLE
refactor(runtime): extract shared idle detection into runtime-utils

### DIFF
--- a/server/runtime-codex.js
+++ b/server/runtime-codex.js
@@ -43,6 +43,7 @@ function resolveCodexPath() {
 const CODEX_EXE = resolveCodexPath();
 
 const killTree = require('./kill-tree');
+const { createIdleController } = require('./runtime-utils');
 
 /**
  * Dispatch a plan to Codex headless CLI.
@@ -90,10 +91,9 @@ function dispatch(plan) {
     fs.writeFileSync(msgFile, plan.message, 'utf8');
 
     const baseTimeoutMs = (plan.timeoutSec || 300) * 1000;
-    const TOOL_TIMEOUT_MS = baseTimeoutMs;
     // Codex does extended reasoning before emitting events — 120s too aggressive
     const IDLE_TIMEOUT_MS = Math.min(baseTimeoutMs, 300_000);
-    let currentTimeoutMs = IDLE_TIMEOUT_MS;
+    const TOOL_TIMEOUT_MS = baseTimeoutMs;
     
     console.log('[codex-rt] spawn:', CODEX_EXE);
     console.log('[codex-rt] model:', model || '(default)');
@@ -177,7 +177,18 @@ function dispatch(plan) {
     let totalTokens = { input: 0, output: 0 };
     let totalCost = 0;
     let toolCallCount = 0;
-    let toolExecutionDepth = 0;
+
+    const idleController = createIdleController({
+      idleTimeoutMs: IDLE_TIMEOUT_MS,
+      toolTimeoutMs: TOOL_TIMEOUT_MS,
+      logPrefix: '[codex-rt]',
+      onTimeout: (timeoutMs, depth) => {
+        console.log('[codex-rt] idle for %ds (depth=%d), killing',
+          Math.round(timeoutMs / 1000), depth);
+        settle(new Error(`codex idle for ${Math.round(timeoutMs / 1000)}s`));
+        killTree(child.pid);
+      }
+    });
 
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
@@ -187,7 +198,7 @@ function dispatch(plan) {
     function settle(err, result) {
       if (settled) return;
       settled = true;
-      clearTimeout(inactivityTimer);
+      idleController.dispose();
       clearInterval(heartbeatInterval);
       try {
         fs.unlinkSync(msgFile);
@@ -197,40 +208,7 @@ function dispatch(plan) {
       if (err) reject(err); else resolve(result);
     }
 
-    function enterToolExecution() {
-      toolExecutionDepth++;
-      if (toolExecutionDepth === 1) {
-        currentTimeoutMs = TOOL_TIMEOUT_MS;
-        console.log('[codex-rt] entering tool execution (depth=%d), timeout=%ds',
-          toolExecutionDepth, Math.round(currentTimeoutMs / 1000));
-        resetInactivityTimer();
-      }
-    }
-
-    function exitToolExecution() {
-      if (toolExecutionDepth > 0) {
-        toolExecutionDepth--;
-        if (toolExecutionDepth === 0) {
-          currentTimeoutMs = IDLE_TIMEOUT_MS;
-          console.log('[codex-rt] exited tool execution (depth=%d), timeout=%ds',
-            toolExecutionDepth, Math.round(currentTimeoutMs / 1000));
-          resetInactivityTimer();
-        }
-      }
-    }
-
-    let inactivityTimer = null;
-    function resetInactivityTimer() {
-      if (settled) return;
-      clearTimeout(inactivityTimer);
-      inactivityTimer = setTimeout(() => {
-        console.log('[codex-rt] idle for %ds (depth=%d), killing',
-          Math.round(currentTimeoutMs / 1000), toolExecutionDepth);
-        settle(new Error(`codex idle for ${Math.round(currentTimeoutMs / 1000)}s`));
-        killTree(child.pid);
-      }, currentTimeoutMs);
-    }
-    resetInactivityTimer();
+    idleController.touch();
 
     function buildResult(text) {
       return {
@@ -252,7 +230,7 @@ function dispatch(plan) {
     // item.started, item.completed, error
     child.stdout.on('data', chunk => {
       lineBuf += chunk;
-      resetInactivityTimer();
+      idleController.touch();
       heartbeat();
 
       const lines = lineBuf.split('\n');
@@ -287,7 +265,7 @@ function dispatch(plan) {
         // item.started — track tool/command usage for progress
         if (obj.type === 'item.started' && obj.item) {
           if (obj.item.type !== 'agent_message') {
-            enterToolExecution();
+            idleController.enterToolExecution();
           }
           toolCallCount++;
           if (plan.onProgress) {
@@ -306,7 +284,7 @@ function dispatch(plan) {
 
         // item.completed — tool execution finished (only for non-agent_message items)
         if (obj.type === 'item.completed' && obj.item?.type !== 'agent_message') {
-          exitToolExecution();
+          idleController.exitToolExecution();
         }
 
         // turn.completed — accumulate tokens/cost + reset tool execution depth
@@ -319,10 +297,7 @@ function dispatch(plan) {
             usage, totalTokens);
           // turn.completed means all items in this turn are done — reset depth
           // (prevents stale depth from missed item.completed events)
-          if (toolExecutionDepth > 0) {
-            toolExecutionDepth = 0;
-            currentTimeoutMs = IDLE_TIMEOUT_MS;
-          }
+          idleController.forceResetDepth('turn.completed');
         }
 
         // turn.failed — log but don't settle (codex may have more turns)
@@ -345,7 +320,7 @@ function dispatch(plan) {
 
     child.stderr.on('data', chunk => {
       stderr += chunk;
-      resetInactivityTimer();
+      idleController.touch();
       heartbeat();
       if (stderr.length <= 1000) {
         console.log('[codex-rt] stderr:', chunk.slice(0, 200));

--- a/server/runtime-opencode.js
+++ b/server/runtime-opencode.js
@@ -45,6 +45,7 @@ function resolveOpencodePath() {
 const OPENCODE_EXE = resolveOpencodePath();
 
 const killTree = require('./kill-tree');
+const { createIdleController } = require('./runtime-utils');
 
 /**
  * Dispatch a plan to OpenCode headless CLI.
@@ -72,9 +73,8 @@ function dispatch(plan) {
     // @end-protected
 
     const baseTimeoutMs = (plan.timeoutSec || 300) * 1000;
-    const TOOL_TIMEOUT_MS = baseTimeoutMs;
     const IDLE_TIMEOUT_MS = Math.min(baseTimeoutMs, 120_000);
-    let currentTimeoutMs = IDLE_TIMEOUT_MS;
+    const TOOL_TIMEOUT_MS = baseTimeoutMs;
     
     console.log('[opencode-rt] spawn:', OPENCODE_EXE);
     console.log('[opencode-rt] model:', model || '(default)');
@@ -133,7 +133,18 @@ function dispatch(plan) {
     let totalTokens = { input: 0, output: 0 };
     let totalCost = 0;
     let toolCallCount = 0;
-    let toolExecutionDepth = 0;
+
+    const idleController = createIdleController({
+      idleTimeoutMs: IDLE_TIMEOUT_MS,
+      toolTimeoutMs: TOOL_TIMEOUT_MS,
+      logPrefix: '[opencode-rt]',
+      onTimeout: (timeoutMs, depth) => {
+        console.log('[opencode-rt] idle for %ds (depth=%d), killing',
+          Math.round(timeoutMs / 1000), depth);
+        settle(new Error(`opencode idle for ${Math.round(timeoutMs / 1000)}s`));
+        killTree(child.pid);
+      }
+    });
 
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
@@ -145,7 +156,7 @@ function dispatch(plan) {
     function settle(err, result) {
       if (settled) return;
       settled = true;
-      clearTimeout(inactivityTimer);
+      idleController.dispose();
       clearInterval(heartbeatInterval);
       try {
         fs.unlinkSync(msgFile);
@@ -155,40 +166,7 @@ function dispatch(plan) {
       if (err) reject(err); else resolve(result);
     }
 
-    function enterToolExecution() {
-      toolExecutionDepth++;
-      if (toolExecutionDepth === 1) {
-        currentTimeoutMs = TOOL_TIMEOUT_MS;
-        console.log('[opencode-rt] entering tool execution (depth=%d), timeout=%ds',
-          toolExecutionDepth, Math.round(currentTimeoutMs / 1000));
-        resetInactivityTimer();
-      }
-    }
-
-    function exitToolExecution() {
-      if (toolExecutionDepth > 0) {
-        toolExecutionDepth--;
-        if (toolExecutionDepth === 0) {
-          currentTimeoutMs = IDLE_TIMEOUT_MS;
-          console.log('[opencode-rt] exited tool execution (depth=%d), timeout=%ds',
-            toolExecutionDepth, Math.round(currentTimeoutMs / 1000));
-          resetInactivityTimer();
-        }
-      }
-    }
-
-    let inactivityTimer = null;
-    function resetInactivityTimer() {
-      if (settled) return;
-      clearTimeout(inactivityTimer);
-      inactivityTimer = setTimeout(() => {
-        console.log('[opencode-rt] idle for %ds (depth=%d), killing',
-          Math.round(currentTimeoutMs / 1000), toolExecutionDepth);
-        settle(new Error(`opencode idle for ${Math.round(currentTimeoutMs / 1000)}s`));
-        killTree(child.pid);
-      }, currentTimeoutMs);
-    }
-    resetInactivityTimer();
+    idleController.touch();
 
     function buildResult(text) {
       return {
@@ -208,7 +186,7 @@ function dispatch(plan) {
     // NDJSON parsing
     child.stdout.on('data', chunk => {
       lineBuf += chunk;
-      resetInactivityTimer();
+      idleController.touch();
       heartbeat();
 
       const lines = lineBuf.split('\n');
@@ -253,10 +231,7 @@ function dispatch(plan) {
             lastFinish.reason, lastFinish.cost, lastFinish.tokens, totalCost, totalTokens);
           // step_finish means a tool call round completed — reset tool execution depth
           // (opencode emits tool_use but no tool_result, so exitToolExecution never fires)
-          if (toolExecutionDepth > 0) {
-            toolExecutionDepth = 0;
-            currentTimeoutMs = IDLE_TIMEOUT_MS;
-          }
+          idleController.forceResetDepth('step_finish');
           // Do NOT settle here. opencode's agentic loop may have more steps.
           // Settlement happens via: STEP_RESULT marker, process exit, or inactivity timeout.
         }
@@ -266,7 +241,7 @@ function dispatch(plan) {
         // opencode emits 'tool_use' (not 'tool_call') for tool execution start
         if (obj.type === 'tool_call' || obj.type === 'tool_use') {
           toolCallCount++;
-          enterToolExecution();
+          idleController.enterToolExecution();
           if (plan.onProgress) {
             try {
               plan.onProgress({
@@ -283,14 +258,14 @@ function dispatch(plan) {
 
         // Tool execution completed — return to IDLE_TIMEOUT
         if (obj.type === 'tool_result') {
-          exitToolExecution();
+          idleController.exitToolExecution();
         }
       }
     });
 
     child.stderr.on('data', chunk => {
       stderr += chunk;
-      resetInactivityTimer();
+      idleController.touch();
       heartbeat();
       if (stderr.length <= 1000) {
         console.log('[opencode-rt] stderr:', chunk.slice(0, 200));

--- a/server/runtime-utils.js
+++ b/server/runtime-utils.js
@@ -1,0 +1,116 @@
+/**
+ * runtime-utils.js — Shared idle detection for CLI runtimes
+ *
+ * Extracts the duplicated idle/tool timeout state machine from
+ * runtime-opencode.js and runtime-codex.js into a reusable controller.
+ *
+ * Usage:
+ *   const idleController = createIdleController({
+ *     idleTimeoutMs: 120_000,
+ *     toolTimeoutMs: 300_000,
+ *     logPrefix: '[opencode-rt]',
+ *     onTimeout: (timeoutMs, depth) => { ... }
+ *   });
+ *   idleController.touch();              // reset inactivity timer
+ *   idleController.enterToolExecution(); // switch to tool timeout
+ *   idleController.exitToolExecution();  // return to idle timeout
+ *   idleController.dispose();            // clear all timers
+ */
+
+function createIdleController(options) {
+  const {
+    idleTimeoutMs,
+    toolTimeoutMs,
+    logPrefix = '[runtime]',
+    onTimeout,
+    guardTimeoutMs = 600_000
+  } = options;
+
+  let depth = 0;
+  let currentTimeoutMs = idleTimeoutMs;
+  let timer = null;
+  let guardTimer = null;
+  let disposed = false;
+
+  function resetTimer() {
+    if (disposed) return;
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      if (!disposed) onTimeout(currentTimeoutMs, depth);
+    }, currentTimeoutMs);
+  }
+
+  function enterToolExecution() {
+    if (disposed) return;
+    depth++;
+    if (depth === 1) {
+      currentTimeoutMs = toolTimeoutMs;
+      console.log(`${logPrefix} entering tool execution (depth=${depth}), timeout=${Math.round(currentTimeoutMs / 1000)}s`);
+      if (guardTimeoutMs && !guardTimer) {
+        guardTimer = setTimeout(() => {
+          if (depth > 0) {
+            console.log(`${logPrefix} safety guard triggered, resetting depth from ${depth}`);
+            depth = 0;
+            currentTimeoutMs = idleTimeoutMs;
+            resetTimer();
+          }
+        }, guardTimeoutMs);
+      }
+      resetTimer();
+    }
+  }
+
+  function exitToolExecution() {
+    if (disposed) return;
+    if (depth > 0) {
+      depth--;
+      if (depth === 0) {
+        currentTimeoutMs = idleTimeoutMs;
+        console.log(`${logPrefix} exited tool execution (depth=${depth}), timeout=${Math.round(currentTimeoutMs / 1000)}s`);
+        if (guardTimer) {
+          clearTimeout(guardTimer);
+          guardTimer = null;
+        }
+        resetTimer();
+      }
+    }
+  }
+
+  function forceResetDepth(reason) {
+    if (disposed) return;
+    if (depth > 0) {
+      console.log(`${logPrefix} force reset depth from ${depth} (${reason})`);
+      depth = 0;
+      currentTimeoutMs = idleTimeoutMs;
+      if (guardTimer) {
+        clearTimeout(guardTimer);
+        guardTimer = null;
+      }
+      resetTimer();
+    }
+  }
+
+  function dispose() {
+    disposed = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (guardTimer) {
+      clearTimeout(guardTimer);
+      guardTimer = null;
+    }
+  }
+
+  return {
+    enterToolExecution,
+    exitToolExecution,
+    forceResetDepth,
+    touch: resetTimer,
+    dispose,
+    get depth() { return depth; },
+    get currentTimeoutMs() { return currentTimeoutMs; }
+  };
+}
+
+module.exports = { createIdleController };

--- a/server/test-runtime-utils.js
+++ b/server/test-runtime-utils.js
@@ -1,0 +1,195 @@
+/**
+ * test-runtime-utils.js — Unit tests for shared idle detection controller
+ *
+ * Run: node --test server/test-runtime-utils.js
+ */
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { createIdleController } = require('./runtime-utils');
+
+describe('createIdleController', () => {
+  it('starts in idle mode', () => {
+    const c = createIdleController({
+      idleTimeoutMs: 100,
+      toolTimeoutMs: 200,
+      onTimeout: () => {}
+    });
+    assert.equal(c.depth, 0);
+    assert.equal(c.currentTimeoutMs, 100);
+    c.dispose();
+  });
+
+  it('switches to tool timeout on first enter', () => {
+    const c = createIdleController({
+      idleTimeoutMs: 100,
+      toolTimeoutMs: 200,
+      onTimeout: () => {}
+    });
+    c.enterToolExecution();
+    assert.equal(c.depth, 1);
+    assert.equal(c.currentTimeoutMs, 200);
+    c.dispose();
+  });
+
+  it('returns to idle on exit', () => {
+    const c = createIdleController({
+      idleTimeoutMs: 100,
+      toolTimeoutMs: 200,
+      onTimeout: () => {}
+    });
+    c.enterToolExecution();
+    c.exitToolExecution();
+    assert.equal(c.depth, 0);
+    assert.equal(c.currentTimeoutMs, 100);
+    c.dispose();
+  });
+
+  it('handles nested enter/exit', () => {
+    const c = createIdleController({
+      idleTimeoutMs: 100,
+      toolTimeoutMs: 200,
+      onTimeout: () => {}
+    });
+    c.enterToolExecution();
+    c.enterToolExecution();
+    assert.equal(c.depth, 2);
+    assert.equal(c.currentTimeoutMs, 200);
+
+    c.exitToolExecution();
+    assert.equal(c.depth, 1);
+    assert.equal(c.currentTimeoutMs, 200);
+
+    c.exitToolExecution();
+    assert.equal(c.depth, 0);
+    assert.equal(c.currentTimeoutMs, 100);
+    c.dispose();
+  });
+
+  it('exit at depth 0 is no-op', () => {
+    const c = createIdleController({
+      idleTimeoutMs: 100,
+      toolTimeoutMs: 200,
+      onTimeout: () => {}
+    });
+    c.exitToolExecution();
+    assert.equal(c.depth, 0);
+    assert.equal(c.currentTimeoutMs, 100);
+    c.dispose();
+  });
+
+  it('forceResetDepth resets when depth > 0', () => {
+    const c = createIdleController({
+      idleTimeoutMs: 100,
+      toolTimeoutMs: 200,
+      onTimeout: () => {}
+    });
+    c.enterToolExecution();
+    c.enterToolExecution();
+    assert.equal(c.depth, 2);
+
+    c.forceResetDepth('test');
+    assert.equal(c.depth, 0);
+    assert.equal(c.currentTimeoutMs, 100);
+    c.dispose();
+  });
+
+  it('forceResetDepth is no-op when depth is 0', () => {
+    const c = createIdleController({
+      idleTimeoutMs: 100,
+      toolTimeoutMs: 200,
+      onTimeout: () => {}
+    });
+    c.forceResetDepth('test');
+    assert.equal(c.depth, 0);
+    assert.equal(c.currentTimeoutMs, 100);
+    c.dispose();
+  });
+
+  it('touch resets the inactivity timer', (_, done) => {
+    let timeoutCalled = false;
+    const c = createIdleController({
+      idleTimeoutMs: 50,
+      toolTimeoutMs: 200,
+      onTimeout: () => { timeoutCalled = true; }
+    });
+
+    setTimeout(() => {
+      c.touch();
+    }, 30);
+
+    setTimeout(() => {
+      assert.equal(timeoutCalled, false, 'should not timeout because touch() reset timer');
+      c.dispose();
+      done();
+    }, 70);
+  });
+
+  it('safety guard resets stuck depth', (_, done) => {
+    const c = createIdleController({
+      idleTimeoutMs: 1000,
+      toolTimeoutMs: 1000,
+      guardTimeoutMs: 50,
+      onTimeout: () => {}
+    });
+    c.enterToolExecution();
+    assert.equal(c.depth, 1);
+
+    setTimeout(() => {
+      assert.equal(c.depth, 0, 'depth should be reset by safety guard');
+      assert.equal(c.currentTimeoutMs, 1000, 'should be back to idle timeout');
+      c.dispose();
+      done();
+    }, 100);
+  });
+
+  it('safety guard is cleared on normal exit', (_, done) => {
+    const c = createIdleController({
+      idleTimeoutMs: 1000,
+      toolTimeoutMs: 1000,
+      guardTimeoutMs: 50,
+      onTimeout: () => {}
+    });
+    c.enterToolExecution();
+    c.exitToolExecution();
+
+    setTimeout(() => {
+      assert.equal(c.depth, 0, 'depth should still be 0');
+      assert.equal(c.currentTimeoutMs, 1000, 'should remain in idle timeout');
+      c.dispose();
+      done();
+    }, 100);
+  });
+
+  it('dispose clears all timers', (_, done) => {
+    let timeoutCalled = false;
+    const c = createIdleController({
+      idleTimeoutMs: 50,
+      toolTimeoutMs: 200,
+      onTimeout: () => { timeoutCalled = true; }
+    });
+    c.dispose();
+
+    setTimeout(() => {
+      assert.equal(timeoutCalled, false, 'timeout should not fire after dispose');
+      done();
+    }, 100);
+  });
+
+  it('methods are no-op after dispose', () => {
+    const c = createIdleController({
+      idleTimeoutMs: 100,
+      toolTimeoutMs: 200,
+      onTimeout: () => {}
+    });
+    c.dispose();
+
+    c.enterToolExecution();
+    assert.equal(c.depth, 0, 'enterToolExecution should be no-op after dispose');
+
+    c.exitToolExecution();
+    assert.equal(c.depth, 0, 'exitToolExecution should be no-op after dispose');
+
+    c.forceResetDepth('test');
+    assert.equal(c.depth, 0, 'forceResetDepth should be no-op after dispose');
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts duplicated idle detection state machine from `runtime-opencode.js` and `runtime-codex.js` into a new shared `runtime-utils.js` module
- Adds `createIdleController()` factory function with:
  - `enterToolExecution()` / `exitToolExecution()` for depth tracking
  - `touch()` to reset inactivity timer
  - `forceResetDepth()` for emergency resets
  - Safety guard timer that auto-resets stuck depth after 10 minutes
- Both runtimes now use the shared controller, eliminating ~50 lines of duplicated code
- Includes comprehensive unit tests in `test-runtime-utils.js`

Closes #303

## Test plan

- [x] `node --test server/test-runtime-utils.js` - 12 tests pass
- [x] `node --test server/test-runtime-opencode.js` - 16 tests pass
- [x] Syntax verified with `node -c` on all modified files