### PR TITLE
feat(pipeline): step input/output contract (GH-346)

### DIFF
--- a/server/step-schema.js
+++ b/server/step-schema.js
@@ -54,6 +54,196 @@ const ERROR_KINDS = {
   UNKNOWN:           { retryable: true,  backoff: 'exponential' },
 };
 
+// --- Step Input/Output Contracts (GH-346) ---
+
+const STEP_OUTPUT_SCHEMAS = {
+  plan: {
+    required: ['status', 'summary'],
+    optional: ['payload'],
+    payloadSchema: {
+      optional: ['scope', 'proposal', 'plan'],
+      scopeSchema: {
+        optional: ['allow', 'deny'],
+      },
+    },
+  },
+  implement: {
+    required: ['status', 'summary'],
+    optional: ['payload', 'tokens_used', 'duration_ms'],
+    payloadSchema: {
+      optional: ['pr_url', 'commit_hash', 'files_changed'],
+    },
+  },
+  test: {
+    required: ['status', 'summary'],
+    optional: ['payload', 'tokens_used', 'duration_ms'],
+    payloadSchema: {
+      optional: ['passed', 'failed', 'skipped', 'coverage'],
+    },
+  },
+  review: {
+    required: ['status', 'summary'],
+    optional: ['payload', 'tokens_used', 'duration_ms'],
+    payloadSchema: {
+      optional: ['verdict', 'score', 'issues', 'suggestions'],
+    },
+  },
+  execute: {
+    required: ['status', 'summary'],
+    optional: ['payload', 'tokens_used', 'duration_ms'],
+    payloadSchema: {
+      optional: ['pr_url', 'commit_hash', 'files_changed'],
+    },
+  },
+};
+
+const STEP_INPUT_EXPECTATIONS = {
+  plan: {
+    required: [],
+    optional: ['task_description', 'issue_context'],
+    description: 'First step — no upstream requirements',
+  },
+  implement: {
+    required: [],
+    optional: ['scope', 'plan'],
+    description: 'Consumes scope from plan step',
+  },
+  test: {
+    required: [],
+    optional: ['files_changed', 'commit_hash'],
+    description: 'Consumes implementation artifacts',
+  },
+  review: {
+    required: [],
+    optional: ['pr_url', 'commit_hash'],
+    description: 'Consumes PR/commit from implement step',
+  },
+  execute: {
+    required: [],
+    optional: ['task_description', 'issue_context'],
+    description: 'Standalone execution — no upstream requirements',
+  },
+};
+
+const STEP_PIPELINE_ORDER = ['plan', 'implement', 'test', 'review'];
+
+function validateStepOutputSchema(stepType, output) {
+  const errors = [];
+  const schema = STEP_OUTPUT_SCHEMAS[stepType];
+  
+  if (!schema) {
+    return { valid: true, warnings: [`No schema defined for step type "${stepType}"`] };
+  }
+  
+  if (!output || typeof output !== 'object') {
+    return { valid: false, errors: ['Output must be a non-null object'] };
+  }
+  
+  for (const field of schema.required) {
+    if (!(field in output) || output[field] === undefined) {
+      errors.push(`Missing required field: ${field}`);
+    }
+  }
+  
+  if (output.status && !['succeeded', 'failed', 'needs_revision'].includes(output.status)) {
+    errors.push(`Invalid status "${output.status}" — must be succeeded, failed, or needs_revision`);
+  }
+  
+  if (schema.payloadSchema && output.payload && typeof output.payload === 'object') {
+    const payloadErrors = validatePayloadFields(stepType, output.payload, schema.payloadSchema);
+    errors.push(...payloadErrors);
+  }
+  
+  return errors.length === 0 ? { valid: true } : { valid: false, errors };
+}
+
+function validatePayloadFields(stepType, payload, payloadSchema) {
+  const errors = [];
+  
+  if (payloadSchema.scopeSchema && payload.scope) {
+    if (typeof payload.scope !== 'object') {
+      errors.push('payload.scope must be an object');
+    } else {
+      if (payload.scope.allow && !Array.isArray(payload.scope.allow)) {
+        errors.push('payload.scope.allow must be an array');
+      }
+      if (payload.scope.deny && !Array.isArray(payload.scope.deny)) {
+        errors.push('payload.scope.deny must be an array');
+      }
+    }
+  }
+  
+  if (payload.pr_url && typeof payload.pr_url !== 'string') {
+    errors.push('payload.pr_url must be a string');
+  }
+  
+  if (payload.verdict && !['lgtm', 'needs_revision', 'blocked'].includes(payload.verdict)) {
+    errors.push(`Invalid payload.verdict "${payload.verdict}"`);
+  }
+  
+  if (payload.score !== undefined && typeof payload.score !== 'number') {
+    errors.push('payload.score must be a number');
+  }
+  
+  if (payload.issues && !Array.isArray(payload.issues)) {
+    errors.push('payload.issues must be an array');
+  }
+  
+  return errors;
+}
+
+function validateStepContract(currentStepType, output, nextStepType) {
+  const errors = [];
+  const warnings = [];
+  
+  const outputResult = validateStepOutputSchema(currentStepType, output);
+  if (!outputResult.valid) {
+    return { valid: false, errors: outputResult.errors, warnings: [] };
+  }
+  if (outputResult.warnings) {
+    warnings.push(...outputResult.warnings);
+  }
+  
+  if (output.status !== 'succeeded') {
+    return { valid: true, warnings: ['Step did not succeed — skipping contract validation'] };
+  }
+  
+  const expectations = STEP_INPUT_EXPECTATIONS[nextStepType];
+  if (!expectations) {
+    return { valid: true, warnings: [`No input expectations defined for step type "${nextStepType}"`] };
+  }
+  
+  const payload = output.payload || {};
+  
+  for (const field of expectations.required) {
+    if (!(field in payload) || payload[field] === undefined || payload[field] === null) {
+      errors.push(`Next step "${nextStepType}" requires "${field}" but current step output does not provide it`);
+    }
+  }
+  
+  if (nextStepType === 'implement' && currentStepType === 'plan') {
+    if (!payload.scope || typeof payload.scope !== 'object') {
+      warnings.push('Plan step should provide payload.scope for implement step (file allow/deny patterns)');
+    }
+  }
+  
+  if (nextStepType === 'review' && currentStepType === 'implement') {
+    if (!payload.pr_url && !output.summary?.match(/github\.com\/[^/]+\/[^/]+\/pull\/\d+/i)) {
+      warnings.push('Implement step should provide payload.pr_url or include PR URL in summary for review step');
+    }
+  }
+  
+  return errors.length === 0 ? { valid: true, warnings } : { valid: false, errors, warnings };
+}
+
+function getStepOutputSchema(stepType) {
+  return STEP_OUTPUT_SCHEMAS[stepType] || null;
+}
+
+function getStepInputExpectations(stepType) {
+  return STEP_INPUT_EXPECTATIONS[stepType] || null;
+}
+
 // --- Functions ---
 
 function computeBackoff(kindConfig, step) {
@@ -185,6 +375,9 @@ module.exports = {
   ALLOWED_STEP_TRANSITIONS,
   DEFAULT_RETRY_POLICY,
   ERROR_KINDS,
+  STEP_OUTPUT_SCHEMAS,
+  STEP_INPUT_EXPECTATIONS,
+  STEP_PIPELINE_ORDER,
   createStep,
   canTransitionStep,
   ensureStepTransition,
@@ -192,4 +385,8 @@ module.exports = {
   computeBackoff,
   computeIdempotencyKey,
   isStepIdempotent,
+  validateStepOutputSchema,
+  validateStepContract,
+  getStepOutputSchema,
+  getStepInputExpectations,
 };

--- a/server/test-step-schema.js
+++ b/server/test-step-schema.js
@@ -567,6 +567,238 @@ test('buildDispatchPlan normalizes whitespace in modelHint', () => {
 });
 
 // ─────────────────────────────────────
+// Step Input/Output Contract Validation (GH-346)
+// ─────────────────────────────────────
+
+console.log('\n=== Step Contract Validation ===\n');
+
+test('STEP_OUTPUT_SCHEMAS defines schemas for all step types', () => {
+  for (const type of stepSchema.STEP_TYPES) {
+    assert.ok(stepSchema.STEP_OUTPUT_SCHEMAS[type], `Should have schema for ${type}`);
+    assert.ok(Array.isArray(stepSchema.STEP_OUTPUT_SCHEMAS[type].required), `${type} should have required fields`);
+  }
+});
+
+test('STEP_INPUT_EXPECTATIONS defines expectations for all step types', () => {
+  for (const type of stepSchema.STEP_TYPES) {
+    assert.ok(stepSchema.STEP_INPUT_EXPECTATIONS[type], `Should have input expectations for ${type}`);
+  }
+});
+
+test('validateStepOutputSchema accepts valid plan output', () => {
+  const output = { status: 'succeeded', summary: 'Plan created' };
+  const result = stepSchema.validateStepOutputSchema('plan', output);
+  assert.strictEqual(result.valid, true);
+});
+
+test('validateStepOutputSchema accepts valid plan output with scope', () => {
+  const output = {
+    status: 'succeeded',
+    summary: 'Plan created',
+    payload: { scope: { allow: ['server/*.js'], deny: ['.claude/**'] } },
+  };
+  const result = stepSchema.validateStepOutputSchema('plan', output);
+  assert.strictEqual(result.valid, true);
+});
+
+test('validateStepOutputSchema rejects output missing required fields', () => {
+  const output = { summary: 'Missing status' };
+  const result = stepSchema.validateStepOutputSchema('plan', output);
+  assert.strictEqual(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('status')));
+});
+
+test('validateStepOutputSchema rejects null output', () => {
+  const result = stepSchema.validateStepOutputSchema('plan', null);
+  assert.strictEqual(result.valid, false);
+});
+
+test('validateStepOutputSchema rejects invalid status value', () => {
+  const output = { status: 'invalid', summary: 'test' };
+  const result = stepSchema.validateStepOutputSchema('plan', output);
+  assert.strictEqual(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('status')));
+});
+
+test('validateStepOutputSchema validates scope.allow is array', () => {
+  const output = {
+    status: 'succeeded',
+    summary: 'Plan',
+    payload: { scope: { allow: 'not-an-array' } },
+  };
+  const result = stepSchema.validateStepOutputSchema('plan', output);
+  assert.strictEqual(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('scope.allow')));
+});
+
+test('validateStepOutputSchema validates scope.deny is array', () => {
+  const output = {
+    status: 'succeeded',
+    summary: 'Plan',
+    payload: { scope: { deny: 'not-an-array' } },
+  };
+  const result = stepSchema.validateStepOutputSchema('plan', output);
+  assert.strictEqual(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('scope.deny')));
+});
+
+test('validateStepOutputSchema accepts valid implement output', () => {
+  const output = {
+    status: 'succeeded',
+    summary: 'Implemented',
+    payload: { pr_url: 'https://github.com/owner/repo/pull/1' },
+  };
+  const result = stepSchema.validateStepOutputSchema('implement', output);
+  assert.strictEqual(result.valid, true);
+});
+
+test('validateStepOutputSchema validates pr_url is string', () => {
+  const output = {
+    status: 'succeeded',
+    summary: 'Implemented',
+    payload: { pr_url: 123 },
+  };
+  const result = stepSchema.validateStepOutputSchema('implement', output);
+  assert.strictEqual(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('pr_url')));
+});
+
+test('validateStepOutputSchema accepts valid review output with verdict', () => {
+  const output = {
+    status: 'succeeded',
+    summary: 'Reviewed',
+    payload: { verdict: 'lgtm', score: 85, issues: [] },
+  };
+  const result = stepSchema.validateStepOutputSchema('review', output);
+  assert.strictEqual(result.valid, true);
+});
+
+test('validateStepOutputSchema rejects invalid verdict', () => {
+  const output = {
+    status: 'succeeded',
+    summary: 'Reviewed',
+    payload: { verdict: 'invalid-verdict' },
+  };
+  const result = stepSchema.validateStepOutputSchema('review', output);
+  assert.strictEqual(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('verdict')));
+});
+
+test('validateStepOutputSchema validates score is number', () => {
+  const output = {
+    status: 'succeeded',
+    summary: 'Reviewed',
+    payload: { score: 'not-a-number' },
+  };
+  const result = stepSchema.validateStepOutputSchema('review', output);
+  assert.strictEqual(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('score')));
+});
+
+test('validateStepOutputSchema validates issues is array', () => {
+  const output = {
+    status: 'succeeded',
+    summary: 'Reviewed',
+    payload: { issues: 'not-an-array' },
+  };
+  const result = stepSchema.validateStepOutputSchema('review', output);
+  assert.strictEqual(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('issues')));
+});
+
+test('validateStepOutputSchema returns warning for unknown step type', () => {
+  const result = stepSchema.validateStepOutputSchema('unknown-type', { status: 'succeeded' });
+  assert.strictEqual(result.valid, true);
+  assert.ok(result.warnings && result.warnings.length > 0);
+});
+
+test('validateStepContract passes for plan -> implement with scope', () => {
+  const output = {
+    status: 'succeeded',
+    summary: 'Plan done',
+    payload: { scope: { allow: ['server/*.js'], deny: [] } },
+  };
+  const result = stepSchema.validateStepContract('plan', output, 'implement');
+  assert.strictEqual(result.valid, true);
+});
+
+test('validateStepContract warns for plan -> implement without scope', () => {
+  const output = { status: 'succeeded', summary: 'Plan done' };
+  const result = stepSchema.validateStepContract('plan', output, 'implement');
+  assert.strictEqual(result.valid, true);
+  assert.ok(result.warnings.some(w => w.includes('scope')));
+});
+
+test('validateStepContract passes for implement -> review with pr_url', () => {
+  const output = {
+    status: 'succeeded',
+    summary: 'Implemented',
+    payload: { pr_url: 'https://github.com/owner/repo/pull/1' },
+  };
+  const result = stepSchema.validateStepContract('implement', output, 'review');
+  assert.strictEqual(result.valid, true);
+});
+
+test('validateStepContract warns for implement -> review without pr_url', () => {
+  const output = { status: 'succeeded', summary: 'Implemented without PR URL' };
+  const result = stepSchema.validateStepContract('implement', output, 'review');
+  assert.strictEqual(result.valid, true);
+  assert.ok(result.warnings.some(w => w.includes('pr_url')));
+});
+
+test('validateStepContract skips validation for failed step', () => {
+  const output = { status: 'failed', summary: 'Step failed' };
+  const result = stepSchema.validateStepContract('plan', output, 'implement');
+  assert.strictEqual(result.valid, true);
+  assert.ok(result.warnings.some(w => w.includes('did not succeed')));
+});
+
+test('validateStepContract fails if output schema is invalid', () => {
+  const output = { summary: 'Missing status' };
+  const result = stepSchema.validateStepContract('plan', output, 'implement');
+  assert.strictEqual(result.valid, false);
+  assert.ok(result.errors.length > 0);
+});
+
+test('getStepOutputSchema returns schema for known type', () => {
+  const schema = stepSchema.getStepOutputSchema('plan');
+  assert.ok(schema);
+  assert.ok(Array.isArray(schema.required));
+});
+
+test('getStepOutputSchema returns null for unknown type', () => {
+  const schema = stepSchema.getStepOutputSchema('nonexistent');
+  assert.strictEqual(schema, null);
+});
+
+test('getStepInputExpectations returns expectations for known type', () => {
+  const expectations = stepSchema.getStepInputExpectations('implement');
+  assert.ok(expectations);
+  assert.ok(expectations.description);
+});
+
+test('getStepInputExpectations returns null for unknown type', () => {
+  const expectations = stepSchema.getStepInputExpectations('nonexistent');
+  assert.strictEqual(expectations, null);
+});
+
+test('validateStepContract handles execute step type', () => {
+  const output = { status: 'succeeded', summary: 'Executed' };
+  const result = stepSchema.validateStepOutputSchema('execute', output);
+  assert.strictEqual(result.valid, true);
+});
+
+test('validateStepContract handles test step type', () => {
+  const output = {
+    status: 'succeeded',
+    summary: 'Tests passed',
+    payload: { passed: 10, failed: 0 },
+  };
+  const result = stepSchema.validateStepOutputSchema('test', output);
+  assert.strictEqual(result.valid, true);
+});
+
+// ─────────────────────────────────────
 // Cleanup & Summary
 // ─────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add step input/output contract validation
- Closes #346

Dispatched via Karvi server → z.ai (zai-coding-plan/glm-5)