### PR TITLE
feat(edda): add Edda integration API for dynamic controls adjustment

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -28,6 +28,9 @@ Complete API documentation with curl examples for all major endpoints.
 - [Controls](#controls)
   - [GET /api/controls](#get-apicontrols)
   - [POST /api/controls](#post-apicontrols)
+- [Edda Integration](#edda-integration)
+  - [POST /api/edda/propose-controls](#post-apieddapropose-controls)
+  - [GET /api/edda/status](#get-apieddastatus)
 - [Evolution Layer](#evolution-layer)
   - [POST /api/retro](#post-apiretro)
 - [Vault (Secrets)](#vault-secrets)
@@ -636,6 +639,90 @@ curl -X POST http://localhost:3461/api/controls \
 | `use_step_pipeline` | boolean | true | Enable step pipeline |
 | `use_worktrees` | boolean | true | Create git worktrees |
 | `auto_merge_on_approve` | boolean | false | Auto-merge approved PRs |
+
+---
+
+## Edda Integration
+
+Edda is the governance agent that can propose adjustments to Karvi's automation controls.
+
+### POST /api/edda/propose-controls
+
+Edda proposes a controls patch. Proposals are stored as insights and can be auto-applied (low risk) or require manual approval (medium/high risk).
+
+```bash
+curl -X POST http://localhost:3461/api/edda/propose-controls \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "patch": { "quality_threshold": 75 },
+    "reasoning": "Success rate improved, increase threshold",
+    "by": "edda"
+  }'
+```
+
+**Request Body Fields**:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `patch` | object | Yes | Controls to update (key-value pairs) |
+| `reasoning` | string | No | Explanation for the proposal |
+| `by` | string | No | Source identifier (default: "edda") |
+| `risk` | string | No | Override risk level: "low", "medium", "high" |
+| `data` | object | No | Additional metadata |
+
+**Risk Classification** (automatic if not overridden):
+
+- **High risk**: Disabling `auto_dispatch`, `auto_review`, or other critical controls; large threshold changes (>50%)
+- **Medium risk**: Moderate threshold changes (20-50%); changes to `usage_limits` or `cost_routing`
+- **Low risk**: Small adjustments (<20%); adding `model_map` entries
+
+**Response (201)**:
+
+```json
+{
+  "ok": true,
+  "insight": {
+    "id": "ins-abc123",
+    "ts": "2026-03-12T12:00:00.000Z",
+    "by": "edda",
+    "about": "controls_adjustment",
+    "judgement": "Adjust controls: quality_threshold=75",
+    "reasoning": "Success rate improved, increase threshold",
+    "suggestedAction": {
+      "type": "controls_patch",
+      "payload": { "quality_threshold": 75 }
+    },
+    "risk": "low",
+    "status": "applied"
+  },
+  "autoApplied": true
+}
+```
+
+---
+
+### GET /api/edda/status
+
+Get current controls snapshot and pending proposal count.
+
+```bash
+curl http://localhost:3461/api/edda/status
+```
+
+**Response (200)**:
+
+```json
+{
+  "controls": {
+    "auto_dispatch": true,
+    "auto_review": true,
+    "quality_threshold": 75,
+    "max_concurrent_tasks": 2
+  },
+  "pendingProposals": 2,
+  "autoApplyEnabled": true
+}
+```
 
 ---
 

--- a/server/routes/edda.js
+++ b/server/routes/edda.js
@@ -1,0 +1,152 @@
+/**
+ * routes/edda.js — Edda Integration API
+ *
+ * POST /api/edda/propose-controls — Edda proposes a controls patch
+ *
+ * This endpoint allows Edda (the governance agent) to propose adjustments to
+ * Karvi's automation controls. Proposals are stored as insights and can be
+ * auto-applied (low risk) or require manual approval (medium/high risk).
+ */
+const bb = require('../blackboard-server');
+const { json } = bb;
+
+const HIGH_RISK_KEYS = ['auto_dispatch', 'auto_review', 'auto_redispatch', 'auto_apply_insights'];
+const THRESHOLD_KEYS = ['quality_threshold', 'review_timeout_sec', 'max_review_attempts', 'max_concurrent_tasks'];
+
+function classifyRisk(patch, currentControls) {
+  for (const key of HIGH_RISK_KEYS) {
+    if (key in patch) return 'high';
+  }
+  for (const key of THRESHOLD_KEYS) {
+    if (key in patch) {
+      const current = currentControls[key];
+      const proposed = patch[key];
+      if (typeof current === 'number' && typeof proposed === 'number' && current !== 0) {
+        const changeRatio = Math.abs(proposed - current) / Math.abs(current);
+        if (changeRatio > 0.5) return 'high';
+        if (changeRatio > 0.2) return 'medium';
+      }
+    }
+  }
+  if ('usage_limits' in patch || 'cost_routing' in patch) return 'medium';
+  return 'low';
+}
+
+function validatePatch(patch, mgmt) {
+  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+    return { valid: false, error: 'patch must be a non-null object' };
+  }
+  const allowed = Object.keys(mgmt.DEFAULT_CONTROLS);
+  const unknown = Object.keys(patch).filter(k => !allowed.includes(k));
+  if (unknown.length > 0) {
+    return { valid: false, error: `unknown control keys: ${unknown.join(', ')}` };
+  }
+  if (patch.quality_threshold !== undefined) {
+    if (typeof patch.quality_threshold !== 'number' || patch.quality_threshold < 0 || patch.quality_threshold > 100) {
+      return { valid: false, error: 'quality_threshold must be 0-100' };
+    }
+  }
+  if (patch.auto_dispatch !== undefined && typeof patch.auto_dispatch !== 'boolean') {
+    return { valid: false, error: 'auto_dispatch must be boolean' };
+  }
+  if (patch.auto_review !== undefined && typeof patch.auto_review !== 'boolean') {
+    return { valid: false, error: 'auto_review must be boolean' };
+  }
+  return { valid: true };
+}
+
+module.exports = function eddaRoutes(req, res, helpers, deps) {
+  const { mgmt } = deps;
+
+  if (req.method === 'POST' && req.url === '/api/edda/propose-controls') {
+    let body = '';
+    req.on('data', c => (body += c));
+    req.on('end', () => {
+      try {
+        const payload = JSON.parse(body || '{}');
+        const patch = payload.patch;
+        const reasoning = String(payload.reasoning || '').trim();
+        const by = String(payload.by || 'edda').trim();
+        const forceRisk = payload.risk;
+
+        const validation = validatePatch(patch, mgmt);
+        if (!validation.valid) {
+          return json(res, 400, { error: validation.error });
+        }
+
+        const board = helpers.readBoard();
+        mgmt.ensureEvolutionFields(board);
+        const currentControls = mgmt.getControls(board);
+        const risk = forceRisk || classifyRisk(patch, currentControls);
+
+        if (!['low', 'medium', 'high'].includes(risk)) {
+          return json(res, 400, { error: 'risk must be low, medium, or high' });
+        }
+
+        const judgement = Object.entries(patch)
+          .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+          .join(', ');
+
+        const insight = {
+          id: helpers.uid('ins'),
+          ts: helpers.nowIso(),
+          by,
+          about: 'controls_adjustment',
+          judgement: `Adjust controls: ${judgement}`,
+          reasoning: reasoning || null,
+          suggestedAction: {
+            type: 'controls_patch',
+            payload: patch,
+          },
+          risk,
+          status: 'pending',
+          snapshot: null,
+          appliedAt: null,
+          verifyAfter: payload.verifyAfter || 3,
+        };
+        if (payload.data && typeof payload.data === 'object') {
+          insight.data = payload.data;
+        }
+
+        board.insights.push(insight);
+        mgmt.autoApplyInsights(board);
+        helpers.writeBoard(board);
+
+        json(res, 201, {
+          ok: true,
+          insight,
+          autoApplied: insight.status === 'applied',
+        });
+      } catch (error) {
+        json(res, 400, { error: error.message });
+      }
+    });
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/api/edda/status') {
+    try {
+      const board = helpers.readBoard();
+      mgmt.ensureEvolutionFields(board);
+      const controls = mgmt.getControls(board);
+      const pendingControlsPatches = board.insights.filter(
+        i => i.status === 'pending' && i.suggestedAction?.type === 'controls_patch'
+      );
+      json(res, 200, {
+        controls: {
+          auto_dispatch: controls.auto_dispatch,
+          auto_review: controls.auto_review,
+          quality_threshold: controls.quality_threshold,
+          max_concurrent_tasks: controls.max_concurrent_tasks,
+        },
+        pendingProposals: pendingControlsPatches.length,
+        autoApplyEnabled: controls.auto_apply_insights,
+      });
+    } catch (error) {
+      json(res, 500, { error: error.message });
+    }
+    return;
+  }
+
+  return false;
+};

--- a/server/server.js
+++ b/server/server.js
@@ -155,6 +155,7 @@ const discoveryRoutes = require('./routes/discovery');
 const versionRoutes = require('./routes/version');
 const artifactsRoutes = require('./routes/artifacts');
 const logsRoutes = require('./routes/logs');
+const eddaRoutes = require('./routes/edda');
 
 // --- Route chain ---
 const routes = [
@@ -175,6 +176,7 @@ const routes = [
   discoveryRoutes,
   artifactsRoutes,
   logsRoutes,
+  eddaRoutes,
 ];
 
 const { json } = bb;

--- a/server/test-edda-api.js
+++ b/server/test-edda-api.js
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/**
+ * test-edda-api.js — 測試 Edda integration API
+ *
+ * Tests:
+ * 1. POST /api/edda/propose-controls — basic proposal
+ * 2. Risk classification (low/medium/high)
+ * 3. Auto-apply for low-risk patches
+ * 4. GET /api/edda/status
+ */
+
+const http = require('http');
+const fs = require('fs');
+const os = require('os');
+const { spawn } = require('child_process');
+const path = require('path');
+
+const PORT = Number(process.env.TEST_PORT) || 13461;
+const API_TOKEN = process.env.KARVI_API_TOKEN || null;
+const GLOBAL_TIMEOUT_MS = 60_000;
+
+setTimeout(() => {
+  console.error(`\n❌ Global timeout (${GLOBAL_TIMEOUT_MS / 1000}s) — forcing exit`);
+  if (serverProc) { serverProc.kill(); serverProc = null; }
+  process.exit(2);
+}, GLOBAL_TIMEOUT_MS).unref();
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'karvi-edda-test-'));
+let serverProc = null;
+
+function post(urlPath, body) {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const headers = { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data) };
+    if (API_TOKEN) headers['Authorization'] = `Bearer ${API_TOKEN}`;
+    const req = http.request({
+      hostname: 'localhost', port: PORT, path: urlPath, method: 'POST', headers
+    }, res => {
+      let d = '';
+      res.on('data', c => d += c);
+      res.on('end', () => {
+        try { resolve({ status: res.statusCode, body: JSON.parse(d) }); }
+        catch { resolve({ status: res.statusCode, body: d }); }
+      });
+    });
+    req.on('error', reject);
+    req.end(data);
+  });
+}
+
+function get(urlPath) {
+  return new Promise((resolve, reject) => {
+    const headers = {};
+    if (API_TOKEN) headers['Authorization'] = `Bearer ${API_TOKEN}`;
+    http.get({ hostname: 'localhost', port: PORT, path: urlPath, headers }, res => {
+      let d = '';
+      res.on('data', c => d += c);
+      res.on('end', () => {
+        try { resolve({ status: res.statusCode, body: JSON.parse(d) }); }
+        catch { resolve({ status: res.statusCode, body: d }); }
+      });
+    }).on('error', reject);
+  });
+}
+
+function ok(label) { console.log(`  ✅ ${label}`); }
+function fail(label, reason) { console.log(`  ❌ ${label}: ${reason}`); process.exitCode = 1; }
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(process.execPath, [path.join(__dirname, 'server.js')], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, PORT: String(PORT), DATA_DIR: TEST_DATA_DIR },
+    });
+
+    let started = false;
+    proc.stdout.on('data', (data) => {
+      if (!started && data.toString().includes('running at')) {
+        started = true;
+        resolve(proc);
+      }
+    });
+    proc.stderr.on('data', (data) => {
+      if (!started) process.stderr.write('[server] ' + data.toString());
+    });
+    const timer = setTimeout(() => {
+      if (!started) { proc.kill(); reject(new Error('Server failed to start within 10s')); }
+    }, 10000);
+    proc.on('error', (err) => { clearTimeout(timer); reject(err); });
+    proc.on('exit', (code) => {
+      if (!started) { clearTimeout(timer); reject(new Error(`Server exited with code ${code}`)); }
+    });
+  });
+}
+
+function stopServer() {
+  if (serverProc) { serverProc.kill(); serverProc = null; }
+}
+
+function cleanState() {
+  for (const f of ['board.json', 'board.json.bak', 'task-log.jsonl']) {
+    try { fs.unlinkSync(path.join(TEST_DATA_DIR, f)); }
+    catch (err) { }
+  }
+}
+
+async function main() {
+  cleanState();
+  console.log('Starting server...');
+  serverProc = await startServer();
+  console.log(`Server started on port ${PORT}`);
+  process.on('exit', stopServer);
+
+  console.log('\n=== Edda API Tests ===\n');
+
+  // Test 1: Low-risk patch (small threshold adjustment)
+  console.log('Test 1: Propose low-risk patch (quality_threshold 70→75)...');
+  const r1 = await post('/api/edda/propose-controls', {
+    patch: { quality_threshold: 75 },
+    reasoning: 'Success rate improved, increase threshold',
+    by: 'edda-test',
+  });
+  if (r1.status === 201 && r1.body.ok && r1.body.insight.risk === 'low') {
+    ok('Low-risk patch proposed');
+    if (r1.body.autoApplied) ok('Auto-applied (auto_apply_insights enabled)');
+    else fail('Auto-apply', 'expected auto-apply for low risk');
+  } else {
+    fail('Low-risk patch', JSON.stringify(r1.body));
+  }
+
+  // Test 2: High-risk patch (disable auto_dispatch)
+  console.log('\nTest 2: Propose high-risk patch (auto_dispatch=false)...');
+  const r2 = await post('/api/edda/propose-controls', {
+    patch: { auto_dispatch: false },
+    reasoning: 'Critical failure detected, pause dispatch',
+    by: 'edda-test',
+  });
+  if (r2.status === 201 && r2.body.ok && r2.body.insight.risk === 'high') {
+    ok('High-risk patch proposed');
+    if (!r2.body.autoApplied) ok('Not auto-applied (requires manual approval)');
+    else fail('High-risk auto-apply', 'should NOT auto-apply high risk');
+  } else {
+    fail('High-risk patch', JSON.stringify(r2.body));
+  }
+
+  // Test 3: Medium-risk patch (medium threshold change ~36%)
+  console.log('\nTest 3: Propose medium-risk patch (quality_threshold 70→45)...');
+  const r3 = await post('/api/edda/propose-controls', {
+    patch: { quality_threshold: 45 },
+    reasoning: 'Tasks struggling, lower threshold moderately',
+    by: 'edda-test',
+  });
+  if (r3.status === 201 && r3.body.ok && r3.body.insight.risk === 'medium') {
+    ok('Medium-risk patch proposed');
+    if (!r3.body.autoApplied) ok('Not auto-applied (requires manual approval)');
+    else fail('Medium-risk auto-apply', 'should NOT auto-apply medium risk');
+  } else {
+    fail('Medium-risk patch', JSON.stringify(r3.body));
+  }
+
+  // Test 4: Invalid patch (unknown key)
+  console.log('\nTest 4: Reject invalid patch (unknown key)...');
+  const r4 = await post('/api/edda/propose-controls', {
+    patch: { unknown_key: 123 },
+    by: 'edda-test',
+  });
+  if (r4.status === 400 && r4.body.error.includes('unknown control keys')) {
+    ok('Invalid patch rejected');
+  } else {
+    fail('Invalid patch rejection', JSON.stringify(r4.body));
+  }
+
+  // Test 5: Force risk level
+  console.log('\nTest 5: Force risk level override...');
+  const r5 = await post('/api/edda/propose-controls', {
+    patch: { model_map: { opencode: { default: 'test/model' } } },
+    reasoning: 'Model switch',
+    by: 'edda-test',
+    risk: 'high',
+  });
+  if (r5.status === 201 && r5.body.insight.risk === 'high') {
+    ok('Risk level forced to high');
+  } else {
+    fail('Force risk level', JSON.stringify(r5.body));
+  }
+
+  // Test 6: GET /api/edda/status
+  console.log('\nTest 6: GET /api/edda/status...');
+  const r6 = await get('/api/edda/status');
+  if (r6.status === 200 && typeof r6.body.controls === 'object') {
+    ok('Status endpoint works');
+    console.log(`    pendingProposals: ${r6.body.pendingProposals}`);
+    console.log(`    autoApplyEnabled: ${r6.body.autoApplyEnabled}`);
+  } else {
+    fail('Status endpoint', JSON.stringify(r6.body));
+  }
+
+  // Test 7: Verify pending proposals count
+  console.log('\nTest 7: Verify pending proposals count...');
+  const r7 = await get('/api/edda/status');
+  // We have 2 pending proposals (high risk from test 2, medium risk from test 3)
+  if (r7.body.pendingProposals >= 2) {
+    ok(`At least 2 pending proposals (found ${r7.body.pendingProposals})`);
+  } else {
+    fail('Pending proposals count', `expected >= 2, got ${r7.body.pendingProposals}`);
+  }
+
+  console.log('\n=== Tests Complete ===\n');
+  stopServer();
+
+  try { fs.rmSync(TEST_DATA_DIR, { recursive: true }); } catch (e) { }
+
+  if (!process.exitCode) {
+    console.log('All tests passed!');
+  } else {
+    console.log('Some tests failed.');
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  stopServer();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implements GitHub issue #354: Dynamic automation adjustment via Edda integration.

### What's Added

1. **POST /api/edda/propose-controls** - Edda proposes controls patches
   - Automatic risk classification (low/medium/high)
   - Low-risk patches auto-applied via existing insight system
   - Medium/high-risk patches require manual approval
   - Validates patch against known control keys

2. **GET /api/edda/status** - Get current controls snapshot and pending proposal count

3. **Risk Classification Logic**:
   - **High risk**: Disabling `auto_dispatch`, `auto_review`, etc.; large threshold changes (>50%)
   - **Medium risk**: Moderate threshold changes (20-50%); changes to `usage_limits`/`cost_routing`
   - **Low risk**: Small adjustments (<20%); adding `model_map` entries

### Integration Flow

```
Edda analyzes metrics → POST /api/edda/propose-controls
  → Insight created with risk level
  → Low risk: auto-applied if auto_apply_insights=true
  → Medium/high risk: pending, requires manual approval via /api/insights/:id/apply
```

### Test Coverage

- `server/test-edda-api.js` - Tests all endpoints and risk classification

Closes #354