### PR TITLE
feat(metrics): per-agent quality tracking (GH-345)

### DIFF
--- a/server/routes/metrics.js
+++ b/server/routes/metrics.js
@@ -1,0 +1,132 @@
+/**
+ * routes/metrics.js — Per-Agent Quality Metrics API (#345)
+ *
+ * GET /api/metrics/agents — 按 runtime+model 聚合 step 成功率、tokens、duration
+ *
+ * 查詢參數:
+ *   from      — 起始時間 ISO string（>=）
+ *   to        — 結束時間 ISO string（<=）
+ *   runtime   — 過濾 runtime（精確匹配）
+ *   model     — 過濾 model（精確匹配）
+ *   step_type — 過濾 step 類型（精確匹配）
+ */
+const fs = require('fs');
+const bb = require('../blackboard-server');
+const { json } = bb;
+
+// Step terminal events that carry metrics (enriched in step-worker.js)
+const METRIC_EVENTS = new Set(['step_completed', 'step_dead', 'step_failed']);
+
+function readLogEntries(logPath) {
+  const raw = fs.readFileSync(logPath, 'utf8');
+  const entries = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      entries.push(JSON.parse(trimmed));
+    } catch { /* skip unparseable lines */ }
+  }
+  return entries;
+}
+
+function matchEntry(entry, filters) {
+  if (!METRIC_EVENTS.has(entry.event)) return false;
+  // Must have runtime or model to be useful for per-agent tracking
+  if (!entry.runtime && !entry.model) return false;
+  if (filters.from && entry.ts < filters.from) return false;
+  if (filters.to && entry.ts > filters.to) return false;
+  if (filters.runtime && entry.runtime !== filters.runtime) return false;
+  if (filters.model && entry.model !== filters.model) return false;
+  if (filters.step_type && entry.step_type !== filters.step_type) return false;
+  return true;
+}
+
+function aggregate(entries) {
+  // Group by runtime + model
+  const groups = new Map();
+
+  for (const entry of entries) {
+    const key = `${entry.runtime || 'unknown'}::${entry.model || 'unknown'}`;
+    if (!groups.has(key)) {
+      groups.set(key, {
+        runtime: entry.runtime || 'unknown',
+        model: entry.model || 'unknown',
+        total_steps: 0,
+        succeeded: 0,
+        failed: 0,
+        total_tokens: 0,
+        total_duration_ms: 0,
+        by_step_type: {},
+      });
+    }
+    const g = groups.get(key);
+    g.total_steps++;
+
+    const isSuccess = entry.to === 'succeeded';
+    if (isSuccess) g.succeeded++;
+    else g.failed++;
+
+    g.total_tokens += entry.tokens_used || 0;
+    g.total_duration_ms += entry.duration_ms || 0;
+
+    // Per step_type breakdown
+    const st = entry.step_type || 'unknown';
+    if (!g.by_step_type[st]) {
+      g.by_step_type[st] = { total: 0, succeeded: 0, failed: 0 };
+    }
+    const stg = g.by_step_type[st];
+    stg.total++;
+    if (isSuccess) stg.succeeded++;
+    else stg.failed++;
+  }
+
+  // Compute rates
+  const agents = [];
+  for (const g of groups.values()) {
+    g.success_rate = g.total_steps > 0 ? Math.round((g.succeeded / g.total_steps) * 1000) / 1000 : 0;
+    g.avg_duration_ms = g.total_steps > 0 ? Math.round(g.total_duration_ms / g.total_steps) : 0;
+
+    for (const st of Object.values(g.by_step_type)) {
+      st.success_rate = st.total > 0 ? Math.round((st.succeeded / st.total) * 1000) / 1000 : 0;
+    }
+
+    agents.push(g);
+  }
+
+  // Sort by total_steps descending
+  agents.sort((a, b) => b.total_steps - a.total_steps);
+  return agents;
+}
+
+module.exports = function metricsRoutes(req, res, helpers, deps) {
+  if (req.method !== 'GET') return false;
+
+  const url = new URL(req.url, 'http://localhost');
+  if (url.pathname !== '/api/metrics/agents') return false;
+
+  const from = url.searchParams.get('from') || null;
+  const to = url.searchParams.get('to') || null;
+  const runtime = url.searchParams.get('runtime') || null;
+  const model = url.searchParams.get('model') || null;
+  const step_type = url.searchParams.get('step_type') || null;
+
+  const filters = { from, to, runtime, model, step_type };
+
+  let allEntries;
+  try {
+    allEntries = readLogEntries(deps.ctx.logPath);
+  } catch {
+    // Log file may not exist yet
+    return json(res, 200, { agents: [], period: { from, to }, total_entries: 0 });
+  }
+
+  const filtered = allEntries.filter(e => matchEntry(e, filters));
+  const agents = aggregate(filtered);
+
+  return json(res, 200, {
+    agents,
+    period: { from, to },
+    total_entries: filtered.length,
+  });
+};

