### PR TITLE
feat(dispatch): model hint validation before dispatch (GH-352)

### DIFF
--- a/server/management.js
+++ b/server/management.js
@@ -334,9 +334,37 @@ function preferredModelFor(agentId) {
  * Priority: model_map[runtime][stepType] > model_map[runtime].default > (openclaw) AGENT_MODEL_MAP > null
  * CLI runtimes (opencode, codex, claude) only get a model if model_map is configured.
  */
+/**
+ * Validate modelHint format: must be "provider/model" with non-empty parts.
+ * Returns { valid, normalized, warning, reason }.
+ * null/undefined → valid (no hint). Bad format → invalid with reason.
+ * Unknown but well-formatted → valid with warning.
+ */
+function validateModelHint(hint) {
+  if (hint === null || hint === undefined) return { valid: true, normalized: null };
+  if (typeof hint !== 'string') return { valid: false, reason: 'modelHint must be a string' };
+  const trimmed = hint.trim();
+  if (!trimmed) return { valid: false, reason: 'modelHint must not be empty' };
+  const slashIdx = trimmed.indexOf('/');
+  if (slashIdx < 0) return { valid: false, reason: 'modelHint must be in "provider/model" format (e.g. "anthropic/claude-sonnet-4")' };
+  const provider = trimmed.slice(0, slashIdx);
+  const model = trimmed.slice(slashIdx + 1);
+  if (!provider || !model) return { valid: false, reason: 'modelHint must have both provider and model parts' };
+  const known = new Set(Object.values(AGENT_MODEL_MAP));
+  const warning = !known.has(trimmed) ? `model "${trimmed}" is not in the known models registry` : null;
+  return { valid: true, normalized: trimmed, warning };
+}
+
 function resolveModelHint(runtimeHint, stepType, controls, task) {
-  // Per-task model override takes highest priority
-  if (task.modelHint) return task.modelHint;
+  // Per-task model override takes highest priority — validate format first
+  if (task.modelHint) {
+    const v = validateModelHint(task.modelHint);
+    if (!v.valid) {
+      console.warn(`[resolveModelHint] invalid modelHint for ${task.id}: ${v.reason} — falling through to model_map`);
+    } else {
+      return v.normalized;
+    }
+  }
   const map = controls.model_map;
   if (map && typeof map === 'object') {
     const runtimeMap = map[runtimeHint];
@@ -1224,6 +1252,7 @@ module.exports = {
   buildTaskDispatchMessage,
   buildRedispatchMessage,
   buildDispatchPlan,
+  validateModelHint,
   resolveOwnerId,
   DISPATCH_PLAN_VERSION,
   VALID_DISPATCH_STATES,

--- a/server/routes/controls.js
+++ b/server/routes/controls.js
@@ -63,7 +63,11 @@ module.exports = function controlsRoutes(req, res, helpers, deps) {
                   if (mapping && typeof mapping === 'object') {
                     const rtClean = {};
                     for (const [k, v] of Object.entries(mapping)) {
-                      if (typeof v === 'string' && v.trim()) rtClean[k] = v.trim();
+                      if (typeof v === 'string' && v.trim()) {
+                        const mv = mgmt.validateModelHint(v.trim());
+                        if (!mv.valid) return json(res, 400, { error: `invalid model in model_map.${rt}.${k}: ${mv.reason}` });
+                        rtClean[k] = mv.normalized;
+                      }
                     }
                     if (Object.keys(rtClean).length > 0) clean[rt] = rtClean;
                   }

--- a/server/routes/projects.js
+++ b/server/routes/projects.js
@@ -158,6 +158,14 @@ module.exports = function projectsRoutes(req, res, helpers, deps) {
           return json(res, 400, { error: 'circular dependency detected in tasks' });
         }
 
+        // Validate modelHint format on each task
+        for (const t of normalized) {
+          if (t.modelHint) {
+            const v = mgmt.validateModelHint(t.modelHint);
+            if (!v.valid) return json(res, 400, { error: `invalid modelHint for task ${t.id}: ${v.reason}` });
+          }
+        }
+
         const board = helpers.readBoard();
         board.projects = board.projects || [];
         board.taskPlan = board.taskPlan || { tasks: [] };

--- a/server/test-step-schema.js
+++ b/server/test-step-schema.js
@@ -471,6 +471,102 @@ test('buildDispatchPlan workingDir defaults to null', () => {
 });
 
 // ─────────────────────────────────────
+// validateModelHint
+// ─────────────────────────────────────
+
+test('validateModelHint accepts null/undefined', () => {
+  assert.deepStrictEqual(mgmt.validateModelHint(null), { valid: true, normalized: null });
+  assert.deepStrictEqual(mgmt.validateModelHint(undefined), { valid: true, normalized: null });
+});
+
+test('validateModelHint accepts valid provider/model format', () => {
+  const r = mgmt.validateModelHint('anthropic/claude-sonnet-4');
+  assert.strictEqual(r.valid, true);
+  assert.strictEqual(r.normalized, 'anthropic/claude-sonnet-4');
+});
+
+test('validateModelHint trims whitespace', () => {
+  const r = mgmt.validateModelHint('  anthropic/claude-sonnet-4  ');
+  assert.strictEqual(r.valid, true);
+  assert.strictEqual(r.normalized, 'anthropic/claude-sonnet-4');
+});
+
+test('validateModelHint rejects empty string', () => {
+  const r = mgmt.validateModelHint('');
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.reason.includes('empty'));
+});
+
+test('validateModelHint rejects whitespace-only', () => {
+  const r = mgmt.validateModelHint('   ');
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.reason.includes('empty'));
+});
+
+test('validateModelHint rejects missing slash', () => {
+  const r = mgmt.validateModelHint('gpt5');
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.reason.includes('provider/model'));
+});
+
+test('validateModelHint rejects non-string', () => {
+  const r = mgmt.validateModelHint(123);
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.reason.includes('string'));
+});
+
+test('validateModelHint rejects empty provider', () => {
+  const r = mgmt.validateModelHint('/model');
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.reason.includes('both provider and model'));
+});
+
+test('validateModelHint rejects empty model', () => {
+  const r = mgmt.validateModelHint('provider/');
+  assert.strictEqual(r.valid, false);
+  assert.ok(r.reason.includes('both provider and model'));
+});
+
+test('validateModelHint returns warning for unknown model', () => {
+  const r = mgmt.validateModelHint('unknown-provider/unknown-model');
+  assert.strictEqual(r.valid, true);
+  assert.strictEqual(r.normalized, 'unknown-provider/unknown-model');
+  assert.ok(r.warning && r.warning.includes('not in the known models registry'));
+});
+
+test('validateModelHint no warning for known model', () => {
+  // engineer_lite maps to custom-ai-t8star-cn/gpt-5.3-codex-high in AGENT_MODEL_MAP
+  const r = mgmt.validateModelHint('custom-ai-t8star-cn/gpt-5.3-codex-high');
+  assert.strictEqual(r.valid, true);
+  assert.strictEqual(r.warning, null);
+});
+
+test('buildDispatchPlan falls through on invalid modelHint', () => {
+  const board = {
+    taskPlan: { tasks: [{ id: 'T-00001', assignee: 'engineer_lite', status: 'dispatched', modelHint: 'bad-no-slash' }] },
+    controls: {},
+    lessons: [],
+    participants: [{ id: 'owner', type: 'human' }],
+  };
+  const task = board.taskPlan.tasks[0];
+  const plan = mgmt.buildDispatchPlan(board, task);
+  // Invalid modelHint should fall through — not used as-is
+  assert.notStrictEqual(plan.modelHint, 'bad-no-slash');
+});
+
+test('buildDispatchPlan normalizes whitespace in modelHint', () => {
+  const board = {
+    taskPlan: { tasks: [{ id: 'T-00001', assignee: 'engineer_lite', status: 'dispatched', modelHint: '  custom-ai-t8star-cn/gpt-5.3-codex-high  ' }] },
+    controls: {},
+    lessons: [],
+    participants: [{ id: 'owner', type: 'human' }],
+  };
+  const task = board.taskPlan.tasks[0];
+  const plan = mgmt.buildDispatchPlan(board, task);
+  assert.strictEqual(plan.modelHint, 'custom-ai-t8star-cn/gpt-5.3-codex-high');
+});
+
+// ─────────────────────────────────────
 // Cleanup & Summary
 // ─────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add `validateModelHint()` in `management.js` that enforces `provider/model` format with non-empty parts
- Reject malformed `modelHint` at API boundary: project creation (`POST /api/projects`) and `model_map` update (`POST /api/controls`) return 400
- `resolveModelHint()` now validates `task.modelHint` — invalid format logs a warning and falls through to `model_map` instead of silently passing a bad value to the runtime
- Known models (from `AGENT_MODEL_MAP`) produce no warning; unknown but well-formatted hints produce a warning but are still accepted
- 13 new tests covering all validation cases (52 total passing)

Closes #352

## Test plan
- [x] `validateModelHint` accepts null/undefined (no-op)
- [x] `validateModelHint` accepts valid `provider/model` format
- [x] `validateModelHint` trims whitespace
- [x] `validateModelHint` rejects empty, whitespace-only, no-slash, non-string, empty provider, empty model
- [x] `validateModelHint` returns warning for unknown model, no warning for known
- [x] `buildDispatchPlan` falls through on invalid modelHint (not used as-is)
- [x] `buildDispatchPlan` normalizes whitespace in modelHint
- [x] `node --check server/server.js` passes
- [x] `node --check server/management.js` passes
- [x] `node server/test-step-schema.js` — 52 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)