### PR TITLE
feat(pipeline): template repository (#347)

### DIFF
--- a/server/management.js
+++ b/server/management.js
@@ -1186,6 +1186,42 @@ const DEFAULT_STEP_PIPELINE = [
   { type: 'review', revision_target: 'implement' },
 ];
 
+// 預建 pipeline 範本，使用者可透過 resolvePipeline 直接引用名稱
+const BUILT_IN_TEMPLATES = {
+  'default': [
+    { type: 'plan' },
+    { type: 'implement' },
+    { type: 'review', revision_target: 'implement' },
+  ],
+  'security-review': [
+    { type: 'plan', instruction: 'Focus on security implications and threat modeling' },
+    { type: 'implement' },
+    { type: 'review', instruction: 'Security-focused review: check for vulnerabilities, injection, auth bypass', revision_target: 'implement' },
+    { type: 'review', instruction: 'Final security audit before merge', revision_target: 'implement' },
+  ],
+  'docs-only': [
+    { type: 'implement', instruction: 'Documentation changes only — no code modifications' },
+    { type: 'review', revision_target: 'implement' },
+  ],
+  'test-heavy': [
+    { type: 'plan', instruction: 'Plan test strategy and identify edge cases' },
+    { type: 'implement', instruction: 'Write tests first, then implement to pass them' },
+    { type: 'review', instruction: 'Verify test coverage and edge cases', revision_target: 'implement' },
+    { type: 'implement', instruction: 'Fix any issues found in review', revision_target: 'implement' },
+    { type: 'review', revision_target: 'implement' },
+  ],
+  'quick-fix': [
+    { type: 'implement' },
+    { type: 'review', revision_target: 'implement' },
+  ],
+  'research': [
+    { type: 'plan', instruction: 'Research and analyze the problem space thoroughly' },
+    { type: 'plan', instruction: 'Propose solution options with trade-offs' },
+    { type: 'implement' },
+    { type: 'review', revision_target: 'implement' },
+  ],
+};
+
 function normalizePipelineEntry(entry) {
   if (typeof entry === 'string') {
     const type = entry.trim();
@@ -1210,8 +1246,9 @@ function normalizePipelineEntry(entry) {
 function resolvePipeline(pipelineValue, board) {
   if (Array.isArray(pipelineValue)) return pipelineValue;
   if (typeof pipelineValue === 'string') {
-    const templates = board?.pipelineTemplates || {};
-    const resolved = templates[pipelineValue];
+    // 先查 board 自訂範本，再查內建範本
+    const userTemplates = board?.pipelineTemplates || {};
+    const resolved = userTemplates[pipelineValue] || BUILT_IN_TEMPLATES[pipelineValue];
     if (Array.isArray(resolved)) return resolved;
     console.warn(`[pipeline] template "${pipelineValue}" not found, using default`);
     return null;
@@ -1335,6 +1372,7 @@ module.exports = {
   normalizePipelineEntry,
   generateStepsForTask,
   DEFAULT_STEP_PIPELINE,
+  BUILT_IN_TEMPLATES,
   trimSignals,
   budgetPctRemaining,
   resolveCostRoutingModel,

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -1940,12 +1940,19 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
 
   // --- Pipeline Templates ---
 
+  // GET /api/pipeline-templates/built-in — 列出所有內建範本
+  if (req.method === 'GET' && req.url === '/api/pipeline-templates/built-in') {
+    json(res, 200, mgmt.BUILT_IN_TEMPLATES);
+    return;
+  }
+
   const templatesMatch = req.url.match(/^\/api\/pipeline-templates(?:\/([^/?]+))?$/);
 
-  // GET /api/pipeline-templates — list all templates
+  // GET /api/pipeline-templates — list all templates (user + built-in merged)
   if (req.method === 'GET' && templatesMatch && !templatesMatch[1]) {
     const board = helpers.readBoard();
-    json(res, 200, board.pipelineTemplates || {});
+    const merged = Object.assign({}, mgmt.BUILT_IN_TEMPLATES, board.pipelineTemplates || {});
+    json(res, 200, merged);
     return;
   }
 

--- a/server/test-step-schema.js
+++ b/server/test-step-schema.js
@@ -430,6 +430,51 @@ test('resolvePipeline returns array for valid template name', () => {
   assert.deepStrictEqual(result, [{ type: 'a' }]);
 });
 
+// --- Built-in Pipeline Templates ---
+
+test('BUILT_IN_TEMPLATES contains expected presets', () => {
+  const templates = mgmt.BUILT_IN_TEMPLATES;
+  assert.ok(templates['default'], 'should have default template');
+  assert.ok(templates['security-review'], 'should have security-review template');
+  assert.ok(templates['docs-only'], 'should have docs-only template');
+  assert.ok(templates['test-heavy'], 'should have test-heavy template');
+  assert.ok(templates['quick-fix'], 'should have quick-fix template');
+  assert.ok(templates['research'], 'should have research template');
+  // 每個範本都是非空陣列
+  for (const [name, pipeline] of Object.entries(templates)) {
+    assert.ok(Array.isArray(pipeline) && pipeline.length > 0, `${name} should be non-empty array`);
+  }
+});
+
+test('resolvePipeline resolves built-in template when board has none', () => {
+  const board = { pipelineTemplates: {} };
+  const result = mgmt.resolvePipeline('quick-fix', board);
+  assert.ok(Array.isArray(result), 'should resolve built-in template');
+  assert.strictEqual(result.length, 2);
+  assert.strictEqual(result[0].type, 'implement');
+  assert.strictEqual(result[1].type, 'review');
+});
+
+test('resolvePipeline user template overrides built-in of same name', () => {
+  const board = { pipelineTemplates: { 'quick-fix': [{ type: 'custom-step' }] } };
+  const result = mgmt.resolvePipeline('quick-fix', board);
+  assert.deepStrictEqual(result, [{ type: 'custom-step' }]);
+});
+
+test('resolvePipeline built-in works with null board', () => {
+  const result = mgmt.resolvePipeline('docs-only', null);
+  assert.ok(Array.isArray(result), 'should resolve built-in even with null board');
+  assert.strictEqual(result[0].type, 'implement');
+});
+
+test('generateStepsForTask uses built-in template by name', () => {
+  const board = { pipelineTemplates: {} };
+  const task = { id: 'T-BUILTIN', pipeline: 'quick-fix' };
+  const steps = mgmt.generateStepsForTask(task, 'run-bi', null, board);
+  assert.strictEqual(steps.length, 2);
+  assert.deepStrictEqual(steps.map(s => s.type), ['implement', 'review']);
+});
+
 test('buildDispatchPlan includes steps field', () => {
   // Minimal board and task for buildDispatchPlan
   const board = {


### PR DESCRIPTION
## Summary
- Add 6 built-in pipeline templates: `default`, `security-review`, `docs-only`, `test-heavy`, `quick-fix`, `research`
- `resolvePipeline()` now falls back to built-in templates when a name is not found in `board.pipelineTemplates`
- User-defined templates override built-in templates of the same name
- `GET /api/pipeline-templates` returns merged view (built-in + user)
- `GET /api/pipeline-templates/built-in` returns only built-in templates

## Test plan
- [x] All 85 step-schema tests pass (5 new tests added)
- [x] Built-in templates resolve by name
- [x] User templates override built-in of same name
- [x] Null board still resolves built-in templates
- [x] `generateStepsForTask` works with built-in template names
- [x] Integration tests pass (`npm test`)
- [x] Syntax checks pass

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)