### PR TITLE
feat(kernel): add blocker.type field for structured blocker classification (GH-305)

### DIFF
--- a/server/blocker-types.js
+++ b/server/blocker-types.js
@@ -1,0 +1,29 @@
+/**
+ * blocker-types.js — Blocker 類型定義與工具函數
+ */
+
+const BLOCKER_TYPES = {
+  DEAD_LETTER: 'dead_letter',
+  REPO_ERROR: 'repo_error',
+  WORKTREE_ERROR: 'worktree_error',
+  DEPENDENCY: 'dependency',
+  MANUAL: 'manual',
+  UNKNOWN: 'unknown',
+};
+
+function inferBlockerType(reason) {
+  if (!reason) return BLOCKER_TYPES.UNKNOWN;
+  const r = reason.toLowerCase();
+  if (r.includes('dead letter')) return BLOCKER_TYPES.DEAD_LETTER;
+  if (r.includes('repo validation')) return BLOCKER_TYPES.REPO_ERROR;
+  if (r.includes('worktree')) return BLOCKER_TYPES.WORKTREE_ERROR;
+  return BLOCKER_TYPES.MANUAL;
+}
+
+function shouldUnblockOnReset(blocker) {
+  if (!blocker) return false;
+  if (blocker.type) return blocker.type === BLOCKER_TYPES.DEAD_LETTER;
+  return inferBlockerType(blocker.reason) === BLOCKER_TYPES.DEAD_LETTER;
+}
+
+module.exports = { BLOCKER_TYPES, inferBlockerType, shouldUnblockOnReset };

--- a/server/kernel.js
+++ b/server/kernel.js
@@ -8,6 +8,7 @@
  * UI is just a dashboard.
  */
 const routeEngine = require('./route-engine');
+const { BLOCKER_TYPES } = require('./blocker-types');
 const contextCompiler = require('./context-compiler');
 const planDispatcher = require('./village/plan-dispatcher');
 const cycleWatchdog = require('./village/cycle-watchdog');
