### PR TITLE
refactor(signal): extract createSignal to shared module and migrate all callers

### DIFF
--- a/server/kernel.js
+++ b/server/kernel.js
@@ -14,6 +14,7 @@ const villageHooks = require('./village-hooks');
 const { verifyContract } = require('./village/deliverable-contracts');
 const worktreeHelper = require('./worktree');
 const { resolveRepoRoot } = require('./repo-resolver');
+const { createSignal } = require('./signal');
 const path = require('path');
 
 /**
@@ -121,13 +122,11 @@ function createKernel(deps) {
     const latestTask = (latestBoard.taskPlan?.tasks || []).find(t => t.id === taskId);
     if (latestTask) latestTask.budget = task.budget;
     mgmt.ensureEvolutionFields(latestBoard);
-    latestBoard.signals.push({
-      id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'kernel',
-      type: 'route_decision',
+    latestBoard.signals.push(createSignal({
+      by: 'kernel', type: 'route_decision',
       content: `${taskId} ${stepId} → ${decision.action} (${decision.rule})`,
-      refs: [taskId],
-      data: { taskId, stepId, decision },
-    });
+      refs: [taskId], data: { taskId, stepId, decision },
+    }, helpers));
     mgmt.trimSignals(latestBoard, helpers.signalArchivePath);
 
     // Village hook deps (used by multiple cases)
@@ -232,13 +231,11 @@ function createKernel(deps) {
         if (latestTask) {
           latestTask.blocker = { reason: decision.human_review?.reason || 'Kernel escalated to human', askedAt: helpers.nowIso() };
         }
-        latestBoard.signals.push({
-          id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'kernel',
-          type: 'human_review_needed',
+        latestBoard.signals.push(createSignal({
+          by: 'kernel', type: 'human_review_needed',
           content: `${taskId} needs human review: ${decision.human_review?.reason || ''}`,
-          refs: [taskId],
-          data: { taskId, stepId, reason: decision.human_review?.reason },
-        });
+          refs: [taskId], data: { taskId, stepId, reason: decision.human_review?.reason },
+        }, helpers));
         // Village: cycle stall detection for meeting tasks
         if (villageHooks.onTaskBlocked(latestBoard, taskId, latestTask, helpers, villageDeps)) {
           return;
@@ -249,13 +246,11 @@ function createKernel(deps) {
           push.notifyTaskEvent(PUSH_TOKENS_PATH, latestTask, 'task.blocked')
             .catch(err => {
               console.error(`[kernel] push error for task ${taskId}, event task.blocked:`, err.message);
-              latestBoard.signals.push({
-                id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'kernel',
-                type: 'push_failed',
+              latestBoard.signals.push(createSignal({
+                by: 'kernel', type: 'push_failed',
                 content: `Push notification failed for ${taskId}: ${err.message}`,
-                refs: [taskId],
-                data: { taskId, eventType: 'task.blocked', error: err.message },
-              });
+                refs: [taskId], data: { taskId, eventType: 'task.blocked', error: err.message },
+              }, helpers));
               mgmt.trimSignals(latestBoard, helpers.signalArchivePath);
             });
         }
@@ -274,13 +269,11 @@ function createKernel(deps) {
           // committed yet. Deleting it permanently loses work. Worktree will be cleaned
           // up when the task is manually cancelled/deleted or re-dispatched. (GH-325)
         }
-        latestBoard.signals.push({
-          id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'kernel',
-          type: 'task_dead_letter',
+        latestBoard.signals.push(createSignal({
+          by: 'kernel', type: 'task_dead_letter',
           content: `${taskId} dead-lettered: ${decision.rule}`,
-          refs: [taskId],
-          data: { taskId, stepId, rule: decision.rule },
-        });
+          refs: [taskId], data: { taskId, stepId, rule: decision.rule },
+        }, helpers));
         // Village: cycle stall detection for meeting tasks
         if (villageHooks.onTaskBlocked(latestBoard, taskId, latestTask, helpers, villageDeps)) {
           return;
@@ -290,13 +283,11 @@ function createKernel(deps) {
           push.notifyTaskEvent(PUSH_TOKENS_PATH, latestTask, 'task.blocked')
             .catch(err => {
               console.error(`[kernel] push error for task ${taskId}, event task.blocked:`, err.message);
-              latestBoard.signals.push({
-                id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'kernel',
-                type: 'push_failed',
+              latestBoard.signals.push(createSignal({
+                by: 'kernel', type: 'push_failed',
                 content: `Push notification failed for ${taskId}: ${err.message}`,
-                refs: [taskId],
-                data: { taskId, eventType: 'task.blocked', error: err.message },
-              });
+                refs: [taskId], data: { taskId, eventType: 'task.blocked', error: err.message },
+              }, helpers));
               mgmt.trimSignals(latestBoard, helpers.signalArchivePath);
             });
         }
@@ -317,13 +308,11 @@ function createKernel(deps) {
 
               // Signal + push (match dead_letter side-effects)
               mgmt.ensureEvolutionFields(latestBoard);
-              latestBoard.signals.push({
-                id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'kernel',
-                type: 'contract_failed',
+              latestBoard.signals.push(createSignal({
+                by: 'kernel', type: 'contract_failed',
                 content: `${taskId} contract verification failed: ${cv.reason}`,
-                refs: [taskId],
-                data: { taskId, kind: latestTask.contract.kind, reason: cv.reason },
-              });
+                refs: [taskId], data: { taskId, kind: latestTask.contract.kind, reason: cv.reason },
+              }, helpers));
               mgmt.trimSignals(latestBoard, helpers.signalArchivePath);
 
               if (push && PUSH_TOKENS_PATH) {
@@ -412,13 +401,11 @@ function createKernel(deps) {
                 .catch(err => {
                   console.error(`[kernel] auto-merge failed for PR #${number}:`, err.message);
                   const freshBoard = helpers.readBoard();
-                  freshBoard.signals.push({
-                    id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'kernel',
-                    type: 'auto_merge_failed',
+                  freshBoard.signals.push(createSignal({
+                    by: 'kernel', type: 'auto_merge_failed',
                     content: `Auto-merge failed for ${taskId} PR #${number}: ${err.message}`,
-                    refs: [taskId],
-                    data: { taskId, prNumber: number, error: err.message },
-                  });
+                    refs: [taskId], data: { taskId, prNumber: number, error: err.message },
+                  }, helpers));
                   mgmt.trimSignals(freshBoard, helpers.signalArchivePath);
                   helpers.writeBoard(freshBoard);
                 });
@@ -448,13 +435,11 @@ function createKernel(deps) {
           push.notifyTaskEvent(PUSH_TOKENS_PATH, latestTask, 'task.completed')
             .catch(err => {
               console.error(`[kernel] push error for task ${taskId}, event task.completed:`, err.message);
-              latestBoard.signals.push({
-                id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'kernel',
-                type: 'push_failed',
+              latestBoard.signals.push(createSignal({
+                by: 'kernel', type: 'push_failed',
                 content: `Push notification failed for ${taskId}: ${err.message}`,
-                refs: [taskId],
-                data: { taskId, eventType: 'task.completed', error: err.message },
-              });
+                refs: [taskId], data: { taskId, eventType: 'task.completed', error: err.message },
+              }, helpers));
               mgmt.trimSignals(latestBoard, helpers.signalArchivePath);
             });
         }

--- a/server/routes/_shared.js
+++ b/server/routes/_shared.js
@@ -130,32 +130,12 @@ function requireRole(req, res, minRole) {
 
 /**
  * Create a signal object with user attribution.
- * @param {object} opts - Signal options
- * @param {string} opts.type - Signal type (e.g., 'status_change', 'task_cancelled')
- * @param {string} opts.content - Human-readable content
- * @param {string[]} opts.refs - References (e.g., task IDs)
- * @param {object} opts.data - Additional data
- * @param {object} req - Express-like request object with karviUser/karviRole
- * @param {object} helpers - Helper functions (uid, nowIso)
- * @returns {object} Signal object ready to push to board.signals
+ * Route-layer wrapper: preserves (opts, req, helpers) signature for backward compat.
+ * Actual logic lives in server/signal.js.
  */
