### PR TITLE
feat(pipeline): integrate step contract validation into execution path (GH-346)

### DIFF
--- a/server/context-compiler.js
+++ b/server/context-compiler.js
@@ -51,6 +51,18 @@ function buildEnvelope(decision, runState, deps) {
     previousOutputRef = prevStep.output_ref || null;
   }
 
+  // Validate previous step output against next step's input expectations (warn-only)
+  if (previousOutput && targetIdx > 0) {
+    const prevStepType = steps[targetIdx - 1].type;
+    const contractResult = stepSchema.validateStepContract(prevStepType, previousOutput, stepType);
+    if (contractResult.warnings?.length > 0) {
+      console.log(`[context-compiler] input warnings for ${targetStepId}: ${contractResult.warnings.join(', ')}`);
+    }
+    if (!contractResult.valid && contractResult.errors?.length > 0) {
+      console.log(`[context-compiler] input contract errors for ${targetStepId} (warn-only): ${contractResult.errors.join(', ')}`);
+    }
+  }
+
   // Compute idempotency key from inputs
   const inputContent = {
     task_id: task.id,

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -592,6 +592,25 @@ function createStepWorker(deps) {
           summary = `Contract violation: ${contractResult.reason}`;
         }
       }
+
+      // 5d. Step output schema validation — verify required output fields
+      if (status === 'succeeded') {
+        const outputValidation = stepSchema.validateStepOutputSchema(envelope.step_type, {
+          status, summary, payload: stepResult,
+        });
+        if (outputValidation.warnings?.length > 0) {
+          console.log(`[step-worker] output warnings for ${envelope.step_id}: ${outputValidation.warnings.join(', ')}`);
+        }
+        if (!outputValidation.valid && outputValidation.errors?.length > 0) {
+          status = 'failed';
+          failure = {
+            failure_signature: `Output contract violation: ${outputValidation.errors.join('; ')}`,
+            failure_mode: 'CONTRACT_VIOLATION',
+            retryable: true,
+          };
+          summary = `Output contract violation: ${outputValidation.errors.join('; ')}`;
+        }
+      }
     }
 
     // Preserve full STEP_RESULT payload (proposal, plan, etc.) for downstream modules.


### PR DESCRIPTION
## Summary

- Wire step I/O schemas (defined in #378/`step-schema.js`) into the actual pipeline execution path
- **context-compiler.js**: validate previous step output against next step's input expectations before dispatch (warn-only, never blocks)
- **step-worker.js**: validate step output against its output schema after completion; missing required fields trigger `CONTRACT_VIOLATION` (retryable)

## Details

Commit `630e6b3` (#378) added schema definitions and validation functions to `step-schema.js` but did not integrate them into the pipeline. This PR completes the feature by calling those functions at the two critical points:

1. **Pre-dispatch (context-compiler)**: When building the envelope for the next step, validate that the previous step's output meets the next step's input expectations. Logs warnings but does not block dispatch (the previous step already succeeded).

2. **Post-completion (step-worker)**: After a step reports success, validate its output against the schema. If required fields are missing (e.g., no `summary`), the step fails with `CONTRACT_VIOLATION` and gets retried with linear backoff.

## Test plan

- [x] `node --check server/context-compiler.js` — syntax OK
- [x] `node --check server/step-worker.js` — syntax OK
- [x] `node server/test-step-schema.js` — 80/80 tests pass
- [x] Manual validation of `validateStepOutputSchema` and `validateStepContract` with sample data
- [x] `npm test` — pre-existing failure unrelated to this change (retro loop)

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)