### PR TITLE
feat(controls): budget gate — enforce before dispatch (GH-338)

### DIFF
--- a/server/blocker-types.js
+++ b/server/blocker-types.js
@@ -7,6 +7,7 @@ const BLOCKER_TYPES = {
   REPO_ERROR: 'repo_error',
   WORKTREE_ERROR: 'worktree_error',
   DEPENDENCY: 'dependency',
+  BUDGET_EXCEEDED: 'budget_exceeded',
   MANUAL: 'manual',
   UNKNOWN: 'unknown',
 };
@@ -17,6 +18,7 @@ function inferBlockerType(reason) {
   if (r.includes('dead letter')) return BLOCKER_TYPES.DEAD_LETTER;
   if (r.includes('repo validation')) return BLOCKER_TYPES.REPO_ERROR;
   if (r.includes('worktree')) return BLOCKER_TYPES.WORKTREE_ERROR;
+  if (r.includes('budget exceeded')) return BLOCKER_TYPES.BUDGET_EXCEEDED;
   return BLOCKER_TYPES.MANUAL;
 }
 

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -261,6 +261,24 @@ function dispatchTask(task, board, deps, helpers, opts = {}) {
     return { dispatched: false, reason: 'assignee not agent' };
   }
 
+  // --- Budget gate: reject if task budget already exhausted ---
+  if (task.budget && routeEngine.isBudgetExceeded(task.budget)) {
+    _dispatchLocks.delete(taskId);
+    const remaining = deps.contextCompiler.computeRemainingBudget(task.budget);
+    console.log(`[dispatchTask:${taskId}] skip: budget exceeded`);
+    task.status = 'blocked';
+    task.blocker = {
+      type: BLOCKER_TYPES.BUDGET_EXCEEDED,
+      reason: 'Budget exceeded before dispatch',
+      askedAt: helpers.nowIso(),
+      remaining,
+    };
+    helpers.writeBoard(board);
+    helpers.appendLog({ ts: helpers.nowIso(), event: 'dispatch_blocked', taskId, source, code: 'BUDGET_EXCEEDED', remaining });
+    helpers.broadcastSSE('board', board);
+    return { dispatched: false, code: 'BUDGET_EXCEEDED', reason: 'budget exceeded', remaining };
+  }
+
   // --- Phase 1: Worktree (ensure exists on disk) ---
   if (ctrl.use_worktrees) {
     // Validate worktree exists on disk (may have been manually deleted)
@@ -1684,6 +1702,12 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         if (!task) return json(res, 404, { error: `Task ${taskId} not found` });
         if (!task.steps?.length) return json(res, 400, { error: 'Task has no steps' });
 
+        // Budget gate: reject if task budget already exhausted
+        if (task.budget && routeEngine.isBudgetExceeded(task.budget)) {
+          const remaining = deps.contextCompiler.computeRemainingBudget(task.budget);
+          return json(res, 409, { error: 'Budget exceeded', code: 'BUDGET_EXCEEDED', remaining });
+        }
+
         // Filter steps: by step_ids (must be queued) or all queued
         let targets;
         if (Array.isArray(payload.step_ids) && payload.step_ids.length > 0) {
@@ -1779,6 +1803,9 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
       }
 
       const result = dispatchTask(task, board, deps, helpers, { source: 'dispatch', runtimeOverride });
+      if (result.code === 'BUDGET_EXCEEDED') {
+        return json(res, 409, { error: 'Budget exceeded', code: result.code, remaining: result.remaining });
+      }
       json(res, 200, { ok: true, taskId, dispatched: result.dispatched, planId: result.planId });
     } catch (error) {
       json(res, 500, { error: error.message });
@@ -2004,6 +2031,9 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
       }
 
       const result = dispatchTask(task, board, deps, helpers, { source: 'dispatch-next' });
+      if (result.code === 'BUDGET_EXCEEDED') {
+        return json(res, 409, { error: 'Budget exceeded', code: result.code, taskId: task.id, remaining: result.remaining });
+      }
       return json(res, 202, { ok: true, dispatched: result.dispatched, taskId: task.id, planId: result.planId });
     } catch (error) {
       return json(res, 500, { error: error.message });


### PR DESCRIPTION
## Summary

- Add pre-dispatch budget gate in `dispatchTask()` that rejects tasks whose budget is already exhausted before any work begins
- Add `BUDGET_EXCEEDED` blocker type to `blocker-types.js` with inference pattern
- Return structured HTTP 409 responses with `code`, `reason`, and `remaining` budget in per-task dispatch, dispatch-next, and batch-dispatch endpoints
- Gate fires before budget reset (Phase 1), so first-time dispatch passes through (no budget yet) while re-dispatch with exhausted budget is blocked

## Files Changed

- `server/blocker-types.js` — add `BUDGET_EXCEEDED` type + inference pattern
- `server/routes/tasks.js` — budget gate in `dispatchTask()`, 409 responses in 3 API routes

## Test Plan

- [x] `node --check` syntax passes on all modified files
- [x] `node server/test-blocker-types.js` — all pass
- [x] `node server/test-route-engine.js` — 14/14 pass
- [x] `node server/test-step-worker.js` — 48/48 pass
- [x] `node server/test-context-compiler.js` — 13/13 pass

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)