### PR TITLE
fix(security): replace cmd.exe string interpolation with execFileSync array args

### DIFF
--- a/server/runtime-claude-api.js
+++ b/server/runtime-claude-api.js
@@ -11,7 +11,7 @@
 const https = require('https');
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 
 // --- Constants ---
 const API_HOST = 'api.anthropic.com';
@@ -210,18 +210,18 @@ function executeToolCall(toolName, toolInput, workingDir) {
 
       case 'bash': {
         const cmd = toolInput.command;
-        // Windows-first: use cmd.exe /d /s /c wrapping (see runtime-openclaw.js)
-        const shellCmd = process.platform === 'win32'
-          ? `cmd.exe /d /s /c "${cmd}"`
-          : cmd;
-        const result = execSync(shellCmd, {
+        // Windows-first: use execFileSync with array args to prevent injection
+        // (LLM-generated cmd may contain crafted double quotes)
+        const execOpts = {
           cwd: workingDir,
           timeout: TOOL_EXEC_TIMEOUT_MS,
           encoding: 'utf8',
           maxBuffer: 1024 * 1024, // 1MB
           windowsHide: true,
-          shell: process.platform !== 'win32', // Unix: use shell; Windows: already wrapped
-        });
+        };
+        const result = process.platform === 'win32'
+          ? execFileSync('cmd.exe', ['/d', '/s', '/c', cmd], execOpts)
+          : execSync(cmd, { ...execOpts, shell: true });
         return result || '(no output)';
       }
 


### PR DESCRIPTION
## Summary
- Replace `execSync(`cmd.exe /d /s /c "${cmd}"`)` with `execFileSync('cmd.exe', ['/d', '/s', '/c', cmd])` in `runtime-claude-api.js` bash tool execution
- Prevents command injection via crafted double quotes in LLM-generated bash commands
- Unix path unchanged (`execSync` with `shell: true`)

Closes #411

## Test plan
- [x] `node --check server/runtime-claude-api.js` passes
- [ ] Manual: dispatch a claude-api task with bash tool usage, verify commands execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)