### PR TITLE
feat(api): audit log query endpoint (GH-340)

### DIFF
--- a/server/routes/logs.js
+++ b/server/routes/logs.js
@@ -22,6 +22,8 @@ const MAX_LIMIT = 1000;
 const DEFAULT_LIMIT = 100;
 
 function readLogEntries(logPath) {
+  // NOTE: reads entire file into memory — adequate for single-server JSON file storage.
+  // If task-log.jsonl grows beyond ~100 MB, switch to streaming (readline) or pagination at the FS layer.
   const raw = fs.readFileSync(logPath, 'utf8');
   const entries = [];
   for (const line of raw.split('\n')) {
@@ -29,8 +31,8 @@ function readLogEntries(logPath) {
     if (!trimmed) continue;
     try {
       entries.push(JSON.parse(trimmed));
-    } catch {
-      // 跳過無法解析的行
+    } catch (err) {
+      console.warn(`[logs] skipping unparseable JSONL line: ${err.message}`);
     }
   }
   return entries;

--- a/server/server.js
+++ b/server/server.js
@@ -155,7 +155,6 @@ const discoveryRoutes = require('./routes/discovery');
 const versionRoutes = require('./routes/version');
 const artifactsRoutes = require('./routes/artifacts');
 const logsRoutes = require('./routes/logs');
-const artifactsRoutes = require('./routes/artifacts');
 
 // --- Route chain ---
 const routes = [
@@ -176,7 +175,6 @@ const routes = [
   discoveryRoutes,
   artifactsRoutes,
   logsRoutes,
-  artifactsRoutes,
 ];
 
 const { json } = bb;

--- a/server/smoke-test.js
+++ b/server/smoke-test.js
@@ -967,6 +967,18 @@ async function runSuite(target) {
     } catch (e) { fail('GET /api/artifacts/:run/:step/:kind → 404', e.message); }
   }
 
+  // ── Audit Log Query (GH-340) ──
+  if (port === 3461) {
+    try {
+      const r = await get(port, '/api/logs');
+      if (r.status !== 200) throw new Error(`status ${r.status}`);
+      const body = JSON.parse(r.body);
+      if (!Array.isArray(body.entries)) throw new Error('expected entries array');
+      if (typeof body.total !== 'number') throw new Error('missing total');
+      ok('GET /api/logs → 200 + entries array');
+    } catch (e) { fail('GET /api/logs', e.message); }
+  }
+
   console.log(`  ── ${passed} passed, ${failed} failed ──`);
   return { passed, failed };
 }


### PR DESCRIPTION
## Summary
- Add `GET /api/logs` endpoint for structured querying of `task-log.jsonl`
- Supports filtering by `taskId`, `event`, `user`, `from`/`to` time range
- Supports pagination (`limit`/`offset`), sorting (`sort=asc|desc`), and JSONL export (`format=jsonl`)

Closes #340

## Test plan
- [ ] `GET /api/logs` returns 200 with `total`, `limit`, `offset`, `entries`
- [ ] `GET /api/logs?event=controls_updated` filters correctly
- [ ] `GET /api/logs?limit=1` returns exactly 1 entry
- [ ] `GET /api/logs?sort=asc` returns oldest first
- [ ] `GET /api/logs?format=jsonl` returns `application/x-ndjson` content type
- [ ] `GET /api/logs?from=2026-03-01&to=2026-03-02` filters by time range
- [ ] `GET /api/logs?taskId=GH-1` matches both `entry.taskId` and `entry.data.taskId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)