### PR TITLE
fix(board): add optimistic locking to high-frequency write paths

### DIFF
--- a/server/kernel.js
+++ b/server/kernel.js
@@ -15,6 +15,7 @@ const { verifyContract } = require('./village/deliverable-contracts');
 const worktreeHelper = require('./worktree');
 const { resolveRepoRoot } = require('./repo-resolver');
 const { createSignal } = require('./signal');
+const { retryOnConflict } = require('./helpers/retry');
 const path = require('path');
 
 /**
@@ -244,14 +245,22 @@ function createKernel(deps) {
         // Push notification
         if (push && PUSH_TOKENS_PATH && latestTask) {
           push.notifyTaskEvent(PUSH_TOKENS_PATH, latestTask, 'task.blocked')
-            .catch(err => {
+            .catch(async err => {
               console.error(`[kernel] push error for task ${taskId}, event task.blocked:`, err.message);
-              latestBoard.signals.push(createSignal({
-                by: 'kernel', type: 'push_failed',
-                content: `Push notification failed for ${taskId}: ${err.message}`,
-                refs: [taskId], data: { taskId, eventType: 'task.blocked', error: err.message },
-              }, helpers));
-              mgmt.trimSignals(latestBoard, helpers.signalArchivePath);
+              try {
+                await retryOnConflict(async () => {
+                  const freshBoard = helpers.readBoard();
+                  freshBoard.signals.push(createSignal({
+                    by: 'kernel', type: 'push_failed',
+                    content: `Push notification failed for ${taskId}: ${err.message}`,
+                    refs: [taskId], data: { taskId, eventType: 'task.blocked', error: err.message },
+                  }, helpers));
+                  mgmt.trimSignals(freshBoard, helpers.signalArchivePath);
+                  helpers.writeBoard(freshBoard);
+                });
+              } catch (retryErr) {
+                console.error(`[kernel] push_failed signal write failed after retries:`, retryErr.message);
+              }
             });
         }
         return;
@@ -281,14 +290,22 @@ function createKernel(deps) {
         helpers.writeBoard(latestBoard);
         if (push && PUSH_TOKENS_PATH && latestTask) {
           push.notifyTaskEvent(PUSH_TOKENS_PATH, latestTask, 'task.blocked')
-            .catch(err => {
+            .catch(async err => {
               console.error(`[kernel] push error for task ${taskId}, event task.blocked:`, err.message);
-              latestBoard.signals.push(createSignal({
-                by: 'kernel', type: 'push_failed',
-                content: `Push notification failed for ${taskId}: ${err.message}`,
-                refs: [taskId], data: { taskId, eventType: 'task.blocked', error: err.message },
-              }, helpers));
-              mgmt.trimSignals(latestBoard, helpers.signalArchivePath);
+              try {
+                await retryOnConflict(async () => {
+                  const freshBoard = helpers.readBoard();
+                  freshBoard.signals.push(createSignal({
+                    by: 'kernel', type: 'push_failed',
+                    content: `Push notification failed for ${taskId}: ${err.message}`,
+                    refs: [taskId], data: { taskId, eventType: 'task.blocked', error: err.message },
+                  }, helpers));
+                  mgmt.trimSignals(freshBoard, helpers.signalArchivePath);
+                  helpers.writeBoard(freshBoard);
+                });
+              } catch (retryErr) {
+                console.error(`[kernel] push_failed signal write failed after retries:`, retryErr.message);
+              }
             });
         }
         return;
@@ -387,27 +404,39 @@ function createKernel(deps) {
               const repoName = latestTask.pr.repo.split('/')[1];
               const commitTitle = `${latestTask.title || taskId} (#${number})`;
               githubApi.mergePR(pat, owner, repoName, number, commitTitle, 'squash')
-                .then(() => {
+                .then(async () => {
                   console.log(`[kernel] auto-merged PR #${number} for ${taskId}`);
-                  const freshBoard = helpers.readBoard();
-                  const freshTask = (freshBoard.taskPlan?.tasks || []).find(t => t.id === taskId);
-                  if (freshTask?.pr) {
-                    freshTask.pr.outcome = 'merged';
-                    freshTask.pr.mergedAt = helpers.nowIso();
-                    freshTask.pr.mergedBy = 'karvi-auto-merge';
-                    helpers.writeBoard(freshBoard);
+                  try {
+                    await retryOnConflict(async () => {
+                      const freshBoard = helpers.readBoard();
+                      const freshTask = (freshBoard.taskPlan?.tasks || []).find(t => t.id === taskId);
+                      if (freshTask?.pr) {
+                        freshTask.pr.outcome = 'merged';
+                        freshTask.pr.mergedAt = helpers.nowIso();
+                        freshTask.pr.mergedBy = 'karvi-auto-merge';
+                        helpers.writeBoard(freshBoard);
+                      }
+                    });
+                  } catch (retryErr) {
+                    console.error(`[kernel] auto-merge board update failed after retries:`, retryErr.message);
                   }
                 })
-                .catch(err => {
+                .catch(async err => {
                   console.error(`[kernel] auto-merge failed for PR #${number}:`, err.message);
-                  const freshBoard = helpers.readBoard();
-                  freshBoard.signals.push(createSignal({
-                    by: 'kernel', type: 'auto_merge_failed',
-                    content: `Auto-merge failed for ${taskId} PR #${number}: ${err.message}`,
-                    refs: [taskId], data: { taskId, prNumber: number, error: err.message },
-                  }, helpers));
-                  mgmt.trimSignals(freshBoard, helpers.signalArchivePath);
-                  helpers.writeBoard(freshBoard);
+                  try {
+                    await retryOnConflict(async () => {
+                      const freshBoard = helpers.readBoard();
+                      freshBoard.signals.push(createSignal({
+                        by: 'kernel', type: 'auto_merge_failed',
+                        content: `Auto-merge failed for ${taskId} PR #${number}: ${err.message}`,
+                        refs: [taskId], data: { taskId, prNumber: number, error: err.message },
+                      }, helpers));
+                      mgmt.trimSignals(freshBoard, helpers.signalArchivePath);
+                      helpers.writeBoard(freshBoard);
+                    });
+                  } catch (retryErr) {
+                    console.error(`[kernel] auto_merge_failed signal write failed after retries:`, retryErr.message);
+                  }
                 });
             }
           }
@@ -433,14 +462,22 @@ function createKernel(deps) {
 
         if (push && PUSH_TOKENS_PATH && latestTask) {
           push.notifyTaskEvent(PUSH_TOKENS_PATH, latestTask, 'task.completed')
-            .catch(err => {
+            .catch(async err => {
               console.error(`[kernel] push error for task ${taskId}, event task.completed:`, err.message);
-              latestBoard.signals.push(createSignal({
-                by: 'kernel', type: 'push_failed',
-                content: `Push notification failed for ${taskId}: ${err.message}`,
-                refs: [taskId], data: { taskId, eventType: 'task.completed', error: err.message },
-              }, helpers));
-              mgmt.trimSignals(latestBoard, helpers.signalArchivePath);
+              try {
+                await retryOnConflict(async () => {
+                  const freshBoard = helpers.readBoard();
+                  freshBoard.signals.push(createSignal({
+                    by: 'kernel', type: 'push_failed',
+                    content: `Push notification failed for ${taskId}: ${err.message}`,
+                    refs: [taskId], data: { taskId, eventType: 'task.completed', error: err.message },
+                  }, helpers));
+                  mgmt.trimSignals(freshBoard, helpers.signalArchivePath);
+                  helpers.writeBoard(freshBoard);
+                });
+              } catch (retryErr) {
+                console.error(`[kernel] push_failed signal write failed after retries:`, retryErr.message);
+              }
             });
         }
 

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -16,7 +16,9 @@ const mgmt = require('./management');
 const { resolveRepoRoot } = require('./repo-resolver');
 const { runHook } = require('./hook-runner');
 const { createSignal } = require('./signal');
+const { retryOnConflict } = require('./helpers/retry');
 const LOCK_GRACE_MS = 30_000; // 30s grace on top of step timeout
+const HEARTBEAT_DEBOUNCE_MS = 10_000; // Debounce heartbeat writes to 10s interval
 
 // --- Webhook event emission (#333) — Event Envelope v1 contract ---
 function emitWebhookEvent(board, eventType, payload) {
@@ -245,24 +247,41 @@ function createStepWorker(deps) {
     } else {
       // 4. Dispatch with duration tracking (catch failures to transition step properly)
       //    Heartbeat callback: refresh lock while runtime is alive (prevents retry-poller conflicts)
-      plan.onActivity = () => {
+      //    Debounced to write once per HEARTBEAT_DEBOUNCE_MS instead of per-activity.
+      let lastHeartbeatWrite = 0;
+      let heartbeatPending = false;
+      const writeHeartbeat = async () => {
         try {
-          const hbBoard = helpers.readBoard();
-          const hbTask = (hbBoard.taskPlan?.tasks || []).find(t => t.id === envelope.task_id);
-          const hbStep = hbTask?.steps?.find(s => s.step_id === envelope.step_id);
-          if (hbStep && hbStep.state === 'running') {
-            hbStep.lock_expires_at = new Date(Date.now() + timeoutMs + LOCK_GRACE_MS).toISOString();
-            // Also update last_activity so retry-poller sees fresh activity
-            if (!hbStep.progress) hbStep.progress = {};
-            hbStep.progress.last_activity = new Date().toISOString();
-            helpers.writeBoard(hbBoard);
-            console.log(`[step-worker] heartbeat: ${envelope.step_id} lock renewed to +${Math.round(timeoutMs/1000)}s`);
-          } else {
-            console.log(`[step-worker] heartbeat: ${envelope.step_id} skipped (state=${hbStep?.state} found=${!!hbStep})`);
-          }
+          await retryOnConflict(async () => {
+            const hbBoard = helpers.readBoard();
+            const hbTask = (hbBoard.taskPlan?.tasks || []).find(t => t.id === envelope.task_id);
+            const hbStep = hbTask?.steps?.find(s => s.step_id === envelope.step_id);
+            if (hbStep && hbStep.state === 'running') {
+              hbStep.lock_expires_at = new Date(Date.now() + timeoutMs + LOCK_GRACE_MS).toISOString();
+              if (!hbStep.progress) hbStep.progress = {};
+              hbStep.progress.last_activity = new Date().toISOString();
+              helpers.writeBoard(hbBoard);
+              console.log(`[step-worker] heartbeat: ${envelope.step_id} lock renewed to +${Math.round(timeoutMs/1000)}s`);
+            } else {
+              console.log(`[step-worker] heartbeat: ${envelope.step_id} skipped (state=${hbStep?.state} found=${!!hbStep})`);
+            }
+          });
         } catch (err) {
           console.log(`[step-worker] heartbeat error: ${envelope.step_id}: ${err.message}`);
         }
+        heartbeatPending = false;
+      };
+      plan.onActivity = () => {
+        const now = Date.now();
+        if (now - lastHeartbeatWrite < HEARTBEAT_DEBOUNCE_MS) {
+          if (!heartbeatPending) {
+            heartbeatPending = true;
+            setTimeout(writeHeartbeat, HEARTBEAT_DEBOUNCE_MS - (now - lastHeartbeatWrite));
+          }
+          return;
+        }
+        lastHeartbeatWrite = now;
+        writeHeartbeat();
       };
 
       // Progress callback: write granular progress to step metadata (throttled)
@@ -270,45 +289,49 @@ function createStepWorker(deps) {
       let lastProgressWrite = 0;
       const startMs = Date.now();
 
-      plan.onProgress = (event) => {
+      plan.onProgress = async (event) => {
         const now = Date.now();
         if (now - lastProgressWrite < PROGRESS_THROTTLE_MS) return;
         lastProgressWrite = now;
         try {
-          const pgBoard = helpers.readBoard();
-          const pgTask = (pgBoard.taskPlan?.tasks || []).find(t => t.id === envelope.task_id);
-          const pgStep = pgTask?.steps?.find(s => s.step_id === envelope.step_id);
-          if (!pgStep || pgStep.state !== 'running') return;
-          pgStep.progress = {
-            tool_calls: event.tool_calls || 0,
-            tokens: event.tokens || null,
-            last_tool: event.tool_name || null,
-            last_activity: new Date(now).toISOString(),
-            elapsed_ms: now - startMs,
-          };
-          helpers.writeBoard(pgBoard);
+          await retryOnConflict(async () => {
+            const pgBoard = helpers.readBoard();
+            const pgTask = (pgBoard.taskPlan?.tasks || []).find(t => t.id === envelope.task_id);
+            const pgStep = pgTask?.steps?.find(s => s.step_id === envelope.step_id);
+            if (!pgStep || pgStep.state !== 'running') return;
+            pgStep.progress = {
+              tool_calls: event.tool_calls || 0,
+              tokens: event.tokens || null,
+              last_tool: event.tool_name || null,
+              last_activity: new Date(now).toISOString(),
+              elapsed_ms: now - startMs,
+            };
+            helpers.writeBoard(pgBoard);
+          });
         } catch (err) {
           console.error(`[step-worker] onProgress write failed for ${envelope.step_id}:`, err.message);
         }
       };
       // Write initial progress before spawn (so progress is never undefined)
       try {
-        const initBoard = helpers.readBoard();
-        const initTask = (initBoard.taskPlan?.tasks || []).find(t => t.id === envelope.task_id);
-        const initStep = initTask?.steps?.find(s => s.step_id === envelope.step_id);
-        if (initStep && initStep.state === 'running') {
-          initStep.progress = {
-            tool_calls: 0,
-            tokens: null,
-            last_tool: null,
-            last_activity: new Date().toISOString(),
-            elapsed_ms: 0,
-            dispatched_at: new Date().toISOString(),
-            cwd: plan.workingDir || plan.cwd || null,
-            runtime: runtimeHint || 'unknown',
-          };
-          helpers.writeBoard(initBoard);
-        }
+        await retryOnConflict(async () => {
+          const initBoard = helpers.readBoard();
+          const initTask = (initBoard.taskPlan?.tasks || []).find(t => t.id === envelope.task_id);
+          const initStep = initTask?.steps?.find(s => s.step_id === envelope.step_id);
+          if (initStep && initStep.state === 'running') {
+            initStep.progress = {
+              tool_calls: 0,
+              tokens: null,
+              last_tool: null,
+              last_activity: new Date().toISOString(),
+              elapsed_ms: 0,
+              dispatched_at: new Date().toISOString(),
+              cwd: plan.workingDir || plan.cwd || null,
+              runtime: runtimeHint || 'unknown',
+            };
+            helpers.writeBoard(initBoard);
+          }
+        });
       } catch (err) {
         console.error(`[step-worker] initial progress write failed for ${envelope.step_id}:`, err.message);
       }


### PR DESCRIPTION
## Summary

- Wrap step-worker heartbeat with `retryOnConflict()` and debounce to 10s interval
- Wrap step-worker `onProgress` with `retryOnConflict()`
- Wrap kernel push callback signal writes with `retryOnConflict()` (re-read board before write)

## Problem

Multiple concurrent read-modify-write cycles on board.json create lost-update race conditions:
- step-worker heartbeat (every activity event)
- step-worker onProgress (every 10s)
- kernel push notification callbacks

The storage-json.js already has optimistic locking (version field), but callers were not consistently using `retryOnConflict()`.

## Changes

### step-worker.js
1. Added import for `retryOnConflict` helper
2. Added `HEARTBEAT_DEBOUNCE_MS = 10_000` constant
3. **Heartbeat callback**: Debounced to batch writes into single write per 10s interval, wrapped with `retryOnConflict()`
4. **onProgress callback**: Wrapped with `retryOnConflict()`
5. **Initial progress write**: Wrapped with `retryOnConflict()`

### kernel.js
1. Added import for `retryOnConflict` helper
2. **human_review push error callback**: Wrapped with `retryOnConflict()`, re-reads board before appending signal
3. **dead_letter push error callback**: Wrapped with `retryOnConflict()`, re-reads board before appending signal
4. **auto-merge success callback**: Wrapped with `retryOnConflict()`, re-reads board before updating
5. **auto-merge failure callback**: Wrapped with `retryOnConflict()`, re-reads board before appending signal
6. **done push error callback**: Wrapped with `retryOnConflict()`, re-reads board before appending signal

Closes #417