+const { createSignal: _createSignal } = require('../signal');
 function createSignal(opts, req, helpers) {
-  const { type, content, refs = [], data = {}, by } = opts;
-  const actor = req?.karviUser || null;
-  const role = req?.karviRole || null;
-
-  return {
-    id: helpers.uid('sig'),
-    ts: helpers.nowIso(),
-    by: actor || by || 'api',
-    type,
-    content,
-    refs,
-    data: {
-      ...data,
-      _attribution: actor ? { actor, role } : undefined,
-    },
-  };
+  return _createSignal(opts, helpers, req);
 }
 
 /**

--- a/server/signal.js
+++ b/server/signal.js
@@ -1,0 +1,41 @@
+/**
+ * signal.js — 統一 signal 建構函式
+ *
+ * 所有 board.signals.push() 都應使用此函式，
+ * 確保 signal schema 一致。非 HTTP context（kernel、step-worker）
+ * 不需傳 req，直接在 opts.by 指定來源。
+ */
+
+/**
+ * Create a signal object.
+ *
+ * @param {object} opts - Signal options
+ * @param {string} opts.type - Signal type (e.g., 'status_change', 'step_completed')
+ * @param {string} opts.content - Human-readable content
+ * @param {string[]} [opts.refs] - References (e.g., task IDs)
+ * @param {object} [opts.data] - Additional data
+ * @param {string} [opts.by] - Actor identifier (e.g., 'kernel', 'step-worker', 'api')
+ * @param {object} helpers - Helper functions with uid() and nowIso()
+ * @param {object} [req] - Optional HTTP request for user attribution
+ * @returns {object} Signal object ready to push to board.signals
+ */
+function createSignal(opts, helpers, req) {
+  const { type, content, refs = [], data = {}, by } = opts;
+  const actor = req?.karviUser || null;
+  const role = req?.karviRole || null;
+
+  return {
+    id: helpers.uid('sig'),
+    ts: helpers.nowIso(),
+    by: actor || by || 'api',
+    type,
+    content,
+    refs,
+    data: {
+      ...data,
+      _attribution: actor ? { actor, role } : undefined,
+    },
+  };
+}
+
+module.exports = { createSignal };

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -15,6 +15,7 @@ const path = require('path');
 const mgmt = require('./management');
 const { resolveRepoRoot } = require('./repo-resolver');
 const { runHook } = require('./hook-runner');