--- a/server/server.js
+++ b/server/server.js
@@ -155,6 +155,7 @@ const discoveryRoutes = require('./routes/discovery');
 const versionRoutes = require('./routes/version');
 const artifactsRoutes = require('./routes/artifacts');
 const logsRoutes = require('./routes/logs');
+const metricsRoutes = require('./routes/metrics');
 
 // --- Route chain ---
 const routes = [
@@ -175,6 +176,7 @@ const routes = [
   discoveryRoutes,
   artifactsRoutes,
   logsRoutes,
+  metricsRoutes,
 ];
 
 const { json } = bb;

--- a/server/smoke-test.js
+++ b/server/smoke-test.js
@@ -1007,6 +1007,19 @@ async function runSuite(target) {
     } catch (e) { fail('GET /api/logs', e.message); }
   }
 
+  // ── Per-Agent Quality Metrics (GH-345) ──
+  if (port === 3461) {
+    try {
+      const r = await get(port, '/api/metrics/agents');
+      if (r.status !== 200) throw new Error(`status ${r.status}`);
+      const body = JSON.parse(r.body);
+      if (!Array.isArray(body.agents)) throw new Error('expected agents array');
+      if (typeof body.total_entries !== 'number') throw new Error('missing total_entries');
+      if (!body.period || !('from' in body.period)) throw new Error('missing period');
+      ok('GET /api/metrics/agents → 200 + agents array');
+    } catch (e) { fail('GET /api/metrics/agents', e.message); }
+  }
+
   console.log(`  ── ${passed} passed, ${failed} failed ──`);
   return { passed, failed };
 }

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -651,8 +651,30 @@ function createStepWorker(deps) {
       });
       mgmt.trimSignals(latestBoard, helpers.signalArchivePath);
       helpers.writeBoard(latestBoard);
-      helpers.appendLog({ ts: helpers.nowIso(), event: signalType, taskId: envelope.task_id, stepId: envelope.step_id, from: 'running', to: latestStep.state });
-      emitWebhookEvent(latestBoard, signalType, { taskId: envelope.task_id, stepId: envelope.step_id, state: latestStep.state });
+      helpers.appendLog({
+        ts: helpers.nowIso(), event: signalType,
+        taskId: envelope.task_id, stepId: envelope.step_id,
+        from: 'running', to: latestStep.state,
+        runtime: runtimeHint || null,
+        model: plan.modelHint || null,
+        tokens_used: agentOutput.tokens_used || 0,
+        duration_ms: agentOutput.duration_ms || 0,
+        step_type: latestStep.type || null,
+        error_kind: agentOutput.failure?.failure_mode || null,
+      });
+      emitWebhookEvent(latestBoard, signalType, {
+        taskId: envelope.task_id, stepId: envelope.step_id, state: latestStep.state,
+        runtime: runtimeHint || null,
+        model: plan.modelHint || null,
+        step_type: latestStep.type || null,
+        usage: {
+          token_in: usage?.inputTokens || 0,
+          token_out: usage?.outputTokens || 0,
+          cost_usd: usage?.totalCost || 0,
+          latency_ms: durationMs || 0,
+        },
+        error_code: agentOutput.failure?.failure_mode || null,
+      });
 
       // 8. Trigger kernel for terminal states (via setImmediate to avoid deep recursion)
       const newSignal = {


### PR DESCRIPTION
## Summary

- Enrich task-log.jsonl step events (`step_completed`, `step_failed`, `step_dead`) with `runtime`, `model`, `tokens_used`, `duration_ms`, `step_type`, `error_kind` fields
- Enrich webhook events with `usage` block matching Event Envelope v1 contract (`token_in`, `token_out`, `cost_usd`, `latency_ms`)
- Add `GET /api/metrics/agents` endpoint that aggregates per-runtime/model success rates, token usage, and duration from task-log.jsonl
- Add smoke test for the new endpoint

Closes #345

## Test plan

- [x] `node --check` passes on all modified files
- [x] Smoke test verifies `GET /api/metrics/agents` returns 200 with expected schema
- [ ] Manual: after running tasks with different runtimes, verify aggregation returns correct per-agent breakdown
- [ ] Verify enriched log entries appear in `task-log.jsonl` after step completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)