### PR TITLE
feat(dispatch): topological sort for ready tasks

### DIFF
--- a/server/management.js
+++ b/server/management.js
@@ -1281,6 +1281,20 @@ function generateStepsForTask(task, runId, pipeline, board) {
   });
 }
 
+function getDependencyDepth(task, allTasks) {
+  const depends = task.depends || [];
+  if (depends.length === 0) return 0;
+  let maxDepth = 0;
+  for (const depId of depends) {
+    const depTask = allTasks.find(t => t.id === depId);
+    if (depTask) {
+      const depDepth = getDependencyDepth(depTask, allTasks);
+      maxDepth = Math.max(maxDepth, depDepth + 1);
+    }
+  }
+  return maxDepth;
+}
+
 function pickNextTask(board) {
   const tasks = board.taskPlan?.tasks || [];
 
@@ -1297,7 +1311,14 @@ function pickNextTask(board) {
 
   if (ready.length === 0) return null;
 
-  // 3. Prefer tasks matching dispatch_hints
+  // 3. Sort by dependency depth (topological order: no-deps first)
+  ready.sort((a, b) => {
+    const depthA = getDependencyDepth(a, tasks);
+    const depthB = getDependencyDepth(b, tasks);
+    return depthA - depthB;
+  });
+
+  // 4. Prefer tasks matching dispatch_hints
   const hints = board.controls?.dispatch_hints || [];
   let picked = ready[0];
   for (const task of ready) {


### PR DESCRIPTION
Closes #360

## Summary

- Add `getDependencyDepth()` helper to calculate dependency chain depth recursively
- Sort ready tasks by dependency depth in `pickNextTask()` - tasks with no dependencies (depth 0) are picked first
- Ensures independent tasks execute before dependent tasks, improving parallel execution efficiency

## Changes

- `server/management.js`: Added topological sorting to `pickNextTask()`

## Test Plan

- Verified with unit test: tasks with `depends: []` (depth 0) are prioritized over tasks with dependencies
- All existing tests pass