+const { createSignal } = require('./signal');
 const LOCK_GRACE_MS = 30_000; // 30s grace on top of step timeout
 
 // --- Webhook event emission (#333) — Event Envelope v1 contract ---
@@ -385,13 +386,11 @@ function createStepWorker(deps) {
               error: killStep.error || 'Killed by user',
             });
             mgmt.ensureEvolutionFields(killBoard);
-            killBoard.signals.push({
-              id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'step-worker',
-              type: 'step_cancelled',
+            killBoard.signals.push(createSignal({
+              by: 'step-worker', type: 'step_cancelled',
               content: `${envelope.task_id} step ${envelope.step_id} cancelling \u2192 cancelled`,
-              refs: [envelope.task_id],
-              data: { taskId: envelope.task_id, stepId: envelope.step_id, from: 'cancelling', to: 'cancelled' },
-            });
+              refs: [envelope.task_id], data: { taskId: envelope.task_id, stepId: envelope.step_id, from: 'cancelling', to: 'cancelled' },
+            }, helpers));
             mgmt.trimSignals(killBoard, helpers.signalArchivePath);
             helpers.writeBoard(killBoard);
             helpers.appendLog({ ts: helpers.nowIso(), event: 'step_killed', taskId: envelope.task_id, stepId: envelope.step_id, duration_ms: dispatchDurationMs });
@@ -412,13 +411,11 @@ function createStepWorker(deps) {
             });
 
             mgmt.ensureEvolutionFields(failBoard);
