### PR TITLE
refactor: centralize board schema migration

### DIFF
--- a/server/board-migration.js
+++ b/server/board-migration.js
@@ -1,0 +1,110 @@
+/**
+ * board-migration.js — Centralized board schema migration
+ *
+ * All board schema changes go through this module.
+ * Each migration is idempotent: running twice produces the same result.
+ */
+
+/**
+ * Migration: ensure board.signals exists as an array
+ */
+function migrateEnsureSignals(board) {
+  if (!Array.isArray(board.signals)) {
+    board.signals = [];
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Migration: ensure board.insights exists as an array
+ */
+function migrateEnsureInsights(board) {
+  if (!Array.isArray(board.insights)) {
+    board.insights = [];
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Migration: ensure board.lessons exists as an array
+ */
+function migrateEnsureLessons(board) {
+  if (!Array.isArray(board.lessons)) {
+    board.lessons = [];
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Migration: ensure board.projects exists as an array
+ */
+function migrateEnsureProjects(board) {
+  if (!Array.isArray(board.projects)) {
+    board.projects = [];
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Migration: ensure board.village exists via villageRoutes.ensureVillage
+ */
+function migrateEnsureVillage(board, deps) {
+  if (!board.village) {
+    deps.villageRoutes.ensureVillage(board);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Migration: recover expired step locks
+ */
+function migrateRecoverExpiredLocks(board, deps) {
+  const recovered = deps.recoverExpiredLocks(board);
+  return recovered > 0;
+}
+
+/**
+ * All migrations in order of execution.
+ * Each entry: { name, fn }
+ * fn(board, deps) -> boolean (true if migration was applied)
+ */
+const MIGRATIONS = [
+  { name: 'ensure-signals', fn: migrateEnsureSignals },
+  { name: 'ensure-insights', fn: migrateEnsureInsights },
+  { name: 'ensure-lessons', fn: migrateEnsureLessons },
+  { name: 'ensure-projects', fn: migrateEnsureProjects },
+  { name: 'ensure-village', fn: migrateEnsureVillage },
+  { name: 'recover-expired-locks', fn: migrateRecoverExpiredLocks },
+];
+
+/**
+ * Run all migrations on a board.
+ *
+ * @param {Object} board - The board object to migrate (mutated in place)
+ * @param {Object} deps - Dependencies: { villageRoutes, recoverExpiredLocks }
+ * @returns {{ dirty: boolean, applied: string[] }}
+ */
+function migrateBoard(board, deps) {
+  const applied = [];
+  let dirty = false;
+
+  for (const { name, fn } of MIGRATIONS) {
+    const changed = fn(board, deps);
+    if (changed) {
+      applied.push(name);
+      dirty = true;
+    }
+  }
+
+  return { dirty, applied };
+}
+
+module.exports = {
+  migrateBoard,
+  MIGRATIONS,
+};

--- a/server/server.js
+++ b/server/server.js
@@ -49,6 +49,7 @@ let runtimeOpencode = null;
 try { runtimeOpencode = require('./runtime-opencode'); } catch { /* opencode not installed, skip */ }
 
 const { validateAllRuntimes } = require('./runtime-contract');
+const { migrateBoard } = require('./board-migration');
 
 const RUNTIMES = {
   openclaw: runtime,
@@ -254,20 +255,12 @@ const appendLog = (e) => bb.appendLog(ctx, e);
 const broadcastSSE = (ev, d) => bb.broadcastSSE(ctx, ev, d);
 
 const initBoard = readBoard();
-let dirty = false;
-if (!Array.isArray(initBoard.signals)) { initBoard.signals = []; dirty = true; }
-if (!Array.isArray(initBoard.insights)) { initBoard.insights = []; dirty = true; }
-if (!Array.isArray(initBoard.lessons)) { initBoard.lessons = []; dirty = true; }
-if (!Array.isArray(initBoard.projects)) { initBoard.projects = []; dirty = true; }
-// Village Chief: ensure village block exists on startup
-if (!initBoard.village) { villageRoutes.ensureVillage(initBoard); dirty = true; }
-if (dirty) writeBoard(initBoard);
-
-// --- Recover expired step locks (crashed dispatch recovery) ---
 const { recoverExpiredLocks } = require('./step-worker');
-const recoveredLocks = recoverExpiredLocks(initBoard);
-if (recoveredLocks > 0) {
-  console.log(`[step-worker] recovered ${recoveredLocks} expired step lock(s)`);
+const migrationResult = migrateBoard(initBoard, { villageRoutes, recoverExpiredLocks });
+if (migrationResult.applied.length > 0) {
+  console.log(`[migration] applied: ${migrationResult.applied.join(', ')}`);
+}
+if (migrationResult.dirty) {
   writeBoard(initBoard);
 }
 


### PR DESCRIPTION
## Summary

Closes #145

Create `server/board-migration.js` to centralize all board schema migrations:

- **migrateBoard(board, deps)** runs all migrations and returns `{ dirty, applied }`
- Each migration is idempotent (running twice produces same result)
- Migrations: ensure-signals, ensure-insights, ensure-lessons, ensure-projects, ensure-village, recover-expired-locks
- Reduces server.js migration code from ~17 lines to ~6 lines

## Acceptance Criteria

- [x] server.js migration code reduced to ~6 lines
- [x] Each migration is idempotent
- [x] migrateBoard returns which migrations were applied
- [x] Board initialization behavior unchanged
- [x] All existing tests pass