### PR TITLE
feat: add GET /api/version endpoint

### DIFF
--- a/server/routes/version.js
+++ b/server/routes/version.js
@@ -1,0 +1,15 @@
+/**
+ * routes/version.js — Version endpoint
+ *
+ * GET /api/version — return server version from package.json
+ */
+const bb = require('../blackboard-server');
+const { json } = bb;
+
+module.exports = function versionRoutes(req, res, helpers, deps) {
+  if (req.method === 'GET' && req.url === '/api/version') {
+    const { version } = require('../../package.json');
+    return json(res, 200, { version });
+  }
+  return false;
+};

--- a/server/server.js
+++ b/server/server.js
@@ -152,6 +152,7 @@ const projectsRoutes = require('./routes/projects');
 const tasksRoutes = require('./routes/tasks');
 const statusRoutes = require('./routes/status');
 const discoveryRoutes = require('./routes/discovery');
+const versionRoutes = require('./routes/version');
 
 // --- Route chain ---
 const routes = [
@@ -168,6 +169,7 @@ const routes = [
   projectsRoutes,
   tasksRoutes,
   statusRoutes,
+  versionRoutes,
   discoveryRoutes,
 ];
 

--- a/server/smoke-test.js
+++ b/server/smoke-test.js
@@ -197,6 +197,16 @@ async function runSuite(target) {
     ok('GET /health → 200 + valid health response');
   } catch (e) { fail('GET /health', e.message); }
 
+  // 6b. GET /api/version
+  try {
+    const r = await get(port, '/api/version', { token: null });
+    if (r.status !== 200) throw new Error(`status ${r.status}`);
+    const data = JSON.parse(r.body);
+    if (!data.version || typeof data.version !== 'string') throw new Error('missing or invalid version');
+    if (!/^\d+\.\d+\.\d+/.test(data.version)) throw new Error(`bad format: ${data.version}`);
+    ok(`GET /api/version → 200 (v${data.version})`);
+  } catch (e) { fail('GET /api/version', e.message); }
+
   // 7. CORS headers (accepts '*' or a whitelisted origin when KARVI_CORS_ORIGINS is set)
   try {
     const r = await get(port, '/api/board');


### PR DESCRIPTION
## Summary

- Add `GET /api/version` endpoint that returns `{ version: "x.y.z" }` from `package.json`
- Add smoke test to validate the endpoint

Closes #114