-            failBoard.signals.push({
-              id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'step-worker',
-              type: 'step_cancelled',
+            failBoard.signals.push(createSignal({
+              by: 'step-worker', type: 'step_cancelled',
               content: `${envelope.task_id} step ${envelope.step_id} cancelling → cancelled`,
-              refs: [envelope.task_id],
-              data: { taskId: envelope.task_id, stepId: envelope.step_id, from: 'cancelling', to: 'cancelled' },
-            });
+              refs: [envelope.task_id], data: { taskId: envelope.task_id, stepId: envelope.step_id, from: 'cancelling', to: 'cancelled' },
+            }, helpers));
             mgmt.trimSignals(failBoard, helpers.signalArchivePath);
 
             helpers.writeBoard(failBoard);
@@ -435,13 +432,11 @@ function createStepWorker(deps) {
           // Emit signal so dashboard/SSE sees dispatch errors
           const signalType = failStep.state === 'dead' ? 'step_dead' : 'step_failed';
           mgmt.ensureEvolutionFields(failBoard);
-          failBoard.signals.push({
-            id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'step-worker',
-            type: signalType,
+          failBoard.signals.push(createSignal({
+            by: 'step-worker', type: signalType,
             content: `${envelope.task_id} step ${envelope.step_id} dispatch error → ${failStep.state}`,
-            refs: [envelope.task_id],
-            data: { taskId: envelope.task_id, stepId: envelope.step_id, from: 'running', to: failStep.state, attempt: failStep.attempt },
-          });
+            refs: [envelope.task_id], data: { taskId: envelope.task_id, stepId: envelope.step_id, from: 'running', to: failStep.state, attempt: failStep.attempt },
+          }, helpers));
           mgmt.trimSignals(failBoard, helpers.signalArchivePath);
 
           helpers.writeBoard(failBoard);
@@ -725,13 +720,11 @@ function createStepWorker(deps) {
         : latestStep.state === 'queued' ? 'step_failed'
         : `step_${latestStep.state}`;
       mgmt.ensureEvolutionFields(latestBoard);
-      latestBoard.signals.push({
-        id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'step-worker',
-        type: signalType,
+      latestBoard.signals.push(createSignal({
+        by: 'step-worker', type: signalType,
         content: `${envelope.task_id} step ${envelope.step_id} running → ${latestStep.state}`,
-        refs: [envelope.task_id],
-        data: { taskId: envelope.task_id, stepId: envelope.step_id, from: 'running', to: latestStep.state, attempt: latestStep.attempt, ...(preflightResult.alreadyDone ? { preflight: { skipped: true, evidence: preflightResult.evidence } } : {}) },
-      });
+        refs: [envelope.task_id], data: { taskId: envelope.task_id, stepId: envelope.step_id, from: 'running', to: latestStep.state, attempt: latestStep.attempt, ...(preflightResult.alreadyDone ? { preflight: { skipped: true, evidence: preflightResult.evidence } } : {}) },
+      }, helpers));
       mgmt.trimSignals(latestBoard, helpers.signalArchivePath);
       helpers.writeBoard(latestBoard);
       helpers.appendLog({ ts: helpers.nowIso(), event: signalType, taskId: envelope.task_id, stepId: envelope.step_id, from: 'running', to: latestStep.state });

--- a/server/village-hooks.js
+++ b/server/village-hooks.js
@@ -11,6 +11,7 @@
  */
 const planDispatcher = require('./village/plan-dispatcher');
 const cycleWatchdog = require('./village/cycle-watchdog');
+const { createSignal } = require('./signal');
 
 /**
  * Check if a blocked/reviewed meeting task has stalled the cycle.
@@ -168,13 +169,11 @@ function _pushTaskEvent(board, task, taskId, eventType, helpers, deps) {
 }
 
 function _pushFailedSignal(board, taskId, eventType, err, helpers, deps) {
-  board.signals.push({
-    id: helpers.uid('sig'), ts: helpers.nowIso(), by: 'kernel',
-    type: 'push_failed',
+  board.signals.push(createSignal({
+    by: 'kernel', type: 'push_failed',
     content: `Push notification failed for ${taskId || eventType}: ${err.message}`,
-    refs: taskId ? [taskId] : [],
-    data: { taskId: taskId || null, eventType, error: err.message },
-  });
+    refs: taskId ? [taskId] : [], data: { taskId: taskId || null, eventType, error: err.message },
+  }, helpers));
   deps.mgmt.trimSignals(board, helpers.signalArchivePath);
 }
 

--- a/server/village/cycle-watchdog.js
+++ b/server/village/cycle-watchdog.js
@@ -12,6 +12,7 @@
  */
 
 const mgmt = require('../management');
+const { createSignal } = require('../signal');
 
 const DEFAULT_STALL_TIMEOUT_MS = 4 * 3_600_000; // 4 hours
 
@@ -118,21 +119,16 @@ function closeStalledCycle(board, helpers, reason, healthResult) {
   cycle.failureReason = reason;
 
   if (!Array.isArray(board.signals)) board.signals = [];
-  board.signals.push({
-    id: helpers.uid("sig"),
-    ts: now,
-    by: "cycle-watchdog",
-    type: "cycle_stalled",
+  board.signals.push(createSignal({
+    by: "cycle-watchdog", type: "cycle_stalled",
     content: "Cycle " + cycleId + " stalled in phase " + failedPhase + ": " + reason,
     refs: [cycleId],
     data: {
-      cycleId,
-      stalledPhase: failedPhase,
-      reason,
+      cycleId, stalledPhase: failedPhase, reason,
       taskStatuses: healthResult?.taskStatuses || {},
       stuckDurationMs: healthResult?.stuckDurationMs || 0,
     },
-  });
+  }, helpers));
   mgmt.trimSignals(board, helpers.signalArchivePath);
 
   helpers.writeBoard(board);

--- a/server/village/plan-dispatcher.js
+++ b/server/village/plan-dispatcher.js
@@ -15,6 +15,7 @@ const { uid, nowIso } = bb;
 const mgmt = require('../management');
 const { retryOnConflict } = require('../helpers/retry');
 const { buildContract } = require('./deliverable-contracts');
+const { createSignal } = require('../signal');
 
 /**
  * Extract plan data from a synthesis step's output artifact.
@@ -170,21 +171,16 @@ async function parsePlanAndDispatch(board, planData, helpers, deps, synthesisTas
     // Emit signal
     if (deps.mgmt) deps.mgmt.ensureEvolutionFields(latestBoard);
     if (!Array.isArray(latestBoard.signals)) latestBoard.signals = [];
-    latestBoard.signals.push({
-      id: helpers.uid('sig'),
-      ts: now,
-      by: 'plan-dispatcher',
-      type: 'village_plan_dispatched',
+    latestBoard.signals.push(createSignal({
+      by: 'plan-dispatcher', type: 'village_plan_dispatched',
       content: `Plan dispatched: ${createdTaskIds.length} tasks from ${cycleId}`,
       refs: createdTaskIds,
       data: {
-        cycleId,
-        taskCount: createdTaskIds.length,
-        taskIds: createdTaskIds,
+        cycleId, taskCount: createdTaskIds.length, taskIds: createdTaskIds,
         conflictsResolved: planData.conflicts_resolved || [],
         deferred: planData.deferred || [],
       },
-    });
+    }, helpers));
     mgmt.trimSignals(latestBoard, helpers.signalArchivePath);
 
     // Write board + broadcast


### PR DESCRIPTION
## Summary
- Extract `createSignal()` from `routes/_shared.js` to new `server/signal.js` with non-HTTP-friendly signature `(opts, helpers, req?)`
- Migrate all 15 hand-constructed `board.signals.push({...})` across 5 files to use the shared function
- `routes/_shared.js` re-exports with old `(opts, req, helpers)` signature for backward compat — zero changes needed in route callers

## Files changed
| File | Hand-constructed signals removed |
|------|---:|
| `server/signal.js` | new (canonical implementation) |
| `server/kernel.js` | 9 |
| `server/step-worker.js` | 4 |
| `server/village-hooks.js` | 1 |
| `server/village/cycle-watchdog.js` | 1 |
| `server/village/plan-dispatcher.js` | 1 |
| `server/routes/_shared.js` | re-export wrapper |

## Test plan
- [x] `node --check` passes on all 7 modified files
- [x] `npm test` passes (integration tests)
- [x] Zero hand-constructed `signals.push({` remaining in migrated files
- [x] Route callers (`tasks.js`, `github.js`, `evolution.js`, `projects.js`) unchanged — backward compat confirmed

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)