@@ -275,7 +276,11 @@ function createKernel(deps) {
       case 'dead_letter': {
         if (latestTask) {
           latestTask.status = 'blocked';
-          latestTask.blocker = { reason: `Dead letter: ${decision.rule}`, askedAt: helpers.nowIso() };
+          latestTask.blocker = {
+            type: BLOCKER_TYPES.DEAD_LETTER,
+            reason: `Dead letter: ${decision.rule}`,
+            askedAt: helpers.nowIso()
+          };
           // Preserve worktree on failure — agent may have written code that hasn't been
           // committed yet. Deleting it permanently loses work. Worktree will be cleaned
           // up when the task is manually cancelled/deleted or re-dispatched. (GH-325)

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -28,6 +28,7 @@ const { participantById, pushMessage, getUserIdForTask } = require('./_shared');
 const routeEngine = require('../route-engine');
 const worktreeHelper = require('../worktree');
 const { resolveRepoRoot, validateRepoRoot } = require('../repo-resolver');
+const { BLOCKER_TYPES, shouldUnblockOnReset } = require('../blocker-types');
 
 // --- Preflight logging: lessons injection + runtime selection ---
 function logDispatchPreflight(plan, task, deps, helpers) {
@@ -277,7 +278,11 @@ function dispatchTask(task, board, deps, helpers, opts = {}) {
         _dispatchLocks.delete(taskId);
         console.error(`[dispatchTask:${taskId}] repo validation failed: ${validation.error}`);
         task.status = 'blocked';
-        task.blocker = { reason: `Repo validation failed: ${validation.error}`, askedAt: helpers.nowIso() };
+        task.blocker = {
+          type: BLOCKER_TYPES.REPO_ERROR,
+          reason: `Repo validation failed: ${validation.error}`,
+          askedAt: helpers.nowIso()
+        };
         helpers.writeBoard(board);
         helpers.appendLog({ ts: helpers.nowIso(), event: 'dispatch_blocked', taskId, source, error: validation.error });
         helpers.broadcastSSE('board', board);
@@ -293,7 +298,11 @@ function dispatchTask(task, board, deps, helpers, opts = {}) {
         _dispatchLocks.delete(taskId);
         console.error(`[dispatchTask:${taskId}] worktree failed: ${err.message}`);
         task.status = 'blocked';
-        task.blocker = { reason: `Worktree creation failed: ${err.message}`, askedAt: helpers.nowIso() };
+        task.blocker = {
+          type: BLOCKER_TYPES.WORKTREE_ERROR,
+          reason: `Worktree creation failed: ${err.message}`,
+          askedAt: helpers.nowIso()
+        };
         helpers.writeBoard(board);
         helpers.appendLog({ ts: helpers.nowIso(), event: 'dispatch_blocked', taskId, source, error: err.message });
         helpers.broadcastSSE('board', board);
@@ -874,7 +883,11 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         }
 
         if (payload.status === 'blocked' && !payload.blocker) {
-          task.blocker = { reason: 'Unknown block', askedAt: helpers.nowIso() };
+          task.blocker = {
+            type: BLOCKER_TYPES.UNKNOWN,
+            reason: 'Unknown block',
+            askedAt: helpers.nowIso()
+          };
         }
 
         // Strict gate: only approved can unlock dependents
@@ -1292,7 +1305,11 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
           delete task.review;
         }
         if (newStatus === 'blocked' && payload.reason) {
-          task.blocker = { reason: payload.reason, askedAt: helpers.nowIso() };
+          task.blocker = {
+            type: payload.blocker?.type || BLOCKER_TYPES.MANUAL,
+            reason: payload.reason,
+            askedAt: helpers.nowIso()
+          };
         }
         if (newStatus !== 'blocked') task.blocker = null;
 
@@ -1603,10 +1620,9 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
     step.output_ref = null;
     step.scheduled_at = helpers.nowIso();
 
-    // Unblock task only if it was blocked due to dead/failed step (not dependency blocks)
+    // Unblock task only if it was blocked due to dead_letter (not dependency blocks)
     let taskUnblocked = false;
-    const blockerReason = task.blocker?.reason || '';
-    if (task.status === 'blocked' && (blockerReason.includes('Dead letter') || blockerReason.includes('dead') || blockerReason.includes('failed'))) {
+    if (task.status === 'blocked' && shouldUnblockOnReset(task.blocker)) {
       task.status = 'in_progress';
       task.blocker = null;
       taskUnblocked = true;

--- a/server/test-blocker-types.js
+++ b/server/test-blocker-types.js
@@ -1,0 +1,40 @@
+/**
+ * test-blocker-types.js — blocker-types 模組測試
+ */
+const assert = require('assert');
+const { BLOCKER_TYPES, inferBlockerType, shouldUnblockOnReset } = require('./blocker-types');
+
+async function runTests() {
+  // Test inferBlockerType
+  assert.strictEqual(inferBlockerType('Dead letter: budget_exceeded'), BLOCKER_TYPES.DEAD_LETTER);
+  assert.strictEqual(inferBlockerType('Repo validation failed: ...'), BLOCKER_TYPES.REPO_ERROR);
+  assert.strictEqual(inferBlockerType('Worktree creation failed: ...'), BLOCKER_TYPES.WORKTREE_ERROR);
+  assert.strictEqual(inferBlockerType('Custom reason'), BLOCKER_TYPES.MANUAL);
+  assert.strictEqual(inferBlockerType(null), BLOCKER_TYPES.UNKNOWN);
+  console.log('✓ inferBlockerType tests passed');
+
+  // Test shouldUnblockOnReset - new structure
+  assert.strictEqual(shouldUnblockOnReset({ type: 'dead_letter', reason: '...' }), true);
+  assert.strictEqual(shouldUnblockOnReset({ type: 'repo_error', reason: '...' }), false);
+  assert.strictEqual(shouldUnblockOnReset({ type: 'manual', reason: '...' }), false);
+  console.log('✓ shouldUnblockOnReset new structure tests passed');
+
+  // Test shouldUnblockOnReset - legacy structure (backward compat)
+  assert.strictEqual(shouldUnblockOnReset({ reason: 'Dead letter: budget_exceeded' }), true);
+  assert.strictEqual(shouldUnblockOnReset({ reason: 'Worktree creation failed' }), false);
+  assert.strictEqual(shouldUnblockOnReset({ reason: 'Custom blocker' }), false);
+  console.log('✓ shouldUnblockOnReset backward compat tests passed');
+
+  // Test edge cases
+  assert.strictEqual(shouldUnblockOnReset(null), false);
+  assert.strictEqual(shouldUnblockOnReset(undefined), false);
+  assert.strictEqual(shouldUnblockOnReset({}), false);
+  console.log('✓ Edge case tests passed');
+
+  console.log('\nAll blocker-types tests passed!');
+}
+
+runTests().catch(err => {
+  console.error('Test failed:', err);
+  process.exit(1);
+});

--- a/server/test-step-endpoints.js
+++ b/server/test-step-endpoints.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 const os = require('os');
 const { spawn } = require('child_process');
 const path = require('path');
+const { shouldUnblockOnReset } = require('./blocker-types');
 
 let PORT = Number(process.env.TEST_PORT) || 0;  // 0 = OS assigns free port
 const API_TOKEN = process.env.KARVI_API_TOKEN || null;
@@ -477,10 +478,9 @@ async function runTests() {
     // Reset step
     const res = await post('/api/tasks/T-RESET-DEP/steps/T-RESET-DEP:plan/reset', {});
     
-    // Blocker reason should NOT include 'Dead letter', 'dead', or 'failed'
+    // Blocker reason should NOT be dead_letter type
     // So task_unblocked should be false
-    const blockerReason = beforeTask?.blocker?.reason || '';
-    const shouldUnblock = blockerReason.includes('Dead letter') || blockerReason.includes('dead') || blockerReason.includes('failed');
+    const shouldUnblock = shouldUnblockOnReset(beforeTask?.blocker);
     
     if (res.ok && !shouldUnblock && res.task_unblocked === false) {
       ok('Conditional unblock: task_unblocked=false for dependency blocker');


### PR DESCRIPTION
## Summary

- Add `blocker-types.js` module with `BLOCKER_TYPES` enum for structured blocker classification
- Add `shouldUnblockOnReset()` function to replace fragile string matching in step reset logic
- Update all blocker-setting locations to include `type` field
- Provide backward compatibility for legacy blockers without `type` field via `inferBlockerType()`

## Changes

| File | Change |
|------|--------|
| `server/blocker-types.js` | New module with BLOCKER_TYPES enum and helper functions |
| `server/kernel.js` | Set `type: BLOCKER_TYPES.DEAD_LETTER` on dead_letter blockers |
| `server/routes/tasks.js` | Set `type` on 4 blocker locations, refactor unblock logic |
| `server/test-step-endpoints.js` | Use `shouldUnblockOnReset()` instead of string matching |
| `server/test-blocker-types.js` | New unit tests for blocker-types module |

## Problem Solved

The previous step reset unblock logic used string matching:
```javascript
blockerReason.includes('Dead letter') || blockerReason.includes('dead') || blockerReason.includes('failed')
```

This incorrectly matched any blocker containing "failed" (e.g., "Worktree creation failed").

Now uses structured `blocker.type` field:
```javascript
shouldUnblockOnReset(task.blocker)  // checks blocker.type === 'dead_letter'
```

Closes #305