### PR TITLE
fix(gateway): validate X-Forwarded-For header to prevent IP spoofing

### DIFF
--- a/server/gateway-proxy.js
+++ b/server/gateway-proxy.js
@@ -22,6 +22,74 @@ const HOP_BY_HOP = new Set([
 // Timeout for connecting to backend (ms)
 const CONNECT_TIMEOUT_MS = 10000;
 
+// Trusted proxies — comma-separated IPs/CIDRs from env
+// When set, only trust X-Forwarded-For if request comes from trusted proxy
+const TRUSTED_PROXIES = (process.env.KARVI_TRUSTED_PROXIES || '')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
+
+// IPv4 regex — matches valid IPv4 addresses (0-255 in each octet)
+const IPV4_REGEX = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+
+// IPv6 regex — matches full and abbreviated IPv6 addresses
+const IPV6_REGEX = /^(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}$|^(?:[A-Fa-f0-9]{1,4}:){1,7}:$|^(?:[A-Fa-f0-9]{1,4}:){1,6}:[A-Fa-f0-9]{1,4}$|^(?:[A-Fa-f0-9]{1,4}:){1,5}(?::[A-Fa-f0-9]{1,4}){1,2}$|^(?:[A-Fa-f0-9]{1,4}:){1,4}(?::[A-Fa-f0-9]{1,4}){1,3}$|^(?:[A-Fa-f0-9]{1,4}:){1,3}(?::[A-Fa-f0-9]{1,4}){1,4}$|^(?:[A-Fa-f0-9]{1,4}:){1,2}(?::[A-Fa-f0-9]{1,4}){1,5}$|^[A-Fa-f0-9]{1,4}:(?::[A-Fa-f0-9]{1,4}){1,6}$|^:(?::[A-Fa-f0-9]{1,4}){1,7}$|^::(?:[Ff]{4}:)?(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^(?:[A-Fa-f0-9]{1,4}:){1,4}:(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+
+function isValidIP(ip) {
+  if (!ip || typeof ip !== 'string') return false;
+  const trimmed = ip.trim();
+  if (!trimmed) return false;
+  return IPV4_REGEX.test(trimmed) || IPV6_REGEX.test(trimmed);
+}
+
+function ipMatchesCIDR(ip, cidr) {
+  if (!cidr.includes('/')) return ip === cidr;
+  const [network, prefixStr] = cidr.split('/');
+  const prefix = parseInt(prefixStr, 10);
+  if (!isValidIP(ip) || !isValidIP(network) || isNaN(prefix)) return false;
+
+  const isIPv4 = IPV4_REGEX.test(ip);
+  if (isIPv4 !== IPV4_REGEX.test(network)) return false;
+
+  if (isIPv4) {
+    const ipNum = ip.split('.').reduce((acc, octet) => (acc << 8) + parseInt(octet, 10), 0) >>> 0;
+    const netNum = network.split('.').reduce((acc, octet) => (acc << 8) + parseInt(octet, 10), 0) >>> 0;
+    const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
+    return (ipNum & mask) === (netNum & mask);
+  }
+  return false;
+}
+
+function isTrustedProxy(clientIP) {
+  if (TRUSTED_PROXIES.length === 0) return false;
+  return TRUSTED_PROXIES.some(trusted => ipMatchesCIDR(clientIP, trusted));
+}
+
+function sanitizeXForwardedFor(xff, clientIP) {
+  if (!xff) return clientIP;
+
+  const ips = xff.split(',').map(s => s.trim()).filter(Boolean);
+  const validIPs = ips.filter(isValidIP);
+
+  if (validIPs.length === 0) return clientIP;
+  if (validIPs.length === ips.length) return `${validIPs.join(', ')}, ${clientIP}`;
+
+  return `${validIPs.join(', ')}, ${clientIP}`;
+}
+
+function buildForwardedFor(req) {
+  const clientIP = req.socket.remoteAddress || '';
+  const xff = req.headers['x-forwarded-for'];
+
+  if (!xff) return clientIP;
+
+  if (TRUSTED_PROXIES.length === 0 || !isTrustedProxy(clientIP)) {
+    return clientIP;
+  }
+
+  return sanitizeXForwardedFor(xff, clientIP);
+}
+
 /**
  * Proxy an HTTP request to a target instance port.
  *
@@ -59,11 +127,8 @@ function proxyRequest(req, res, port, opts = {}) {
     headers['x-karvi-user'] = opts.injectUser;
   }
 
-  // Forward client IP
-  const clientIp = req.socket.remoteAddress || '';
-  headers['x-forwarded-for'] = req.headers['x-forwarded-for']
-    ? `${req.headers['x-forwarded-for']}, ${clientIp}`
-    : clientIp;
+  // Forward client IP (with spoofing protection)
+  headers['x-forwarded-for'] = buildForwardedFor(req);
   headers['x-forwarded-proto'] = req.headers['x-forwarded-proto'] || 'http';
 
   const proxyReq = http.request({
@@ -120,4 +185,10 @@ function proxyRequest(req, res, port, opts = {}) {
   req.pipe(proxyReq);
 }
 
-module.exports = { proxyRequest };
+module.exports = {
+  proxyRequest,
+  isValidIP,
+  sanitizeXForwardedFor,
+  buildForwardedFor,
+  isTrustedProxy,
+};

--- a/server/gateway.js
+++ b/server/gateway.js
@@ -35,6 +35,8 @@ const proxy = require('./gateway-proxy');
 const mgr = require('./instance-manager');
 const { createLimiter } = require('./rate-limiter');
 
+const { isValidIP, isTrustedProxy } = proxy;
+
 // --- Configuration ---
 const PORT = Number(process.env.GATEWAY_PORT || 3460);
 const DATA_ROOT = path.resolve(process.env.GATEWAY_DATA_ROOT || './data');
@@ -51,11 +53,25 @@ const ALLOWED_ORIGINS = (process.env.KARVI_CORS_ORIGINS || '').split(',').map(s 
 const loginLimiter = createLimiter({ capacity: 5, refillRate: 5 / 60 });
 
 function getClientIP(req) {
+  const socketIP = req.socket.remoteAddress || '127.0.0.1';
+
+  // Only trust X-Forwarded-For when request comes from trusted proxy
   const xff = req.headers['x-forwarded-for'];
-  if (xff) return xff.split(',')[0].trim();
+  if (xff && isTrustedProxy(socketIP)) {
+    const ips = xff.split(',').map(s => s.trim()).filter(Boolean);
+    // Return first valid IP from the chain
+    for (const ip of ips) {
+      if (isValidIP(ip)) return ip;
+    }
+  }
+
+  // Cloudflare connecting IP (only trust if from trusted source)
   const cfIP = req.headers['cf-connecting-ip'];
-  if (cfIP) return cfIP.trim();
-  return req.socket.remoteAddress || '127.0.0.1';
+  if (cfIP && isTrustedProxy(socketIP) && isValidIP(cfIP)) {
+    return cfIP.trim();
+  }
+
+  return socketIP;
 }
 
 // --- Helpers ---

--- a/server/test-gateway.js
+++ b/server/test-gateway.js
@@ -300,6 +300,61 @@ async function testCORS() {
   assert(r1.status === 204, 'OPTIONS returns 204');
 }
 
+async function testXForwardedForValidation() {
+  console.log('\n--- X-Forwarded-For Validation ---');
+
+  const { isValidIP, sanitizeXForwardedFor } = require('./gateway-proxy');
+
+  // IPv4 validation
+  assert(isValidIP('192.168.1.1') === true, 'Valid IPv4 accepted');
+  assert(isValidIP('0.0.0.0') === true, 'Valid IPv4 0.0.0.0 accepted');
+  assert(isValidIP('255.255.255.255') === true, 'Valid IPv4 max accepted');
+  assert(isValidIP('256.1.1.1') === false, 'Invalid IPv4 (256) rejected');
+  assert(isValidIP('1.2.3') === false, 'Invalid IPv4 (3 octets) rejected');
+  assert(isValidIP('1.2.3.4.5') === false, 'Invalid IPv4 (5 octets) rejected');
+
+  // IPv6 validation
+  assert(isValidIP('::1') === true, 'Valid IPv6 loopback accepted');
+  assert(isValidIP('2001:db8::1') === true, 'Valid IPv6 abbreviated accepted');
+  assert(isValidIP('fe80::1') === true, 'Valid IPv6 link-local accepted');
+  assert(isValidIP('::ffff:192.168.1.1') === true, 'Valid IPv6-mapped IPv4 accepted');
+
+  // Invalid formats
+  assert(isValidIP('') === false, 'Empty string rejected');
+  assert(isValidIP(null) === false, 'Null rejected');
+  assert(isValidIP(undefined) === false, 'Undefined rejected');
+  assert(isValidIP('not-an-ip') === false, 'Non-IP string rejected');
+  assert(isValidIP('../../etc/passwd') === false, 'Path injection rejected');
+  assert(isValidIP('123.456.789.999') === false, 'Invalid numeric IP rejected');
+
+  // Sanitization tests
+  const clientIP = '10.0.0.1';
+
+  // Valid IPs should be preserved
+  const s1 = sanitizeXForwardedFor('192.168.1.1, 172.16.0.1', clientIP);
+  assert(s1 === '192.168.1.1, 172.16.0.1, 10.0.0.1', 'Valid IPs preserved');
+
+  // Invalid IPs should be stripped
+  const s2 = sanitizeXForwardedFor('192.168.1.1, invalid-ip, 172.16.0.1', clientIP);
+  assert(s2 === '192.168.1.1, 172.16.0.1, 10.0.0.1', 'Invalid IP stripped from middle');
+
+  // All invalid IPs — only clientIP
+  const s3 = sanitizeXForwardedFor('not-an-ip, also-invalid', clientIP);
+  assert(s3 === clientIP, 'All invalid IPs replaced with clientIP');
+
+  // Empty XFF — just clientIP
+  const s4 = sanitizeXForwardedFor('', clientIP);
+  assert(s4 === clientIP, 'Empty XFF returns clientIP');
+
+  // Null XFF — just clientIP
+  const s5 = sanitizeXForwardedFor(null, clientIP);
+  assert(s5 === clientIP, 'Null XFF returns clientIP');
+
+  // Spoofing attempt with injection patterns
+  const s6 = sanitizeXForwardedFor('192.168.1.1, ../../injection, 172.16.0.1', clientIP);
+  assert(s6 === '192.168.1.1, 172.16.0.1, 10.0.0.1', 'Injection attempt stripped');
+}
+
 // --- Test Runner ---
 
 async function runTests() {
@@ -309,6 +364,7 @@ async function runTests() {
 
   try {
     await testHealth();
+    await testXForwardedForValidation();
     const regToken = await testRegistration();
     const loginToken = await testLogin(regToken);
     await testMe(loginToken);


### PR DESCRIPTION
## Summary

- Validates X-Forwarded-For header values to ensure only valid IPv4/IPv6 addresses are trusted
- Only trusts X-Forwarded-For when request comes from a known reverse proxy (configurable via `KARVI_TRUSTED_PROXIES` env var)
- Strips malformed/spoofed IP values from the chain
- Prevents IP spoofing attacks that could bypass rate limits or access controls

## Changes

1. **gateway-proxy.js**: 
   - Added IP validation functions (`isValidIP`, `ipMatchesCIDR`, `isTrustedProxy`)
   - Added `sanitizeXForwardedFor` to filter invalid IPs from the chain
   - Added `buildForwardedFor` that only trusts XFF from configured proxies
   - Exposed validation functions for testing

2. **gateway.js**:
   - Updated `getClientIP` to use the same trusted proxy logic
   - Rate limiter now only trusts X-Forwarded-For from configured proxies

3. **test-gateway.js**:
   - Added comprehensive tests for IP validation (IPv4, IPv6, invalid formats)
   - Added tests for XFF sanitization (valid IPs preserved, invalid stripped)

## Configuration

Set `KARVI_TRUSTED_PROXIES` env var with comma-separated IPs or CIDR ranges:
```
KARVI_TRUSTED_PROXIES=10.0.0.0/8,192.168.1.100
```

When not set, X-Forwarded-For is ignored and only socket remote address is used.

Closes #172