### PR TITLE
feat(api): artifact query endpoint (GH-344)

### DIFF
--- a/server/artifact-store.js
+++ b/server/artifact-store.js
@@ -77,6 +77,20 @@ function logPath(runId, stepId) {
   return path.join(ARTIFACT_DIR, runId, `${safeStepId}.log`);
 }
 
+/**
+ * List all run directories in the artifact store.
+ * Returns array of run_id strings.
+ */
+function listAllRuns() {
+  try {
+    return fs.readdirSync(ARTIFACT_DIR, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => d.name);
+  } catch {
+    return [];
+  }
+}
+
 module.exports = {
   ARTIFACT_DIR,
   artifactPath,
@@ -86,4 +100,5 @@ module.exports = {
   listArtifacts,
   appendLog,
   logPath,
+  listAllRuns,
 };

--- a/server/routes/artifacts.js
+++ b/server/routes/artifacts.js
@@ -1,0 +1,91 @@
+/**
+ * routes/artifacts.js — Artifact Query API
+ *
+ * GET /api/artifacts              — query artifact metadata (board-indexed)
+ * GET /api/artifacts/:run/:step/:kind — download specific artifact content
+ *
+ * Query params for GET /api/artifacts:
+ *   task    — filter by task ID (e.g., GH-123)
+ *   step    — filter by step type (e.g., plan, implement, review)
+ *   type    — filter by artifact kind (input, output, log)
+ *   run_id  — filter by specific run ID
+ */
+const bb = require('../blackboard-server');
+const { json } = bb;
+
+/**
+ * Build artifact metadata list from board task/step data.
+ * Checks actual file existence via artifactStore.
+ */
+function queryArtifacts(board, filters, artifactStore) {
+  const tasks = board.taskPlan?.tasks || [];
+  const kinds = ['input', 'output'];
+  const results = [];
+
+  for (const task of tasks) {
+    if (filters.task && task.id !== filters.task) continue;
+
+    for (const step of (task.steps || [])) {
+      if (!step.run_id) continue;
+      if (filters.step && step.type !== filters.step) continue;
+      if (filters.run_id && step.run_id !== filters.run_id) continue;
+
+      const targetKinds = filters.type ? [filters.type] : kinds;
+
+      for (const kind of targetKinds) {
+        const exists = artifactStore.artifactExists(step.run_id, step.step_id, kind);
+        if (!exists) continue;
+
+        const safeStepId = step.step_id.replace(/:/g, '_');
+        results.push({
+          task_id: task.id,
+          step_id: step.step_id,
+          step_type: step.type,
+          run_id: step.run_id,
+          kind,
+          download_url: `/api/artifacts/${step.run_id}/${safeStepId}/${kind}`,
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+module.exports = function artifactsRoutes(req, res, helpers, deps) {
+  if (req.method !== 'GET') return false;
+
+  // Match: /api/artifacts/:runId/:stepId/:kind
+  const downloadMatch = req.url.match(/^\/api\/artifacts\/([^/]+)\/([^/]+)\/([^/?]+)/);
+  if (downloadMatch) {
+    const [, runId, safeStepId, kind] = downloadMatch;
+    // Convert safe step ID back to colon format for readArtifact
+    const stepId = safeStepId.replace(/_/g, ':');
+
+    if (!['input', 'output', 'log'].includes(kind)) {
+      return json(res, 400, { error: `invalid artifact kind: ${kind}` });
+    }
+
+    const data = deps.artifactStore.readArtifact(runId, stepId, kind);
+    if (data === null) {
+      return json(res, 404, { error: 'artifact not found' });
+    }
+    return json(res, 200, data);
+  }
+
+  // Match: /api/artifacts or /api/artifacts?...
+  const listMatch = req.url.match(/^\/api\/artifacts(\?|$)/);
+  if (!listMatch) return false;
+
+  const url = new URL(req.url, 'http://localhost');
+  const filters = {
+    task: url.searchParams.get('task') || null,
+    step: url.searchParams.get('step') || null,
+    type: url.searchParams.get('type') || null,
+    run_id: url.searchParams.get('run_id') || null,
+  };
+
+  const board = helpers.readBoard();
+  const artifacts = queryArtifacts(board, filters, deps.artifactStore);
+  return json(res, 200, { artifacts });
+};

--- a/server/server.js
+++ b/server/server.js
@@ -153,6 +153,7 @@ const tasksRoutes = require('./routes/tasks');
 const statusRoutes = require('./routes/status');
 const discoveryRoutes = require('./routes/discovery');
 const versionRoutes = require('./routes/version');
+const artifactsRoutes = require('./routes/artifacts');
 
 // --- Route chain ---
 const routes = [
@@ -171,6 +172,7 @@ const routes = [
   statusRoutes,
   versionRoutes,
   discoveryRoutes,
+  artifactsRoutes,
 ];
 
 const { json } = bb;

--- a/server/smoke-test.js
+++ b/server/smoke-test.js
@@ -939,6 +939,34 @@ async function runSuite(target) {
     } catch (e) { fail('POST /api/tasks/cleanup', e.message); }
   }
 
+  // --- Artifact Query API ---
+  {
+    // GET /api/artifacts — should return 200 with artifacts array
+    try {
+      const r = await get(port, '/api/artifacts');
+      if (r.status !== 200) throw new Error(`expected 200, got ${r.status}`);
+      const body = JSON.parse(r.body);
+      if (!Array.isArray(body.artifacts)) throw new Error('expected artifacts array');
+      ok('GET /api/artifacts → 200 with artifacts array');
+    } catch (e) { fail('GET /api/artifacts → 200', e.message); }
+
+    // GET /api/artifacts?task=NONEXISTENT — should return 200 with empty array
+    try {
+      const r = await get(port, '/api/artifacts?task=SMOKE-NOEXIST-999');
+      if (r.status !== 200) throw new Error(`expected 200, got ${r.status}`);
+      const body = JSON.parse(r.body);
+      if (!Array.isArray(body.artifacts) || body.artifacts.length !== 0) throw new Error('expected empty artifacts array');
+      ok('GET /api/artifacts?task=NONEXISTENT → 200 empty');
+    } catch (e) { fail('GET /api/artifacts?task=NONEXISTENT → 200 empty', e.message); }
+
+    // GET /api/artifacts/:run/:step/:kind — 404 for missing
+    try {
+      const r = await get(port, '/api/artifacts/run-nonexistent/step-nonexistent/output');
+      if (r.status !== 404) throw new Error(`expected 404, got ${r.status}`);
+      ok('GET /api/artifacts/:run/:step/:kind → 404 on missing');
+    } catch (e) { fail('GET /api/artifacts/:run/:step/:kind → 404', e.message); }
+  }
+
   console.log(`  ── ${passed} passed, ${failed} failed ──`);
   return { passed, failed };
 }


### PR DESCRIPTION
## Summary

- Add `GET /api/artifacts` endpoint for querying artifact metadata by task/step/type/run_id filters (board-indexed)
- Add `GET /api/artifacts/:runId/:stepId/:kind` endpoint for direct artifact content download (presigned-download equivalent for local deployment)
- Add `listAllRuns()` helper to `artifact-store.js`
- Add smoke test coverage for all new endpoints

Closes #344

## Test plan

- [x] `node --check` passes for all modified files
- [x] Smoke tests: GET /api/artifacts returns 200 with artifacts array
- [x] Smoke tests: GET /api/artifacts?task=NONEXISTENT returns 200 with empty array
- [x] Smoke tests: GET /api/artifacts/:run/:step/:kind returns 404 for missing artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)