### PR TITLE
refactor(server): extract service-manager for background service lifecycle (#144)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -18,6 +18,7 @@ const push = require('./push');
 const { createScheduler } = require('./village/village-scheduler');
 const githubApi = require('./github-api');
 const usage = require('./usage');
+const { createServiceManager } = require('./service-manager');
 
 const vault = require('./vault').createVault({ vaultDir: path.join(__dirname, 'vaults') });
 
@@ -193,6 +194,11 @@ const server = bb.createServer(ctx, (req, res, helpers) => {
     if (result !== false) return;
   }
 
+  // GET /api/services/status — background service health
+  if (req.method === 'GET' && req.url === '/api/services/status') {
+    return json(res, 200, serviceManager.status());
+  }
+
   // POST /api/shutdown — graceful shutdown (critical for Windows where SIGTERM kills immediately)
   if (req.method === 'POST' && req.url === '/api/shutdown') {
     // Admin-only: shutdown requires highest privilege
@@ -267,9 +273,14 @@ if (migrationResult.dirty) {
   writeBoard(initBoard);
 }
 
-// --- Retry poller: re-dispatch steps stuck in queued with past scheduled_at ---
+// --- Service Manager: 統一管理所有 background services ---
+const serviceManager = createServiceManager();
+deps.serviceManager = serviceManager;
+
+// 1. Retry poller: re-dispatch steps stuck in queued with past scheduled_at
 const RETRY_POLL_MS = 10_000;
-const retryPoller = setInterval(() => {
+let retryPollerTimer = null;
+function retryPollerTick() {
   try {
     const board = readBoard();
     const now = new Date().toISOString();
@@ -334,14 +345,20 @@ const retryPoller = setInterval(() => {
   } catch (err) {
     console.error('[retry-poller] error:', err.message);
   }
-}, RETRY_POLL_MS);
+}
+serviceManager.register('retry-poller', {
+  start() { retryPollerTimer = setInterval(retryPollerTick, RETRY_POLL_MS); },
+  stop() { clearInterval(retryPollerTimer); retryPollerTimer = null; },
+  healthCheck() { return retryPollerTimer !== null; },
+});
 
-// --- TTL cleanup: auto-remove stale terminal tasks ---
+// 2. TTL cleanup: auto-remove stale terminal tasks
 const CLEANUP_POLL_MS = 60_000;
 const TTL_CANCELLED_MS = 1 * 3600_000;       // 1 hour
 const TTL_BLOCKED_DEAD_MS = 6 * 3600_000;    // 6 hours
 const TTL_APPROVED_MS = 24 * 3600_000;        // 24 hours
-const cleanupPoller = setInterval(() => {
+let cleanupPollerTimer = null;
+function cleanupPollerTick() {
   try {
     const board = readBoard();
     const tasks = board.taskPlan?.tasks || [];
@@ -398,46 +415,52 @@ const cleanupPoller = setInterval(() => {
   } catch (err) {
     console.error('[cleanup] error:', err.message);
   }
-}, CLEANUP_POLL_MS);
-
-// --- Telemetry init ---
-let telemetryHandle;
-try {
-  telemetryHandle = telemetry.init({
-    dataDir: DATA_DIR,
-    readBoard,
-  });
-} catch (err) {
-  console.warn(`[telemetry] init failed, continuing without telemetry: ${err.message}`);
 }
+serviceManager.register('cleanup-poller', {
+  start() { cleanupPollerTimer = setInterval(cleanupPollerTick, CLEANUP_POLL_MS); },
+  stop() { clearInterval(cleanupPollerTimer); cleanupPollerTimer = null; },
+  healthCheck() { return cleanupPollerTimer !== null; },
+});
 
-// --- Usage tracking init ---
-let usageHandle;
-try {
-  usageHandle = usage.init({
-    dataDir: DATA_DIR,
-    broadcastSSE,
-    readBoard,
-  });
-  // SSE connection tracking callback
-  ctx.onSSEDisconnect = ({ minutes }) => {
-    usage.record('default', 'sse.connect', { sessionMinutes: minutes });
-  };
-} catch (err) {
-  console.warn(`[usage] init failed, continuing without usage tracking: ${err.message}`);
-}
+// 3. Telemetry
+let telemetryHandle = null;
+serviceManager.register('telemetry', {
+  start() {
+    telemetryHandle = telemetry.init({ dataDir: DATA_DIR, readBoard });
+  },
+  stop() { telemetryHandle?.stop(); },
+  healthCheck() { return telemetryHandle && !telemetryHandle.disabled; },
+});
 
-// --- Village Scheduler (Cadence Engine) ---
+// 4. Usage tracking
+let usageHandle = null;
+serviceManager.register('usage-tracking', {
+  start() {
+    usageHandle = usage.init({ dataDir: DATA_DIR, broadcastSSE, readBoard });
+    ctx.onSSEDisconnect = ({ minutes }) => {
+      usage.record('default', 'sse.connect', { sessionMinutes: minutes });
+    };
+  },
+  stop() { usageHandle?.stop(); },
+  healthCheck() { return usageHandle !== null; },
+});
+
+// 5. Village Scheduler (Cadence Engine)
 let villageScheduler = null;
-try {
-  villageScheduler = createScheduler({
-    helpers: routeHelpers,
-    tryAutoDispatch: (taskId) => deps.tryAutoDispatch && deps.tryAutoDispatch(taskId),
-  });
-  villageScheduler.start();
-} catch (err) {
-  console.warn(`[village-scheduler] init failed, continuing without scheduler: ${err.message}`);
-}
+serviceManager.register('village-scheduler', {
+  start() {
+    villageScheduler = createScheduler({
+      helpers: routeHelpers,
+      tryAutoDispatch: (taskId) => deps.tryAutoDispatch && deps.tryAutoDispatch(taskId),
+    });
+    villageScheduler.start();
+  },
+  stop() { villageScheduler?.stop(); },
+  healthCheck() { return villageScheduler !== null; },
+});
+
+// --- Start all background services ---
+serviceManager.startAll();
 
 // --- Graceful Shutdown with Request Draining ---
 let inFlightRequests = 0;
@@ -445,11 +468,7 @@ const DRAIN_TIMEOUT_MS = 30000;
 
 function gracefulShutdown() {
   console.log('[server] shutting down...');
-  clearInterval(retryPoller);
-  clearInterval(cleanupPoller);
-  villageScheduler?.stop();
-  telemetryHandle?.stop();
-  usageHandle?.stop();
+  serviceManager.stopAll();
 
   if (inFlightRequests === 0) {
     server.close(() => process.exit(0));

--- a/server/service-manager.js
+++ b/server/service-manager.js
@@ -1,0 +1,99 @@
+/**
+ * service-manager.js — 統一管理 background service 生命週期
+ *
+ * 所有 setInterval/setTimeout background tasks 註冊到這裡，
+ * 統一 start/stop/status，graceful shutdown 時一次關閉。
+ */
+
+class ServiceManager {
+  constructor() {
+    /** @type {Map<string, {start: Function, stop: Function, healthCheck?: Function, running: boolean, startedAt: string|null, error: string|null}>} */
+    this._services = new Map();
+  }
+
+  /**
+   * 註冊一個 background service。
+   * @param {string} name - 服務名稱（唯一）
+   * @param {{ start: Function, stop: Function, healthCheck?: Function }} handlers
+   */
+  register(name, handlers) {
+    if (this._services.has(name)) {
+      throw new Error(`Service "${name}" already registered`);
+    }
+    this._services.set(name, {
+      start: handlers.start,
+      stop: handlers.stop,
+      healthCheck: handlers.healthCheck || null,
+      running: false,
+      startedAt: null,
+      error: null,
+    });
+  }
+
+  /**
+   * 啟動所有已註冊的服務。
+   */
+  startAll() {
+    for (const [name, svc] of this._services) {
+      if (svc.running) continue;
+      try {
+        svc.start();
+        svc.running = true;
+        svc.startedAt = new Date().toISOString();
+        svc.error = null;
+        console.log(`[service-manager] started: ${name}`);
+      } catch (err) {
+        svc.error = err.message;
+        console.warn(`[service-manager] failed to start ${name}: ${err.message}`);
+      }
+    }
+  }
+
+  /**
+   * 停止所有已啟動的服務（反向順序，後註冊的先停）。
+   */
+  stopAll() {
+    const entries = [...this._services.entries()].reverse();
+    for (const [name, svc] of entries) {
+      if (!svc.running) continue;
+      try {
+        svc.stop();
+        svc.running = false;
+        console.log(`[service-manager] stopped: ${name}`);
+      } catch (err) {
+        console.warn(`[service-manager] error stopping ${name}: ${err.message}`);
+      }
+    }
+  }
+
+  /**
+   * 回傳所有服務的狀態。
+   * @returns {Object<string, {running: boolean, startedAt: string|null, healthy: boolean|null, error: string|null}>}
+   */
+  status() {
+    const result = {};
+    for (const [name, svc] of this._services) {
+      let healthy = null;
+      if (svc.running && svc.healthCheck) {
+        try {
+          healthy = !!svc.healthCheck();
+        } catch {
+          healthy = false;
+        }
+      }
+      result[name] = {
+        running: svc.running,
+        startedAt: svc.startedAt,
+        healthy,
+        error: svc.error,
+      };
+    }
+    return result;
+  }
+}
+
+function createServiceManager() {
+  return new ServiceManager();
+}
+
+module.exports = { createServiceManager };


### PR DESCRIPTION
## Summary
- Extract `server/service-manager.js` with `ServiceManager` class providing `register()`, `startAll()`, `stopAll()`, `status()` API
- Migrate 5 background services from scattered `setInterval`/init calls in `server.js` to unified service registration:
  1. **retry-poller** — re-dispatches steps stuck in queued (10s interval)
  2. **cleanup-poller** — TTL cleanup of stale terminal tasks (60s interval)
  3. **telemetry** — anonymous usage reporting (24h interval)
  4. **usage-tracking** — per-user resource usage tracking
  5. **village-scheduler** — cadence engine for scheduled meetings (1h interval)
- Add `GET /api/services/status` endpoint returning each service's running state, startedAt, health, and errors
- Graceful shutdown (`SIGTERM`/`SIGINT`) now calls `serviceManager.stopAll()` (reverse registration order)

## Test plan
- [x] `node --check server/service-manager.js` passes
- [x] `node --check server/server.js` passes
- [x] `npm test` — full integration test suite passes
- [ ] Manual: `curl localhost:3461/api/services/status` returns all 5 services as running

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)