### PR TITLE
test: rewrite D/C-grade tests as real integration tests

### DIFF
--- a/server/test-dispatch-sections.js
+++ b/server/test-dispatch-sections.js
@@ -149,8 +149,7 @@ async function runTests() {
     if (dispatchRes.ok || dispatchRes.dispatched) {
       ok('Task dispatch accepted');
     } else {
-      // Dispatch may fail if runtime not available, but brief should still be generated
-      ok('Dispatch attempted: ' + JSON.stringify(dispatchRes).slice(0, 80));
+      fail('Task dispatch', 'dispatch not accepted: ' + JSON.stringify(dispatchRes).slice(0, 80));
     }
 
     // Check if brief was generated in the data dir or briefs dir
@@ -165,20 +164,20 @@ async function runTests() {
         if (briefContent.includes('Coding Standards') || briefContent.includes('coding_standards')) {
           ok('Brief contains skill context section');
         } else {
-          ok('Brief generated (skill context format may vary)');
+          console.warn('  ⚠ Brief generated but skill context format not matched');
         }
 
         // Verify completion criteria section
         if (briefContent.includes('Completion Criteria') || briefContent.includes('node -c') || briefContent.includes('Re-read')) {
           ok('Brief contains completion criteria section');
         } else {
-          ok('Brief generated (completion criteria format may vary)');
+          console.warn('  ⚠ Brief generated but completion criteria format not matched');
         }
       } else {
-        ok('Briefs directory exists but brief may use different naming');
+        fail('Brief file', 'briefs directory exists but no matching brief for T-SECTION-TEST');
       }
     } else {
-      ok('Brief written to alternative location (step-worker handles brief)');
+      console.warn('  ⚠ Briefs directory not found (brief may be written by step-worker)');
     }
   }
 

--- a/server/test-step-concurrency.js
+++ b/server/test-step-concurrency.js
@@ -179,11 +179,10 @@ async function runTests() {
       } else if (planResult && planResult.status === 'dispatched') {
         fail('Concurrency gate', 'plan step dispatched despite limit of 1');
       } else {
-        ok('Batch dispatch returned result: ' + JSON.stringify(planResult));
+        fail('Concurrency gate', 'unexpected batch result: ' + JSON.stringify(planResult));
       }
     } else {
-      // If batch dispatch is not available, try auto-dispatch approach
-      ok('Batch dispatch result: ' + JSON.stringify(res).slice(0, 100));
+      fail('Batch dispatch', 'unexpected response: ' + JSON.stringify(res).slice(0, 100));
     }
   }
 
@@ -200,10 +199,10 @@ async function runTests() {
       if (planResult && (planResult.status === 'dispatched' || planResult.status === 'skipped')) {
         ok('Task B plan dispatchable after A completed (status: ' + planResult.status + ')');
       } else {
-        ok('Batch dispatch completed: ' + JSON.stringify(planResult));
+        fail('Concurrency slot freed', 'unexpected plan result: ' + JSON.stringify(planResult));
       }
     } else {
-      ok('Batch dispatch result: ' + JSON.stringify(res).slice(0, 100));
+      fail('Batch dispatch after completion', 'unexpected response: ' + JSON.stringify(res).slice(0, 100));
     }
   }
 

--- a/server/test-step-observability.js
+++ b/server/test-step-observability.js
@@ -238,12 +238,12 @@ async function testStepProgressOnDispatch() {
     if (planStep.progress && planStep.progress.dispatched_at) {
       ok('Step progress has dispatched_at after dispatch');
     } else {
-      // Progress may be on the step or in the step-worker output
-      ok('Step transitioned to running/completed after dispatch (progress written by step-worker)');
+      console.warn('  ⚠ Step transitioned but progress.dispatched_at not set (set by step-worker)');
     }
+  } else if (planStep.state === 'queued') {
+    fail('Step dispatch', 'step still queued after dispatch — expected running or beyond');
   } else {
-    // queued is ok if dispatch hasn't fully processed yet
-    ok('Step in expected state after dispatch: ' + planStep.state);
+    fail('Step dispatch', `unexpected state: ${planStep.state}`);
   }
 }
 
@@ -292,8 +292,7 @@ async function testDeadLetterViaStepTransition() {
   if (deadSignals.length >= 1) {
     ok('Dead letter signal emitted');
   } else {
-    // step_dead signal may not be emitted by transition — acceptable
-    ok('Dead state reached (signal may be emitted by step-worker only)');
+    console.warn('  ⚠ No step_dead signal found (emitted by step-worker, not transition API)');
   }
 }
 
@@ -326,8 +325,7 @@ async function testActivityAwareLockRenewalViaAPI() {
     if (step.lock_expires_at) {
       ok('Step has lock_expires_at after running transition');
     } else {
-      // Lock expiry may be set by step-worker, not transition
-      ok('Step running (lock_expires_at set by step-worker)');
+      console.warn('  ⚠ lock_expires_at not set by transition (set by step-worker at runtime)');
     }
   } else {
     fail('Step transition to running', JSON.stringify(patchRes));

--- a/server/test-wave-dispatch.js
+++ b/server/test-wave-dispatch.js
@@ -160,9 +160,10 @@ async function runTests() {
     const w2 = tasks.find(t => t.id === 'T-WAVE-2');
     if (w2 && w2.status === 'dispatched') {
       ok('Wave 2 task NOT auto-dispatched when active_wave=1');
+    } else if (w2 && w2.status === 'in_progress') {
+      fail('Wave filter', `wave-2 task was dispatched (status: ${w2.status}) despite active_wave=1`);
     } else {
-      // It may have been dispatched if wave filter is not working — still report
-      ok(`Wave 2 task status: ${w2?.status} (wave filter applied)`);
+      fail('Wave filter', `unexpected wave-2 task status: ${w2?.status}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- **test-step-observability.js**: Removed Tests 2-5 that used `fs.readFileSync` to grep source code for keywords. Replaced with API-driven tests for step progress initialization, dead letter state via step exhaustion, and lock metadata visibility.
- **test-wave-dispatch.js**: Completely rewritten from inline logic duplication to HTTP integration tests. Now starts server, sets `active_wave` via `POST /api/controls`, creates tasks with different wave values, and verifies dispatch filtering behavior.
- **test-step-concurrency.js**: Removed direct imports of `countRunningStepsByType`/`canDispatchStepType` and self-written validation function. Now tests concurrency limits via `POST /api/controls` + batch dispatch endpoint.
- **test-dispatch-sections.js**: Removed always-pass cache timing test and direct module imports. Now verifies dispatch brief generation by dispatching a task and checking output.

All 4 files follow the `test-step-endpoints.js` pattern: start server with temp DATA_DIR, test via HTTP API, cleanup.

## Test plan
- [x] `node --check` passes on all 4 modified files
- [x] `npm test` passes (existing evolution loop tests unaffected)
- [ ] Run each test individually to verify they pass against a live server

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)