### PR TITLE
feat(api): per-user attribution on API calls (GH-353)

### DIFF
--- a/server/blackboard-server.js
+++ b/server/blackboard-server.js
@@ -84,6 +84,7 @@ function createContext(opts = {}) {
   const boardType = opts.boardType || null;
   const apiToken = opts.apiToken || process.env.KARVI_API_TOKEN || null;
   const roleTokens = opts.roleTokens || rbac.parseRoleTokens();
+  const userTokens = opts.userTokens || rbac.parseUserTokens();
   const corsOrigins = opts.corsOrigins || process.env.KARVI_CORS_ORIGINS || null;
 
   // Rate limiting config
@@ -131,6 +132,7 @@ function createContext(opts = {}) {
     boardType,
     apiToken,
     roleTokens,
+    userTokens,
     corsOrigins,
     sseClients: new Set(),
     taskSseClients: new Map(),  // taskId → Set<res>
@@ -151,20 +153,28 @@ function tokenMatch(expected, provided) {
 }
 
 /**
- * checkAuth — 驗證 request 的 token 並解析角色。
- * @returns {{ allowed: boolean, role: string|null }}
+ * checkAuth — 驗證 request 的 token 並解析角色和用戶歸屬。
+ * @returns {{ allowed: boolean, role: string|null, userId: string|null }}
  *   role = 'admin'|'operator'|'viewer'|null
+ *   userId = 用戶標識（來自 X-Karvi-User header 或 token 映射）
  *   null role with allowed=true → local dev mode (no auth configured)
  */
 function checkAuth(ctx, req) {
   const noAuth = !ctx.apiToken && !ctx.roleTokens?.active;
-  if (noAuth) return { allowed: true, role: null };
-  if (req.method === 'OPTIONS') return { allowed: true, role: null };
+  if (noAuth) {
+    // No auth configured — still try to get userId from header (gateway mode)
+    const headerUser = req.headers['x-karvi-user'];
+    return { allowed: true, role: null, userId: headerUser || null };
+  }
+  if (req.method === 'OPTIONS') return { allowed: true, role: null, userId: null };
 
   const url = new URL(req.url, 'http://localhost');
 
-  if (!url.pathname.startsWith('/api/')) return { allowed: true, role: null };
-  if (url.pathname.startsWith('/api/webhooks/')) return { allowed: true, role: null };
+  if (!url.pathname.startsWith('/api/')) {
+    const headerUser = req.headers['x-karvi-user'];
+    return { allowed: true, role: null, userId: headerUser || null };
+  }
+  if (url.pathname.startsWith('/api/webhooks/')) return { allowed: true, role: null, userId: null };
 
   // Extract token from query (SSE) or header (normal)
   let provided = '';
@@ -176,16 +186,26 @@ function checkAuth(ctx, req) {
     provided = match ? match[1] : '';
   }
 
+  // Extract userId from X-Karvi-User header (set by gateway) or from token mapping
+  const headerUser = req.headers['x-karvi-user'];
+  let userId = headerUser || null;
+
   // RBAC: try role-token map first
   if (ctx.roleTokens?.active) {
     const role = rbac.matchRole(ctx.roleTokens.tokenMap, provided);
-    if (role) return { allowed: true, role };
-    return { allowed: false, role: null };
+    if (role) {
+      // Try to get userId from token mapping if not from header
+      if (!userId && ctx.userTokens?.active) {
+        userId = rbac.matchUserId(ctx.userTokens.userTokenMap, provided);
+      }
+      return { allowed: true, role, userId };
+    }
+    return { allowed: false, role: null, userId: null };
   }
 
   // Legacy: single token = admin
   const ok = tokenMatch(ctx.apiToken, provided);
-  return { allowed: ok, role: ok ? 'admin' : null };
+  return { allowed: ok, role: ok ? 'admin' : null, userId: ok ? (headerUser || null) : null };
 }
 
 /**
@@ -495,12 +515,13 @@ function createServer(ctx, routeHandler) {
       });
     }
 
-    // Auth gate (returns { allowed, role })
+    // Auth gate (returns { allowed, role, userId })
     const authResult = checkAuth(ctx, req);
     if (!authResult.allowed) {
       return json(res, 401, { error: 'unauthorized' });
     }
     req.karviRole = authResult.role;
+    req.karviUser = authResult.userId;  // Per-user attribution
 
     // Built-in routes
     if (req.method === 'GET' && pathname === '/api/events') {

--- a/server/gateway-proxy.js
+++ b/server/gateway-proxy.js
@@ -31,6 +31,7 @@ const CONNECT_TIMEOUT_MS = 10000;
  * @param {object}               opts - Options
  * @param {string}  opts.injectToken  - Bearer token to inject for instance auth
  * @param {string}  opts.stripPrefix  - URL prefix to strip (e.g., '/u/alice')
+ * @param {string}  opts.injectUser   - User identity to inject (X-Karvi-User header)
  */
 function proxyRequest(req, res, port, opts = {}) {
   const targetPath = opts.stripPrefix
@@ -51,6 +52,11 @@ function proxyRequest(req, res, port, opts = {}) {
   // Inject instance Bearer token (gateway → instance auth)
   if (opts.injectToken) {
     headers['authorization'] = `Bearer ${opts.injectToken}`;
+  }
+
+  // Inject user identity for per-user attribution (gateway → instance)
+  if (opts.injectUser) {
+    headers['x-karvi-user'] = opts.injectUser;
   }
 
   // Forward client IP

--- a/server/gateway.js
+++ b/server/gateway.js
@@ -372,6 +372,7 @@ async function handleProxy(req, res, username) {
   proxy.proxyRequest(req, res, instance.port, {
     injectToken: instanceToken,
     stripPrefix,
+    injectUser: session.username,  // Per-user attribution
   });
 }
 

--- a/server/rbac.js
+++ b/server/rbac.js
@@ -1,18 +1,20 @@
 /**
- * rbac.js — Role-Based Access Control
+ * rbac.js — Role-Based Access Control with Per-User Attribution
  *
- * 從環境變數讀取 per-role token，提供角色解析和權限檢查。
+ * 從環境變數讀取 per-role token，提供角色解析、權限檢查和用戶歸屬。
  *
  * 環境變數：
  *   KARVI_API_TOKEN          — 既有的單一 token（視為 admin）
  *   KARVI_API_TOKEN_ADMIN    — admin role token
  *   KARVI_API_TOKEN_OPERATOR — operator role token
  *   KARVI_API_TOKEN_VIEWER   — viewer role token
+ *   KARVI_USER_TOKENS        — JSON map of userId → token (per-user attribution)
  *
  * 行為：
  *   - 沒有任何 token → local dev mode，不啟用 RBAC
  *   - 只有 KARVI_API_TOKEN → 該 token = admin（向後相容）
  *   - 有 KARVI_API_TOKEN_* → role-based auth
+ *   - 有 KARVI_USER_TOKENS → per-user attribution（配合 gateway 使用）
  */
 const crypto = require('crypto');
 
@@ -41,6 +43,33 @@ function parseRoleTokens() {
   }
 
   return { tokenMap: map, active: map.size > 0 };
+}
+
+/**
+ * 從環境變數建立 token→userId 映射表（per-user attribution）。
+ * KARVI_USER_TOKENS 格式：JSON object { "userId1": "token1", "userId2": "token2" }
+ * @returns {{ userTokenMap: Map<string, string>, active: boolean }}
+ */
+function parseUserTokens() {
+  const map = new Map();
+  const userTokensJson = process.env.KARVI_USER_TOKENS;
+
+  if (userTokensJson) {
+    try {
+      const userTokens = JSON.parse(userTokensJson);
+      if (userTokens && typeof userTokens === 'object') {
+        for (const [userId, token] of Object.entries(userTokens)) {
+          if (typeof token === 'string' && token.trim()) {
+            map.set(token.trim(), userId);
+          }
+        }
+      }
+    } catch (err) {
+      console.error('[rbac] Failed to parse KARVI_USER_TOKENS:', err.message);
+    }
+  }
+
+  return { userTokenMap: map, active: map.size > 0 };
 }
 
 /**
@@ -79,4 +108,41 @@ function hasRole(role, minRole) {
   return (ROLE_LEVEL[role] || 0) >= (ROLE_LEVEL[minRole] || 0);
 }
 
-module.exports = { ROLES, ROLE_LEVEL, parseRoleTokens, matchRole, hasRole };
+/**
+ * 從 token 解析 userId（per-user attribution）。
+ * @param {Map<string, string>} userTokenMap — token → userId 映射表
+ * @param {string} provided — 從 request 提取的 token
+ * @returns {string|null} userId or null
+ */
+function matchUserId(userTokenMap, provided) {
+  if (!provided || !userTokenMap) return null;
+  for (const [token, userId] of userTokenMap) {
+    if (safeCompare(token, provided)) return userId;
+  }
+  return null;
+}
+
+/**
+ * 解析 request 的完整歸屬資訊（role + userId）。
+ * @param {object} roleTokens — parseRoleTokens() 結果
+ * @param {object} userTokens — parseUserTokens() 結果
+ * @param {string} provided — 從 request 提取的 token
+ * @returns {{ role: string|null, userId: string|null }}
+ */
+function resolveAttribution(roleTokens, userTokens, provided) {
+  const role = roleTokens?.active ? matchRole(roleTokens.tokenMap, provided) : null;
+  const userId = userTokens?.active ? matchUserId(userTokens.userTokenMap, provided) : null;
+  return { role, userId };
+}
+
+module.exports = {
+  ROLES,
+  ROLE_LEVEL,
+  parseRoleTokens,
+  parseUserTokens,
+  matchRole,
+  matchUserId,
+  resolveAttribution,
+  hasRole,
+  safeCompare,
+};

--- a/server/routes/_shared.js
+++ b/server/routes/_shared.js
@@ -81,9 +81,14 @@ function normalizeText(input) {
   return String(input || '').replace(/\r\n/g, '\n').trim();
 }
 
+/**
+ * Get user ID from request (per-user attribution).
+ * Priority: req.karviUser (gateway/auth) > X-Karvi-User header > query param > default
+ */
 function getUserId(req) {
   const url = new URL(req.url, 'http://localhost');
-  return req.headers['x-karvi-user']
+  return req.karviUser
+    || req.headers['x-karvi-user']
     || url.searchParams.get('userId')
     || 'default';
 }
@@ -123,6 +128,47 @@ function requireRole(req, res, minRole) {
   return true;
 }
 
+/**
+ * Create a signal object with user attribution.
+ * @param {object} opts - Signal options
+ * @param {string} opts.type - Signal type (e.g., 'status_change', 'task_cancelled')
+ * @param {string} opts.content - Human-readable content
+ * @param {string[]} opts.refs - References (e.g., task IDs)
+ * @param {object} opts.data - Additional data
+ * @param {object} req - Express-like request object with karviUser/karviRole
+ * @param {object} helpers - Helper functions (uid, nowIso)
+ * @returns {object} Signal object ready to push to board.signals
+ */
+function createSignal(opts, req, helpers) {
+  const { type, content, refs = [], data = {} } = opts;
+  const actor = req?.karviUser || null;
+  const role = req?.karviRole || null;
+  
+  return {
+    id: helpers.uid('sig'),
+    ts: helpers.nowIso(),
+    by: actor || 'api',  // Use userId if available, else 'api'
+    type,
+    content,
+    refs,
+    data: {
+      ...data,
+      _attribution: actor ? { actor, role } : undefined,
+    },
+  };
+}
+
+/**
+ * Get attribution string for logging.
+ * @param {object} req - Request object
+ * @returns {string} Attribution string (e.g., "user:alice" or "role:admin" or "anonymous")
+ */
+function getAttribution(req) {
+  if (req?.karviUser) return `user:${req.karviUser}`;
+  if (req?.karviRole) return `role:${req.karviRole}`;
+  return 'anonymous';
+}
+
 module.exports = {
   conversationById,
   participantById,
@@ -135,4 +181,6 @@ module.exports = {
   getUserIdForTask,
   deepMerge,
   requireRole,
+  createSignal,
+  getAttribution,
 };

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -25,7 +25,7 @@ const fs = require('fs');
 const path = require('path');
 const bb = require('../blackboard-server');
 const { json } = bb;
-const { participantById, pushMessage, getUserIdForTask, requireRole } = require('./_shared');
+const { participantById, pushMessage, getUserIdForTask, requireRole, createSignal, getAttribution } = require('./_shared');
 const routeEngine = require('../route-engine');
 const worktreeHelper = require('../worktree');
 const { resolveRepoRoot, validateRepoRoot } = require('../repo-resolver');
@@ -802,18 +802,15 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
           setImmediate(() => tryAutoDispatch(task.id, deps, helpers));
         }
 
-        // Evolution Layer: emit status_change signal
+        // Evolution Layer: emit status_change signal with attribution
         if (payload.status) {
           mgmt.ensureEvolutionFields(board);
-          board.signals.push({
-            id: helpers.uid('sig'),
-            ts: helpers.nowIso(),
-            by: 'server.js',
+          board.signals.push(createSignal({
             type: 'status_change',
             content: `${task.id} ${oldStatus} → ${task.status}`,
             refs: [task.id],
             data: { taskId: task.id, from: oldStatus, to: task.status, assignee: task.assignee },
-          });
+          }, req, helpers));
           mgmt.trimSignals(board, helpers.signalArchivePath);
         }
 
@@ -1011,15 +1008,12 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         });
         
         mgmt.ensureEvolutionFields(board);
-        board.signals.push({
-          id: helpers.uid('sig'),
-          ts: helpers.nowIso(),
-          by: 'human',
+        board.signals.push(createSignal({
           type: 'task_reopened',
           content: `${taskId} reopened from ${oldStatus}`,
           refs: [taskId],
-          data: { taskId, from: oldStatus, runId, steps: newSteps.map(s => s.step_id) }
-        });
+          data: { taskId, from: oldStatus, runId, steps: newSteps.map(s => s.step_id) },
+        }, req, helpers));
         mgmt.trimSignals(board, helpers.signalArchivePath);
         
         helpers.writeBoard(board);
@@ -1091,15 +1085,12 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         if (allApproved) board.taskPlan.phase = 'done';
 
         mgmt.ensureEvolutionFields(board);
-        board.signals.push({
-          id: helpers.uid('sig'),
-          ts: helpers.nowIso(),
-          by: 'server.js',
+        board.signals.push(createSignal({
           type: 'status_change',
           content: `${task.id} ${oldStatus} → cancelled`,
           refs: [task.id],
           data: { taskId: task.id, from: oldStatus, to: 'cancelled', assignee: task.assignee },
-        });
+        }, req, helpers));
         mgmt.trimSignals(board, helpers.signalArchivePath);
 
         helpers.writeBoard(board);
@@ -1233,15 +1224,12 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
 
         // Evolution Layer: emit status_change signal
         mgmt.ensureEvolutionFields(board);
-        board.signals.push({
-          id: helpers.uid('sig'),
-          ts: helpers.nowIso(),
-          by: 'server.js',
+        board.signals.push(createSignal({
           type: 'status_change',
           content: `${task.id} ${oldStatus} → ${newStatus}`,
           refs: [task.id],
           data: { taskId: task.id, from: oldStatus, to: newStatus, assignee: task.assignee },
-        });
+        }, req, helpers));
         mgmt.trimSignals(board, helpers.signalArchivePath);
 
         helpers.writeBoard(board);

--- a/server/test-attribution.js
+++ b/server/test-attribution.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * test-attribution.js — Per-user attribution tests
+ *
+ * Tests for GH-353: Per-user attribution on API calls
+ *
+ * Usage: node server/test-attribution.js
+ */
+const assert = require('assert');
+
+// Store original env
+const originalEnv = { ...process.env };
+
+function resetEnv() {
+  process.env = { ...originalEnv };
+}
+
+function clearRequireCache() {
+  const paths = ['./rbac', './routes/_shared'];
+  for (const p of paths) {
+    try {
+      delete require.cache[require.resolve(p)];
+    } catch (e) { /* ignore */ }
+  }
+}
+
+function test(label, fn) {
+  try {
+    fn();
+    console.log(`  OK ${label}`);
+  } catch (err) {
+    console.log(`  FAIL ${label}: ${err.message}`);
+    process.exitCode = 1;
+  }
+}
+
+function main() {
+  console.log('=== Per-User Attribution Tests (GH-353) ===\n');
+
+  // Test 1: parseUserTokens()
+  console.log('1. parseUserTokens():');
+  resetEnv();
+  process.env.KARVI_USER_TOKENS = JSON.stringify({
+    'alice': 'token-alice-123',
+    'bob': 'token-bob-456'
+  });
+  clearRequireCache();
+  const rbac = require('./rbac');
+
+  test('parses user tokens from env', () => {
+    const result = rbac.parseUserTokens();
+    assert.strictEqual(result.active, true);
+    assert.strictEqual(result.userTokenMap.size, 2);
+    assert.strictEqual(result.userTokenMap.get('token-alice-123'), 'alice');
+    assert.strictEqual(result.userTokenMap.get('token-bob-456'), 'bob');
+  });
+
+  test('returns inactive when no KARVI_USER_TOKENS', () => {
+    delete process.env.KARVI_USER_TOKENS;
+    const result = rbac.parseUserTokens();
+    assert.strictEqual(result.active, false);
+    assert.strictEqual(result.userTokenMap.size, 0);
+  });
+
+  test('handles invalid JSON gracefully', () => {
+    process.env.KARVI_USER_TOKENS = 'not-valid-json';
+    const result = rbac.parseUserTokens();
+    assert.strictEqual(result.active, false);
+  });
+
+  // Test 2: matchUserId()
+  console.log('\n2. matchUserId():');
+  const userTokenMap = new Map([
+    ['token-alice-123', 'alice'],
+    ['token-bob-456', 'bob'],
+  ]);
+
+  test('returns userId for matching token', () => {
+    const userId = rbac.matchUserId(userTokenMap, 'token-alice-123');
+    assert.strictEqual(userId, 'alice');
+  });
+
+  test('returns null for non-matching token', () => {
+    const userId = rbac.matchUserId(userTokenMap, 'wrong-token');
+    assert.strictEqual(userId, null);
+  });
+
+  test('returns null for empty token', () => {
+    const userId = rbac.matchUserId(userTokenMap, '');
+    assert.strictEqual(userId, null);
+  });
+
+  // Test 3: resolveAttribution()
+  console.log('\n3. resolveAttribution():');
+  resetEnv();
+  process.env.KARVI_API_TOKEN_ADMIN = 'admin-token';
+  process.env.KARVI_USER_TOKENS = JSON.stringify({ 'alice': 'admin-token' });
+  clearRequireCache();
+  const rbac2 = require('./rbac');
+  const roleTokens = rbac2.parseRoleTokens();
+  const userTokens = rbac2.parseUserTokens();
+
+  test('returns role and userId for matching token', () => {
+    const result = rbac2.resolveAttribution(roleTokens, userTokens, 'admin-token');
+    assert.strictEqual(result.role, 'admin');
+    assert.strictEqual(result.userId, 'alice');
+  });
+
+  test('returns null userId when token not in userTokens', () => {
+    process.env.KARVI_USER_TOKENS = JSON.stringify({ 'bob': 'bob-token' });
+    clearRequireCache();
+    const rbac3 = require('./rbac');
+    const rt = rbac3.parseRoleTokens();
+    const ut = rbac3.parseUserTokens();
+    const result = rbac3.resolveAttribution(rt, ut, 'admin-token');
+    assert.strictEqual(result.role, 'admin');
+    assert.strictEqual(result.userId, null);
+  });
+
+  // Test 4: createSignal() with attribution
+  console.log('\n4. createSignal():');
+  resetEnv();
+  clearRequireCache();
+  const { createSignal, getAttribution } = require('./routes/_shared');
+  
+  const mockHelpers = {
+    uid: (prefix) => `${prefix}-test-123`,
+    nowIso: () => '2026-03-12T00:00:00.000Z',
+  };
+
+  test('includes userId in by field', () => {
+    const req = { karviUser: 'alice', karviRole: 'admin' };
+    const signal = createSignal({
+      type: 'status_change',
+      content: 'Task updated',
+      refs: ['T1'],
+      data: { taskId: 'T1' },
+    }, req, mockHelpers);
+    
+    assert.strictEqual(signal.by, 'alice');
+    assert.strictEqual(signal.type, 'status_change');
+    assert.ok(signal.data._attribution);
+    assert.strictEqual(signal.data._attribution.actor, 'alice');
+    assert.strictEqual(signal.data._attribution.role, 'admin');
+  });
+
+  test('uses api as default when no user', () => {
+    const signal = createSignal({
+      type: 'status_change',
+      content: 'Task updated',
+      refs: ['T1'],
+    }, null, mockHelpers);
+    
+    assert.strictEqual(signal.by, 'api');
+  });
+
+  test('uses role when no userId', () => {
+    const req = { karviRole: 'admin' };
+    const signal = createSignal({
+      type: 'status_change',
+      content: 'Task updated',
+      refs: ['T1'],
+    }, req, mockHelpers);
+    
+    assert.strictEqual(signal.by, 'api');
+    assert.ok(signal.data._attribution === undefined);
+  });
+
+  // Test 5: getAttribution()
+  console.log('\n5. getAttribution():');
+  
+  test('returns user:alice when karviUser set', () => {
+    const req = { karviUser: 'alice', karviRole: 'admin' };
+    assert.strictEqual(getAttribution(req), 'user:alice');
+  });
+
+  test('returns role:admin when only karviRole set', () => {
+    const req = { karviRole: 'admin' };
+    assert.strictEqual(getAttribution(req), 'role:admin');
+  });
+
+  test('returns anonymous when neither set', () => {
+    const req = {};
+    assert.strictEqual(getAttribution(req), 'anonymous');
+  });
+
+  test('returns anonymous for null req', () => {
+    assert.strictEqual(getAttribution(null), 'anonymous');
+  });
+
+  // Cleanup
+  resetEnv();
+  console.log('\n=== All tests passed ===\n');
+}
+
+main();


### PR DESCRIPTION
## Summary

Implements per-user attribution on API calls as requested in #353.

### Changes

1. **rbac.js** - Added per-user token mapping support:
   - New `KARVI_USER_TOKENS` env var (JSON: `{"userId": "token"}`)
   - `parseUserTokens()` function to parse user tokens
   - `matchUserId()` to resolve userId from token
   - `resolveAttribution()` to get both role and userId

2. **gateway-proxy.js** - Injects user identity to instances:
   - New `injectUser` option to add `X-Karvi-User` header

3. **gateway.js** - Passes user identity when proxying:
   - `handleProxy()` passes `session.username` as `injectUser`

4. **blackboard-server.js** - Extracts and stores user identity:
   - `createContext()` parses `userTokens`
   - `checkAuth()` returns `{ allowed, role, userId }`
   - Sets `req.karviUser` for downstream use

5. **routes/_shared.js** - Attribution helpers:
   - `createSignal()` creates signals with user attribution
   - `getAttribution()` returns attribution string for logging
   - Updated `getUserId()` to prefer `req.karviUser`

6. **routes/tasks.js** - Uses attribution in signals:
   - Status change signals include user attribution
   - Task cancellation signals include user attribution
   - Task reopen signals include user attribution

7. **test-attribution.js** - Unit tests for attribution

### Usage

```bash
# Per-user tokens (gateway mode)
export KARVI_USER_TOKENS='{"alice": "token-alice-123", "bob": "token-bob-456"}'
```

Signals will include `_attribution` field:
```json
{
  "by": "alice",
  "type": "status_change",
  "data": {
    "_attribution": {"actor": "alice", "role": "admin"}
  }
}
```

Closes #353