### PR TITLE
feat(api): execution registry (#357)

### DIFF
--- a/server/routes/executions.js
+++ b/server/routes/executions.js
@@ -1,0 +1,35 @@
+/**
+ * routes/executions.js — Execution Registry API
+ *
+ * GET /api/executions — 列出執行中的 agent（stepId、task_id、runtime、elapsed）
+ *
+ * 從 step-worker 的 activeExecutions Map 讀取即時執行狀態，
+ * 並從 board 補充 step type 和 progress 資訊。
+ */
+const bb = require('../blackboard-server');
+const { json } = bb;
+
+module.exports = function executionsRoutes(req, res, helpers, deps) {
+  if (req.method !== 'GET' || req.url.split('?')[0] !== '/api/executions') return false;
+
+  const executions = deps.stepWorker.getActiveExecutions();
+  const board = helpers.readBoard();
+  const tasks = board.taskPlan?.tasks || [];
+
+  // 補充 board 上的 step 資訊（type、progress）
+  const enriched = executions.map(exec => {
+    const task = tasks.find(t => t.id === exec.task_id);
+    const step = task?.steps?.find(s => s.step_id === exec.stepId);
+    return {
+      step_id: exec.stepId,
+      task_id: exec.task_id,
+      runtime: exec.runtime,
+      step_type: step?.type || null,
+      started_at: new Date(exec.startedAt).toISOString(),
+      elapsed_ms: exec.elapsed_ms,
+      progress: step?.progress || null,
+    };
+  });
+
+  return json(res, 200, { executions: enriched });
+};

--- a/server/server.js
+++ b/server/server.js
@@ -156,6 +156,7 @@ const versionRoutes = require('./routes/version');
 const artifactsRoutes = require('./routes/artifacts');
 const logsRoutes = require('./routes/logs');
 const eddaRoutes = require('./routes/edda');
+const executionsRoutes = require('./routes/executions');
 
 // --- Route chain ---
 const routes = [
@@ -177,6 +178,7 @@ const routes = [
   artifactsRoutes,
   logsRoutes,
   eddaRoutes,
+  executionsRoutes,
 ];
 
 const { json } = bb;

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -293,7 +293,12 @@ function createStepWorker(deps) {
 
       let result;
       const ac = new AbortController();
-      activeExecutions.set(envelope.step_id, { abort: () => ac.abort(), startedAt: Date.now() });
+      activeExecutions.set(envelope.step_id, {
+        abort: () => ac.abort(),
+        startedAt: Date.now(),
+        task_id: envelope.task_id,
+        runtime: runtimeHint || 'unknown',
+      });
       plan.signal = ac.signal;
       try {
         result = await rt.dispatch(plan);
@@ -698,7 +703,14 @@ function createStepWorker(deps) {
   }
 
   function getActiveExecutions() {
-    return Array.from(activeExecutions.entries()).map(([stepId, { startedAt }]) => ({ stepId, startedAt }));
+    const now = Date.now();
+    return Array.from(activeExecutions.entries()).map(([stepId, info]) => ({
+      stepId,
+      task_id: info.task_id,
+      runtime: info.runtime,
+      startedAt: info.startedAt,
+      elapsed_ms: now - info.startedAt,
+    }));
   }
 
   return { executeStep, killStep, getActiveExecutions };


### PR DESCRIPTION
## Summary
- Add `GET /api/executions` endpoint to list currently running agents
- Enrich step-worker `activeExecutions` Map with `task_id` and `runtime` metadata
- Cross-reference board data to include `step_type` and `progress` in response

## Response Format
```json
{
  "executions": [
    {
      "step_id": "...",
      "task_id": "GH-123",
      "runtime": "opencode",
      "step_type": "implement",
      "started_at": "2026-03-12T...",
      "elapsed_ms": 45000,
      "progress": { "tool_calls": 5, "last_tool": "edit", "last_activity": "..." }
    }
  ]
}
```

## Test plan
- [x] `node --check server/server.js` passes
- [x] `node --check server/management.js` passes
- [x] `npm test` passes (no regressions)
- [ ] Manual: start a task dispatch, hit `GET /api/executions`, verify running agent appears
- [ ] Manual: after task completes, verify execution is removed from list

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)