### PR TITLE
fix(security): enforce body size limit on all POST routes via parseBody

### DIFF
--- a/server/blackboard-server.js
+++ b/server/blackboard-server.js
@@ -459,7 +459,7 @@ function createServer(ctx, routeHandler) {
     // Catches obviously-too-large requests before reading any data.
     // The stream-level guard in parseBody() handles cases where
     // Content-Length is missing or spoofed.
-    if (req.method === 'POST' || req.method === 'PUT') {
+    if (req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH') {
       const contentLength = parseInt(req.headers['content-length'], 10);
       if (contentLength > ctx.maxBodyBytes) {
         res.writeHead(413, { 'Content-Type': 'application/json; charset=utf-8' });

--- a/server/routes/briefs.js
+++ b/server/routes/briefs.js
@@ -53,36 +53,22 @@ module.exports = function briefsRoutes(req, res, helpers, deps) {
 
   if (req.method === 'PATCH' && briefGetMatch) {
     const taskId = decodeURIComponent(briefGetMatch[1]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const patch = JSON.parse(body || '{}');
-        const existing = readBrief(taskId);
-        if (!existing) return json(res, 404, { error: 'no brief for this task' });
-        const merged = deepMerge(existing, patch);
-        writeBrief(taskId, merged);
-        return json(res, 200, { ok: true, taskId });
-      } catch (err) {
-        return json(res, 400, { error: err.message });
-      }
-    });
+    helpers.parseBody(req).then(patch => {
+      const existing = readBrief(taskId);
+      if (!existing) return json(res, 404, { error: 'no brief for this task' });
+      const merged = deepMerge(existing, patch);
+      writeBrief(taskId, merged);
+      return json(res, 200, { ok: true, taskId });
+    }).catch(err => json(res, err.statusCode === 413 ? 413 : 400, { error: err.message }));
     return;
   }
 
   if (req.method === 'PUT' && briefGetMatch) {
     const taskId = decodeURIComponent(briefGetMatch[1]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const data = JSON.parse(body || '{}');
-        if (!writeBrief(taskId, data)) return json(res, 404, { error: 'no brief for this task' });
-        return json(res, 200, { ok: true, taskId });
-      } catch (err) {
-        return json(res, 400, { error: err.message });
-      }
-    });
+    helpers.parseBody(req).then(data => {
+      if (!writeBrief(taskId, data)) return json(res, 404, { error: 'no brief for this task' });
+      return json(res, 200, { ok: true, taskId });
+    }).catch(err => json(res, err.statusCode === 413 ? 413 : 400, { error: err.message }));
     return;
   }
 

--- a/server/routes/chat.js
+++ b/server/routes/chat.js
@@ -232,194 +232,173 @@ async function processQueue(conversationId, deps, helpers) {
 module.exports = function chatRoutes(req, res, helpers, deps) {
 
   if (req.method === 'POST' && req.url === '/api/conversations') {
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
-        const id = String(payload.id || '').trim();
-        const title = String(payload.title || '').trim();
-        const members = Array.isArray(payload.members) && payload.members.length > 0
-          ? [...new Set(payload.members.map(m => String(m).trim()).filter(Boolean))]
-          : ['human', 'main', 'nier'];
-        const defaultAutoTurns = Number.isFinite(Number(payload.defaultAutoTurns))
-          ? Math.max(1, Math.min(50, Number(payload.defaultAutoTurns)))
-          : 6;
+    helpers.parseBody(req).then(payload => {
+      const id = String(payload.id || '').trim();
+      const title = String(payload.title || '').trim();
+      const members = Array.isArray(payload.members) && payload.members.length > 0
+        ? [...new Set(payload.members.map(m => String(m).trim()).filter(Boolean))]
+        : ['human', 'main', 'nier'];
+      const defaultAutoTurns = Number.isFinite(Number(payload.defaultAutoTurns))
+        ? Math.max(1, Math.min(50, Number(payload.defaultAutoTurns)))
+        : 6;
 
-        if (!id || !/^[a-z0-9_-]+$/i.test(id)) {
-          return json(res, 400, { error: 'Invalid conversation id (a-z0-9_-)' });
-        }
-        if (!title) return json(res, 400, { error: 'title is required' });
-
-        const board = helpers.readBoard();
-        if (conversationById(board, id)) {
-          return json(res, 409, { error: `Conversation ${id} already exists` });
-        }
-
-        for (const m of members) {
-          if (!participantById(board, m)) {
-            return json(res, 400, { error: `Unknown member: ${m}` });
-          }
-        }
-
-        const conv = createConversation({ id, title, members, defaultAutoTurns });
-        board.conversations = board.conversations || [];
-        board.conversations.push(conv);
-
-        helpers.writeBoard(board);
-        helpers.appendLog({ ts: helpers.nowIso(), event: 'conversation_created', conversationId: id, title, members });
-        json(res, 200, { ok: true, conversation: conv });
-      } catch (error) {
-        json(res, 400, { error: error.message });
+      if (!id || !/^[a-z0-9_-]+$/i.test(id)) {
+        return json(res, 400, { error: 'Invalid conversation id (a-z0-9_-)' });
       }
-    });
+      if (!title) return json(res, 400, { error: 'title is required' });
+
+      const board = helpers.readBoard();
+      if (conversationById(board, id)) {
+        return json(res, 409, { error: `Conversation ${id} already exists` });
+      }
+
+      for (const m of members) {
+        if (!participantById(board, m)) {
+          return json(res, 400, { error: `Unknown member: ${m}` });
+        }
+      }
+
+      const conv = createConversation({ id, title, members, defaultAutoTurns });
+      board.conversations = board.conversations || [];
+      board.conversations.push(conv);
+
+      helpers.writeBoard(board);
+      helpers.appendLog({ ts: helpers.nowIso(), event: 'conversation_created', conversationId: id, title, members });
+      json(res, 200, { ok: true, conversation: conv });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
   if (req.method === 'POST' && req.url === '/api/participants') {
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
-        const id = String(payload.id || '').trim();
-        const type = payload.type === 'human' ? 'human' : 'agent';
-        const displayName = String(payload.displayName || '').trim();
-        const agentId = String(payload.agentId || '').trim();
+    helpers.parseBody(req).then(payload => {
+      const id = String(payload.id || '').trim();
+      const type = payload.type === 'human' ? 'human' : 'agent';
+      const displayName = String(payload.displayName || '').trim();
+      const agentId = String(payload.agentId || '').trim();
 
-        if (!id || !/^[a-z0-9_-]+$/i.test(id)) {
-          return json(res, 400, { error: 'Invalid participant id (a-z0-9_-)' });
-        }
-        if (!displayName) return json(res, 400, { error: 'displayName is required' });
-        if (type === 'agent' && !agentId) return json(res, 400, { error: 'agentId is required for agent participant' });
-
-        const board = helpers.readBoard();
-        if (participantById(board, id)) return json(res, 409, { error: `Participant ${id} already exists` });
-
-        const participant = { id, type, displayName };
-        if (type === 'agent') participant.agentId = agentId;
-        board.participants = board.participants || [];
-        board.participants.push(participant);
-
-        const conversationId = String(payload.conversationId || '').trim();
-        const conv = conversationId
-          ? conversationById(board, conversationId)
-          : board.conversations?.[0];
-        if (conversationId && !conv) {
-          return json(res, 404, { error: `Conversation ${conversationId} not found` });
-        }
-
-        if (conv) {
-          conv.members = Array.from(new Set([...(conv.members || []), id]));
-          conv.sessionIds = conv.sessionIds || {};
-          if (!(id in conv.sessionIds)) conv.sessionIds[id] = null;
-        }
-
-        helpers.writeBoard(board);
-        helpers.appendLog({ ts: helpers.nowIso(), event: 'participant_added', participant, conversationId: conv?.id || null });
-        json(res, 200, { ok: true, participant, conversationId: conv?.id || null });
-      } catch (error) {
-        json(res, 400, { error: error.message });
+      if (!id || !/^[a-z0-9_-]+$/i.test(id)) {
+        return json(res, 400, { error: 'Invalid participant id (a-z0-9_-)' });
       }
-    });
+      if (!displayName) return json(res, 400, { error: 'displayName is required' });
+      if (type === 'agent' && !agentId) return json(res, 400, { error: 'agentId is required for agent participant' });
+
+      const board = helpers.readBoard();
+      if (participantById(board, id)) return json(res, 409, { error: `Participant ${id} already exists` });
+
+      const participant = { id, type, displayName };
+      if (type === 'agent') participant.agentId = agentId;
+      board.participants = board.participants || [];
+      board.participants.push(participant);
+
+      const conversationId = String(payload.conversationId || '').trim();
+      const conv = conversationId
+        ? conversationById(board, conversationId)
+        : board.conversations?.[0];
+      if (conversationId && !conv) {
+        return json(res, 404, { error: `Conversation ${conversationId} not found` });
+      }
+
+      if (conv) {
+        conv.members = Array.from(new Set([...(conv.members || []), id]));
+        conv.sessionIds = conv.sessionIds || {};
+        if (!(id in conv.sessionIds)) conv.sessionIds[id] = null;
+      }
+
+      helpers.writeBoard(board);
+      helpers.appendLog({ ts: helpers.nowIso(), event: 'participant_added', participant, conversationId: conv?.id || null });
+      json(res, 200, { ok: true, participant, conversationId: conv?.id || null });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
   const sendMatch = req.url.match(/^\/api\/conversations\/([^/]+)\/send$/);
   if (req.method === 'POST' && sendMatch) {
     const conversationId = decodeURIComponent(sendMatch[1]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
-        const from = String(payload.from || '').trim();
-        const to = String(payload.to || '').trim();
-        const text = normalizeText(payload.text);
+    helpers.parseBody(req).then(payload => {
+      const from = String(payload.from || '').trim();
+      const to = String(payload.to || '').trim();
+      const text = normalizeText(payload.text);
 
-        if (!from || !to || !text) return json(res, 400, { error: 'from, to, text are required' });
+      if (!from || !to || !text) return json(res, 400, { error: 'from, to, text are required' });
 
-        const board = helpers.readBoard();
-        const conv = conversationById(board, conversationId);
-        if (!conv) return json(res, 404, { error: `Conversation ${conversationId} not found` });
+      const board = helpers.readBoard();
+      const conv = conversationById(board, conversationId);
+      if (!conv) return json(res, 404, { error: `Conversation ${conversationId} not found` });
 
-        if (!participantById(board, from)) return json(res, 400, { error: `Unknown participant: ${from}` });
-        const toParticipant = participantById(board, to);
-        if (!toParticipant) return json(res, 400, { error: `Unknown participant: ${to}` });
+      if (!participantById(board, from)) return json(res, 400, { error: `Unknown participant: ${from}` });
+      const toParticipant = participantById(board, to);
+      if (!toParticipant) return json(res, 400, { error: `Unknown participant: ${to}` });
 
-        const members = new Set(conv.members || []);
-        if (!members.has(from) || !members.has(to)) {
-          return json(res, 400, { error: `from/to must be members of conversation ${conversationId}` });
-        }
+      const members = new Set(conv.members || []);
+      if (!members.has(from) || !members.has(to)) {
+        return json(res, 400, { error: `from/to must be members of conversation ${conversationId}` });
+      }
 
-        const msg = {
+      const msg = {
+        id: helpers.uid('msg'),
+        ts: helpers.nowIso(),
+        type: 'message',
+        from,
+        to,
+        text,
+      };
+      pushMessage(conv, msg);
+
+      helpers.appendLog({
+        ts: helpers.nowIso(),
+        conversationId,
+        event: 'message_sent',
+        from,
+        to,
+        text,
+      });
+
+      let queuedTurn = null;
+      if (toParticipant.type === 'agent') {
+        const autoLoop = !!payload.autoLoop;
+        const loopPair = Array.isArray(payload.loopPair) ? payload.loopPair.slice(0, 2) : ['main', 'nier'];
+        const maxTurns = Number.isFinite(Number(payload.maxAutoTurns))
+          ? Math.max(0, Math.min(50, Number(payload.maxAutoTurns)))
+          : Number(conv.settings?.defaultAutoTurns || 6);
+
+        queuedTurn = {
+          id: helpers.uid('turn'),
+          createdAt: helpers.nowIso(),
+          status: 'queued',
+          from,
+          to,
+          text,
+          timeoutSec: 180,
+          loop: {
+            enabled: autoLoop,
+            pair: loopPair,
+            remaining: autoLoop ? maxTurns : 0,
+          },
+        };
+
+        enqueueTurn(conv, queuedTurn);
+
+        pushMessage(conv, {
           id: helpers.uid('msg'),
           ts: helpers.nowIso(),
-          type: 'message',
-          from,
-          to,
-          text,
-        };
-        pushMessage(conv, msg);
-
-        helpers.appendLog({
-          ts: helpers.nowIso(),
-          conversationId,
-          event: 'message_sent',
-          from,
-          to,
-          text,
+          type: 'system',
+          from: 'system',
+          to: 'human',
+          text: `已排入佇列：${from} → ${to}。`,
+          turnId: queuedTurn.id,
         });
-
-        let queuedTurn = null;
-        if (toParticipant.type === 'agent') {
-          const autoLoop = !!payload.autoLoop;
-          const loopPair = Array.isArray(payload.loopPair) ? payload.loopPair.slice(0, 2) : ['main', 'nier'];
-          const maxTurns = Number.isFinite(Number(payload.maxAutoTurns))
-            ? Math.max(0, Math.min(50, Number(payload.maxAutoTurns)))
-            : Number(conv.settings?.defaultAutoTurns || 6);
-
-          queuedTurn = {
-            id: helpers.uid('turn'),
-            createdAt: helpers.nowIso(),
-            status: 'queued',
-            from,
-            to,
-            text,
-            timeoutSec: 180,
-            loop: {
-              enabled: autoLoop,
-              pair: loopPair,
-              remaining: autoLoop ? maxTurns : 0,
-            },
-          };
-
-          enqueueTurn(conv, queuedTurn);
-
-          pushMessage(conv, {
-            id: helpers.uid('msg'),
-            ts: helpers.nowIso(),
-            type: 'system',
-            from: 'system',
-            to: 'human',
-            text: `已排入佇列：${from} → ${to}。`,
-            turnId: queuedTurn.id,
-          });
-        }
-
-        helpers.writeBoard(board);
-
-        if (queuedTurn && conv.settings?.autoRunQueue !== false) {
-          processQueue(conversationId, deps, helpers).catch(err => {
-            console.error(`[processQueue error] ${err.message}`);
-          });
-        }
-
-        json(res, 200, { ok: true, queuedTurnId: queuedTurn?.id || null });
-      } catch (error) {
-        json(res, 400, { error: error.message });
       }
-    });
+
+      helpers.writeBoard(board);
+
+      if (queuedTurn && conv.settings?.autoRunQueue !== false) {
+        processQueue(conversationId, deps, helpers).catch(err => {
+          console.error(`[processQueue error] ${err.message}`);
+        });
+      }
+
+      json(res, 200, { ok: true, queuedTurnId: queuedTurn?.id || null });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 

--- a/server/routes/controls.js
+++ b/server/routes/controls.js
@@ -22,11 +22,7 @@ module.exports = function controlsRoutes(req, res, helpers, deps) {
 
   if (req.method === 'POST' && req.url === '/api/controls') {
     if (requireRole(req, res, 'admin')) return;
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const patch = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(patch => {
         const board = helpers.readBoard();
         board.controls = board.controls || {};
         const allowed = Object.keys(mgmt.DEFAULT_CONTROLS);
@@ -149,10 +145,7 @@ module.exports = function controlsRoutes(req, res, helpers, deps) {
         helpers.writeBoard(board);
         helpers.appendLog({ ts: helpers.nowIso(), event: 'controls_updated', controls: board.controls });
         json(res, 200, { ok: true, controls: mgmt.getControls(board) });
-      } catch (error) {
-        json(res, 400, { error: error.message });
-      }
-    });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 

--- a/server/routes/edda.js
+++ b/server/routes/edda.js
@@ -59,13 +59,7 @@ module.exports = function eddaRoutes(req, res, helpers, deps) {
   const { mgmt } = deps;
 
   if (req.method === 'POST' && req.url === '/api/edda/propose-controls') {
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      let payload;
-      try { payload = JSON.parse(body || '{}'); }
-      catch { return json(res, 400, { error: 'Invalid JSON' }); }
-
+    helpers.parseBody(req).then(payload => {
       const patch = payload.patch;
       const reasoning = String(payload.reasoning || '').trim();
       const by = String(payload.by || 'edda').trim();
@@ -119,7 +113,7 @@ module.exports = function eddaRoutes(req, res, helpers, deps) {
         insight,
         autoApplied: insight.status === 'applied',
       });
-    });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 

--- a/server/routes/evolution.js
+++ b/server/routes/evolution.js
@@ -54,43 +54,36 @@ module.exports = function evolutionRoutes(req, res, helpers, deps) {
   }
 
   if (req.method === 'POST' && req.url === '/api/signals') {
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
-        const by = String(payload.by || '').trim();
-        const type = String(payload.type || '').trim();
-        const content = String(payload.content || '').trim();
-        if (!by || !type || !content) {
-          return json(res, 400, { error: 'by, type, content are required' });
-        }
-        const board = helpers.readBoard();
-        mgmt.ensureEvolutionFields(board);
-        const signal = {
-          id: helpers.uid('sig'),
-          ts: helpers.nowIso(),
-          by,
-          type,
-          content,
-        };
-        if (payload.refs) signal.refs = payload.refs;
-        if (payload.data) signal.data = payload.data;
-        board.signals.push(signal);
-        mgmt.trimSignals(board, helpers.signalArchivePath);
-
-        // Evolution Layer: trigger verification and auto-apply on review signals
-        if (type === 'review_result') {
-          mgmt.verifyAppliedInsights(board);
-        }
-        mgmt.autoApplyInsights(board);
-
-        helpers.writeBoard(board);
-        json(res, 201, { ok: true, signal });
-      } catch (error) {
-        json(res, 400, { error: error.message });
+    helpers.parseBody(req).then(payload => {
+      const by = String(payload.by || '').trim();
+      const type = String(payload.type || '').trim();
+      const content = String(payload.content || '').trim();
+      if (!by || !type || !content) {
+        return json(res, 400, { error: 'by, type, content are required' });
       }
-    });
+      const board = helpers.readBoard();
+      mgmt.ensureEvolutionFields(board);
+      const signal = {
+        id: helpers.uid('sig'),
+        ts: helpers.nowIso(),
+        by,
+        type,
+        content,
+      };
+      if (payload.refs) signal.refs = payload.refs;
+      if (payload.data) signal.data = payload.data;
+      board.signals.push(signal);
+      mgmt.trimSignals(board, helpers.signalArchivePath);
+
+      // Evolution Layer: trigger verification and auto-apply on review signals
+      if (type === 'review_result') {
+        mgmt.verifyAppliedInsights(board);
+      }
+      mgmt.autoApplyInsights(board);
+
+      helpers.writeBoard(board);
+      json(res, 201, { ok: true, signal });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
@@ -113,49 +106,42 @@ module.exports = function evolutionRoutes(req, res, helpers, deps) {
   }
 
   if (req.method === 'POST' && req.url === '/api/insights') {
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
-        const by = String(payload.by || '').trim();
-        const judgement = String(payload.judgement || '').trim();
-        const risk = String(payload.risk || '').trim();
-        if (!by || !judgement) {
-          return json(res, 400, { error: 'by, judgement are required' });
-        }
-        if (!mgmt.VALID_RISK_LEVELS.includes(risk)) {
-          return json(res, 400, { error: 'risk must be low, medium, or high' });
-        }
-        const sa = payload.suggestedAction;
-        if (!sa || !mgmt.VALID_ACTION_TYPES.includes(sa.type)) {
-          return json(res, 400, { error: 'suggestedAction.type must be controls_patch, dispatch_hint, lesson_write, set_pipeline, or noop' });
-        }
-        const board = helpers.readBoard();
-        mgmt.ensureEvolutionFields(board);
-        const insight = {
-          id: helpers.uid('ins'),
-          ts: helpers.nowIso(),
-          by,
-          about: payload.about || null,
-          judgement,
-          reasoning: payload.reasoning || null,
-          suggestedAction: sa,
-          risk,
-          status: 'pending',
-          snapshot: null,
-          appliedAt: null,
-          verifyAfter: payload.verifyAfter || 3,
-        };
-        if (payload.data && typeof payload.data === 'object') insight.data = payload.data;
-        board.insights.push(insight);
-        mgmt.autoApplyInsights(board);
-        helpers.writeBoard(board);
-        json(res, 201, { ok: true, insight });
-      } catch (error) {
-        json(res, 400, { error: error.message });
+    helpers.parseBody(req).then(payload => {
+      const by = String(payload.by || '').trim();
+      const judgement = String(payload.judgement || '').trim();
+      const risk = String(payload.risk || '').trim();
+      if (!by || !judgement) {
+        return json(res, 400, { error: 'by, judgement are required' });
       }
-    });
+      if (!mgmt.VALID_RISK_LEVELS.includes(risk)) {
+        return json(res, 400, { error: 'risk must be low, medium, or high' });
+      }
+      const sa = payload.suggestedAction;
+      if (!sa || !mgmt.VALID_ACTION_TYPES.includes(sa.type)) {
+        return json(res, 400, { error: 'suggestedAction.type must be controls_patch, dispatch_hint, lesson_write, set_pipeline, or noop' });
+      }
+      const board = helpers.readBoard();
+      mgmt.ensureEvolutionFields(board);
+      const insight = {
+        id: helpers.uid('ins'),
+        ts: helpers.nowIso(),
+        by,
+        about: payload.about || null,
+        judgement,
+        reasoning: payload.reasoning || null,
+        suggestedAction: sa,
+        risk,
+        status: 'pending',
+        snapshot: null,
+        appliedAt: null,
+        verifyAfter: payload.verifyAfter || 3,
+      };
+      if (payload.data && typeof payload.data === 'object') insight.data = payload.data;
+      board.insights.push(insight);
+      mgmt.autoApplyInsights(board);
+      helpers.writeBoard(board);
+      json(res, 201, { ok: true, insight });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
@@ -218,75 +204,61 @@ module.exports = function evolutionRoutes(req, res, helpers, deps) {
   }
 
   if (req.method === 'POST' && req.url === '/api/lessons') {
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
-        const by = String(payload.by || '').trim();
-        const rule = String(payload.rule || '').trim();
-        if (!by || !rule) {
-          return json(res, 400, { error: 'by, rule are required' });
-        }
-        const board = helpers.readBoard();
-        mgmt.ensureEvolutionFields(board);
-        const lesson = {
-          id: helpers.uid('les'),
-          ts: helpers.nowIso(),
-          by,
-          fromInsight: payload.fromInsight || null,
-          rule,
-          effect: payload.effect || null,
-          status: payload.status || 'active',
-          validatedAt: null,
-          supersededBy: null,
-        };
-        board.lessons.push(lesson);
-        // Archive overflow: if > 100, move invalidated/superseded to archive
-        if (board.lessons.length > 100) {
-          const archived = board.lessons.filter(l => l.status === 'invalidated' || l.status === 'superseded');
-          if (archived.length > 0) {
-            board.lessons_archive = board.lessons_archive || [];
-            board.lessons_archive.push(...archived);
-            board.lessons = board.lessons.filter(l => l.status !== 'invalidated' && l.status !== 'superseded');
-          }
-        }
-        helpers.writeBoard(board);
-        json(res, 201, { ok: true, lesson });
-      } catch (error) {
-        json(res, 400, { error: error.message });
+    helpers.parseBody(req).then(payload => {
+      const by = String(payload.by || '').trim();
+      const rule = String(payload.rule || '').trim();
+      if (!by || !rule) {
+        return json(res, 400, { error: 'by, rule are required' });
       }
-    });
+      const board = helpers.readBoard();
+      mgmt.ensureEvolutionFields(board);
+      const lesson = {
+        id: helpers.uid('les'),
+        ts: helpers.nowIso(),
+        by,
+        fromInsight: payload.fromInsight || null,
+        rule,
+        effect: payload.effect || null,
+        status: payload.status || 'active',
+        validatedAt: null,
+        supersededBy: null,
+      };
+      board.lessons.push(lesson);
+      // Archive overflow: if > 100, move invalidated/superseded to archive
+      if (board.lessons.length > 100) {
+        const archived = board.lessons.filter(l => l.status === 'invalidated' || l.status === 'superseded');
+        if (archived.length > 0) {
+          board.lessons_archive = board.lessons_archive || [];
+          board.lessons_archive.push(...archived);
+          board.lessons = board.lessons.filter(l => l.status !== 'invalidated' && l.status !== 'superseded');
+        }
+      }
+      helpers.writeBoard(board);
+      json(res, 201, { ok: true, lesson });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
   const lessonStatusMatch = req.url.match(/^\/api\/lessons\/([^/]+)\/status$/);
   if (req.method === 'POST' && lessonStatusMatch) {
     const lessonId = decodeURIComponent(lessonStatusMatch[1]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
-        const newStatus = String(payload.status || '').trim();
-        if (!mgmt.VALID_LESSON_STATUSES.includes(newStatus)) {
-          return json(res, 400, { error: 'status must be active, validated, invalidated, or superseded' });
-        }
-        const board = helpers.readBoard();
-        mgmt.ensureEvolutionFields(board);
-        const lesson = board.lessons.find(l => l.id === lessonId);
-        if (!lesson) return json(res, 404, { error: `Lesson ${lessonId} not found` });
-        lesson.status = newStatus;
-        if (newStatus === 'validated') lesson.validatedAt = helpers.nowIso();
-        if (newStatus === 'superseded' && payload.supersededBy) {
-          lesson.supersededBy = payload.supersededBy;
-        }
-        helpers.writeBoard(board);
-        json(res, 200, { ok: true, lesson });
-      } catch (error) {
-        json(res, 400, { error: error.message });
+    helpers.parseBody(req).then(payload => {
+      const newStatus = String(payload.status || '').trim();
+      if (!mgmt.VALID_LESSON_STATUSES.includes(newStatus)) {
+        return json(res, 400, { error: 'status must be active, validated, invalidated, or superseded' });
       }
-    });
+      const board = helpers.readBoard();
+      mgmt.ensureEvolutionFields(board);
+      const lesson = board.lessons.find(l => l.id === lessonId);
+      if (!lesson) return json(res, 404, { error: `Lesson ${lessonId} not found` });
+      lesson.status = newStatus;
+      if (newStatus === 'validated') lesson.validatedAt = helpers.nowIso();
+      if (newStatus === 'superseded' && payload.supersededBy) {
+        lesson.supersededBy = payload.supersededBy;
+      }
+      helpers.writeBoard(board);
+      json(res, 200, { ok: true, lesson });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 

--- a/server/routes/github.js
+++ b/server/routes/github.js
@@ -34,9 +34,16 @@ module.exports = function githubRoutes(req, res, helpers, deps) {
   // =========================================================================
   if (req.method === 'POST' && req.url === '/api/webhooks/github') {
     if (!githubIntegration) { json(res, 404, { error: 'GitHub integration not available' }); return; }
+    // Manual body read with size guard (needs raw string for HMAC verification)
     let body = '';
-    req.on('data', c => (body += c));
+    let received = 0;
+    req.on('data', c => {
+      received += c.length;
+      if (received > 1048576) { req.destroy(); return; }
+      body += c;
+    });
     req.on('end', () => {
+      if (received > 1048576) return json(res, 413, { error: 'Payload too large' });
       try {
         // HMAC verification — secret from vault, not board
         const secretBuf = vault.has('default', 'github_webhook_secret')
@@ -316,27 +323,19 @@ module.exports = function githubRoutes(req, res, helpers, deps) {
   // PUT /api/integrations/github — update GitHub integration config
   // =========================================================================
   if (req.method === 'PUT' && req.url === '/api/integrations/github') {
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
-
-        // Webhook secret → vault (never stored in board.json)
-        if (payload.webhookSecret) {
-          vault.store('default', 'github_webhook_secret', payload.webhookSecret);
-          delete payload.webhookSecret;
-        }
-
-        const board = helpers.readBoard();
-        board.integrations = board.integrations || {};
-        board.integrations.github = { ...(board.integrations.github || {}), ...payload };
-        helpers.writeBoard(board);
-        json(res, 200, { ...board.integrations.github, webhookSecretConfigured: vault.has('default', 'github_webhook_secret') });
-      } catch (err) {
-        json(res, 400, { error: err.message });
+    helpers.parseBody(req).then(payload => {
+      // Webhook secret → vault (never stored in board.json)
+      if (payload.webhookSecret) {
+        vault.store('default', 'github_webhook_secret', payload.webhookSecret);
+        delete payload.webhookSecret;
       }
-    });
+
+      const board = helpers.readBoard();
+      board.integrations = board.integrations || {};
+      board.integrations.github = { ...(board.integrations.github || {}), ...payload };
+      helpers.writeBoard(board);
+      json(res, 200, { ...board.integrations.github, webhookSecretConfigured: vault.has('default', 'github_webhook_secret') });
+    }).catch(err => json(res, err.statusCode === 413 ? 413 : 400, { error: err.message }));
     return;
   }
 

--- a/server/routes/jira.js
+++ b/server/routes/jira.js
@@ -16,11 +16,7 @@ module.exports = function jiraRoutes(req, res, helpers, deps) {
   // POST /api/webhooks/jira — receive Jira webhook
   if (req.method === 'POST' && req.url.startsWith('/api/webhooks/jira')) {
     if (!jiraIntegration) { json(res, 404, { error: 'Jira integration not available' }); return; }
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(payload => {
         const board = helpers.readBoard();
         const result = jiraIntegration.handleWebhook(board, payload, req.url);
 
@@ -208,10 +204,7 @@ module.exports = function jiraRoutes(req, res, helpers, deps) {
           return;
         }
         json(res, 200, { ok: true, action: result.action });
-      } catch (err) {
-        json(res, 400, { error: err.message });
-      }
-    });
+    }).catch(err => json(res, err.statusCode === 413 ? 413 : 400, { error: err.message }));
     return;
   }
 
@@ -225,20 +218,13 @@ module.exports = function jiraRoutes(req, res, helpers, deps) {
 
   // POST /api/integrations/jira — update Jira config
   if (req.method === 'POST' && req.url === '/api/integrations/jira') {
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
-        const board = helpers.readBoard();
-        board.integrations = board.integrations || {};
-        board.integrations.jira = { ...(board.integrations.jira || {}), ...payload };
-        helpers.writeBoard(board);
-        json(res, 200, board.integrations.jira);
-      } catch (err) {
-        json(res, 400, { error: err.message });
-      }
-    });
+    helpers.parseBody(req).then(payload => {
+      const board = helpers.readBoard();
+      board.integrations = board.integrations || {};
+      board.integrations.jira = { ...(board.integrations.jira || {}), ...payload };
+      helpers.writeBoard(board);
+      json(res, 200, board.integrations.jira);
+    }).catch(err => json(res, err.statusCode === 413 ? 413 : 400, { error: err.message }));
     return;
   }
 

--- a/server/routes/projects.js
+++ b/server/routes/projects.js
@@ -128,11 +128,7 @@ module.exports = function projectsRoutes(req, res, helpers, deps) {
     if (req.url === '/api/project') {
       helpers.appendLog({ ts: helpers.nowIso(), event: 'deprecated_api', endpoint: '/api/project', message: 'Use POST /api/projects instead' });
     }
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const input = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(input => {
         const { title, repo, concurrency, completionTrigger, autoStart } = input;
         const rawTasks = input.tasks;
 
@@ -311,10 +307,7 @@ module.exports = function projectsRoutes(req, res, helpers, deps) {
         }
 
         json(res, 201, result);
-      } catch (error) {
-        json(res, 400, { error: error.message });
-      }
-    });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -697,11 +697,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
   }
 
   if (req.method === 'POST' && req.url === '/api/tasks') {
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(payload => {
         const board = helpers.readBoard();
 
         // Merge into existing taskPlan (never overwrite running tasks)
@@ -767,21 +763,14 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         }
 
         json(res, 200, { ok: true, taskPlan: board.taskPlan });
-      } catch (error) {
-        json(res, 400, { error: error.message });
-      }
-    });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
   const taskUpdateMatch = req.url.match(/^\/api\/tasks\/([^/]+)\/update$/);
   if (req.method === 'POST' && taskUpdateMatch) {
     const taskId = decodeURIComponent(taskUpdateMatch[1]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(payload => {
         const board = helpers.readBoard();
         const task = (board.taskPlan?.tasks || []).find(t => t.id === taskId);
 
@@ -945,21 +934,14 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         }
 
         json(res, 200, { ok: true, task });
-      } catch (error) {
-        json(res, 400, { error: error.message });
-      }
-    });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
   const unblockMatch = req.url.match(/^\/api\/tasks\/([^/]+)\/unblock$/);
   if (req.method === 'POST' && unblockMatch) {
     const taskId = decodeURIComponent(unblockMatch[1]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(payload => {
         const message = String(payload.message || '').trim();
         if (!message) return json(res, 400, { error: 'message is required to unblock' });
 
@@ -1007,21 +989,14 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         }
 
         json(res, 200, { ok: true, task });
-      } catch (error) {
-        json(res, 400, { error: error.message });
-      }
-    });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
   const reopenMatch = req.url.match(/^\/api\/tasks\/([^/]+)\/reopen$/);
   if (req.method === 'POST' && reopenMatch) {
     const taskId = decodeURIComponent(reopenMatch[1]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(payload => {
         const message = String(payload.message || '').trim();
         const customSteps = payload.steps;
         
@@ -1090,10 +1065,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
             dispatched: result.dispatched
           }
         });
-      } catch (error) {
-        json(res, 400, { error: error.message });
-      }
-    });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
@@ -1102,11 +1074,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
   if (req.method === 'POST' && taskCancelMatch) {
     if (requireRole(req, res, 'operator')) return;
     const taskId = decodeURIComponent(taskCancelMatch[1]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(payload => {
         const reason = String(payload.reason || '').trim();
         const board = helpers.readBoard();
         const task = (board.taskPlan?.tasks || []).find(t => t.id === taskId);
@@ -1184,10 +1152,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
             worktreeCleanup: cancelMeta.worktreeCleanup,
           },
         });
-      } catch (error) {
-        json(res, 400, { error: error.message });
-      }
-    });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
@@ -1196,11 +1161,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
   if (req.method === 'POST' && taskStatusMatch) {
     if (requireRole(req, res, 'operator')) return;
     const taskId = decodeURIComponent(taskStatusMatch[1]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(payload => {
         const newStatus = String(payload.status || '').trim();
         const validStatuses = ['pending', 'dispatched', 'in_progress', 'blocked', 'completed', 'reviewing', 'approved', 'needs_revision', 'cancelled'];
         if (!validStatuses.includes(newStatus)) {
@@ -1372,10 +1333,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         }
 
         json(res, 200, { ok: true, task });
-      } catch (error) {
-        json(res, 400, { error: error.message });
-      }
-    });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
@@ -1386,11 +1344,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
   // POST /api/tasks/:id/steps — create step pipeline for a task
   if (req.method === 'POST' && stepsCreateMatch) {
     const taskId = decodeURIComponent(stepsCreateMatch[1]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(payload => {
         const runId = payload.run_id || helpers.uid('run');
         const pipeline = payload.pipeline || null;
         const board = helpers.readBoard();
@@ -1406,10 +1360,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         helpers.writeBoard(board);
         helpers.appendLog({ ts: helpers.nowIso(), event: 'steps_created', taskId, runId, count: task.steps.length });
         json(res, 200, { ok: true, taskId, runId, steps: task.steps });
-      } catch (error) {
-        json(res, 400, { error: error.message });
-      }
-    });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
@@ -1428,11 +1379,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
   if (req.method === 'PATCH' && stepUpdateMatch) {
     const taskId = decodeURIComponent(stepUpdateMatch[1]);
     const stepId = decodeURIComponent(stepUpdateMatch[2]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(payload => {
         const newState = String(payload.state || '').trim();
         if (!newState) return json(res, 400, { error: 'state is required' });
 
@@ -1480,10 +1427,9 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         }
 
         json(res, 200, { ok: true, taskId, step });
-      } catch (error) {
-        const status = error.code === 'INVALID_STEP_TRANSITION' ? 400 : 500;
+    }).catch(error => {
+        const status = error.statusCode === 413 ? 413 : (error.code === 'INVALID_STEP_TRANSITION' ? 400 : 500);
         json(res, status, { error: error.message });
-      }
     });
     return;
   }
@@ -1597,11 +1543,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
   if (req.method === 'POST' && batchDispatchMatch) {
     if (requireRole(req, res, 'operator')) return;
     const taskId = decodeURIComponent(batchDispatchMatch[1]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', async () => {
-      try {
-        const payload = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(async payload => {
         const board = helpers.readBoard();
         const task = (board.taskPlan?.tasks || []).find(t => t.id === taskId);
         if (!task) return json(res, 404, { error: `Task ${taskId} not found` });
@@ -1666,10 +1608,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
           }
         }
         json(res, 200, { ok: true, taskId, dispatched: targets.length, results });
-      } catch (error) {
-        json(res, 500, { error: error.message });
-      }
-    });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 500, { error: error.message }));
     return;
   }
 
@@ -1995,11 +1934,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
   // PUT /api/pipeline-templates/:name — create or update a template
   if (req.method === 'PUT' && templatesMatch && templatesMatch[1]) {
     const name = decodeURIComponent(templatesMatch[1]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(payload => {
         const pipeline = payload.pipeline;
         if (!Array.isArray(pipeline) || pipeline.length === 0) {
           return json(res, 400, { error: 'pipeline must be a non-empty array' });
@@ -2019,10 +1954,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
         mgmt.trimSignals(board, helpers.signalArchivePath);
         helpers.writeBoard(board);
         json(res, 200, { ok: true, name, pipeline: normalized });
-      } catch (error) {
-        json(res, 400, { error: error.message });
-      }
-    });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
@@ -2049,11 +1981,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
   const taskRollbackMatch = req.url.match(/^\/api\/tasks\/([^/]+)\/rollback$/);
   if (req.method === 'POST' && taskRollbackMatch) {
     const taskId = decodeURIComponent(taskRollbackMatch[1]);
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(payload => {
         const reason = String(payload.reason || '').trim();
         const board = helpers.readBoard();
         const task = (board.taskPlan?.tasks || []).find(t => t.id === taskId);
@@ -2177,10 +2105,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
             reason: reason || null,
           },
         });
-      } catch (error) {
-        json(res, 400, { error: error.message });
-      }
-    });
+    }).catch(error => json(res, error.statusCode === 413 ? 413 : 400, { error: error.message }));
     return;
   }
 
@@ -2200,11 +2125,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
   // --- POST /api/tasks/cleanup — batch remove tasks by status/age ---
   if (req.method === 'POST' && req.url === '/api/tasks/cleanup') {
     if (requireRole(req, res, 'admin')) return;
-    let body = '';
-    req.on('data', c => (body += c));
-    req.on('end', () => {
-      try {
-        const payload = JSON.parse(body || '{}');
+    helpers.parseBody(req).then(payload => {
         const statuses = payload.statuses || ['cancelled', 'blocked'];
         const olderThanHours = payload.older_than_hours || 0;
         const board = helpers.readBoard();
@@ -2235,10 +2156,7 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
           helpers.broadcastSSE('board', board);
         }
         json(res, 200, { removed: removedIds, count: removedIds.length });
-      } catch (err) {
-        json(res, 500, { error: err.message });
-      }
-    });
+    }).catch(err => json(res, err.statusCode === 413 ? 413 : 500, { error: err.message }));
     return;
   }
 


### PR DESCRIPTION
## Summary
- Replace manual `req.on('data')` + `req.on('end')` body parsing in **9 route files** (27 handlers total) with `helpers.parseBody(req)`, which enforces a 1MB body size guard
- Add `PATCH` to the `Content-Length` fast-reject check in `blackboard-server.js`
- GitHub webhook handler retains manual parsing for HMAC verification but adds an inline 1MB size guard

## Affected Files
- `server/blackboard-server.js` — PATCH added to Content-Length check
- `server/routes/briefs.js` — 2 handlers (PATCH, PUT)
- `server/routes/chat.js` — 3 handlers (conversations, participants, send)
- `server/routes/controls.js` — 1 handler (POST controls)
- `server/routes/edda.js` — 1 handler (propose-controls)
- `server/routes/evolution.js` — 4 handlers (signals, insights, lessons, lesson status)
- `server/routes/github.js` — 2 handlers (webhook with inline guard, PUT config)
- `server/routes/jira.js` — 2 handlers (webhook, config)
- `server/routes/projects.js` — 1 handler (POST projects)
- `server/routes/tasks.js` — 13 handlers (tasks CRUD, steps, dispatch-batch, templates, rollback, cleanup)

## Test plan
- [x] `node --check` passes on all 10 modified files
- [x] `npm test` (evolution loop integration test) passes
- [ ] Manual: send >1MB payload to a previously unprotected route, verify 413 response

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)