### PR TITLE
feat(storage): complete storage abstraction layer

### DIFF
--- a/server/routes/evolution.js
+++ b/server/routes/evolution.js
@@ -7,8 +7,8 @@
  * GET/POST /api/lessons
  * POST /api/lessons/:id/status
  */
-const fs = require('fs');
 const bb = require('../blackboard-server');
+const storage = require('../storage');
 const { json } = bb;
 const { createSignal } = require('./_shared');
 
@@ -36,21 +36,16 @@ module.exports = function evolutionRoutes(req, res, helpers, deps) {
   // --- Signal Archive ---
   if (req.method === 'GET' && (req.url === '/api/signals/archive' || req.url.startsWith('/api/signals/archive?'))) {
     const archivePath = helpers.signalArchivePath;
-    if (!archivePath || !fs.existsSync(archivePath)) {
-      const parsedUrl0 = new URL(req.url, 'http://localhost');
-      const limit0 = Math.min(1000, Math.max(1, Number(parsedUrl0.searchParams.get('limit')) || 100));
-      return json(res, 200, { total: 0, offset: 0, limit: limit0, signals: [] });
-    }
     const parsedUrl = new URL(req.url, 'http://localhost');
     const limit = Math.min(1000, Math.max(1, Number(parsedUrl.searchParams.get('limit')) || 100));
     const offset = Math.max(0, Number(parsedUrl.searchParams.get('offset')) || 0);
-    const lines = fs.readFileSync(archivePath, 'utf8').split('\n').filter(Boolean);
-    const signals = [];
-    const end = Math.min(offset + limit, lines.length);
-    for (let i = offset; i < end; i++) {
-      signals.push(JSON.parse(lines[i]));
+
+    if (!archivePath) {
+      return json(res, 200, { total: 0, offset: 0, limit, signals: [] });
     }
-    return json(res, 200, { total: lines.length, offset, limit, signals });
+
+    const result = storage.readArchiveEntries(archivePath, { offset, limit });
+    return json(res, 200, { total: result.total, offset, limit, signals: result.entries });
   }
 
   if (req.method === 'POST' && req.url === '/api/signals') {

--- a/server/routes/logs.js
+++ b/server/routes/logs.js
@@ -1,7 +1,7 @@
 /**
  * routes/logs.js — Audit Log Query API
  *
- * GET /api/logs — 結構化查詢 task-log.jsonl（stream 逐行讀取，不載入整檔）
+ * GET /api/logs — 結構化查詢 task-log.jsonl（透過 storage layer stream 逐行讀取）
  *
  * 查詢參數:
  *   taskId  — 過濾 taskId（精確匹配 entry.taskId 或 entry.data.taskId）
@@ -14,53 +14,12 @@
  *   sort    — asc|desc，預設 desc
  *   format  — json|jsonl，預設 json
  */
-const fs = require('fs');
-const readline = require('readline');
 const bb = require('../blackboard-server');
+const storage = require('../storage');
 const { json } = bb;
 
 const MAX_LIMIT = 10000;
 const DEFAULT_LIMIT = 5000;
-
-/**
- * 逐行 stream 讀取 JSONL，邊讀邊 filter，收集到記憶體的只有匹配的 entries。
- * 回傳 Promise<Entry[]>。
- */
-function readFilteredEntries(logPath, filters) {
-  return new Promise((resolve, reject) => {
-    const entries = [];
-    const rl = readline.createInterface({
-      input: fs.createReadStream(logPath, { encoding: 'utf8' }),
-      crlfDelay: Infinity,
-    });
-    rl.on('line', (line) => {
-      const trimmed = line.trim();
-      if (!trimmed) return;
-      try {
-        const entry = JSON.parse(trimmed);
-        if (matchEntry(entry, filters)) {
-          entries.push(entry);
-        }
-      } catch (err) {
-        console.warn(`[logs] skipping unparseable JSONL line: ${err.message}`);
-      }
-    });
-    rl.on('close', () => resolve(entries));
-    rl.on('error', reject);
-  });
-}
-
-function matchEntry(entry, filters) {
-  if (filters.taskId) {
-    const entryTaskId = entry.taskId || entry.data?.taskId || null;
-    if (entryTaskId !== filters.taskId) return false;
-  }
-  if (filters.event && entry.event !== filters.event) return false;
-  if (filters.user && entry.user !== filters.user) return false;
-  if (filters.from && entry.ts < filters.from) return false;
-  if (filters.to && entry.ts > filters.to) return false;
-  return true;
-}
 
 module.exports = function logsRoutes(req, res, helpers, deps) {
   if (req.method !== 'GET') return false;
@@ -85,8 +44,8 @@ module.exports = function logsRoutes(req, res, helpers, deps) {
 
   const filters = { taskId, event, user, from, to };
 
-  // 非同步 stream 讀取 — 回傳 true 表示已接管 response
-  readFilteredEntries(deps.ctx.logPath, filters).then((filtered) => {
+  // 透過 storage layer 非同步 stream 讀取
+  storage.readLogEntries(deps.ctx.logPath, filters).then((filtered) => {
     // 排序
     filtered.sort((a, b) => {
       const cmp = (a.ts || '').localeCompare(b.ts || '');

--- a/server/storage-json.js
+++ b/server/storage-json.js
@@ -9,10 +9,13 @@
  *   readBoard(boardPath) → object
  *   writeBoard(boardPath, board) → void
  *   appendLog(logPath, entry) → void
+ *   readLogEntries(logPath, filters) → Promise<Entry[]>
+ *   readArchiveEntries(archivePath, opts) → { total, entries }
  *   boardExists(boardPath) → boolean
  *   ensureLogFile(logPath) → void
  */
 const fs = require('fs');
+const readline = require('readline');
 const path = require('path');
 const os = require('os');
 
@@ -79,11 +82,77 @@ function ensureLogFile(logPath) {
   }
 }
 
+/**
+ * 逐行 stream 讀取 JSONL，邊讀邊 filter，收集到記憶體的只有匹配的 entries。
+ * @param {string} logPath - JSONL 檔案路徑
+ * @param {object} filters - { taskId, event, user, from, to }
+ * @returns {Promise<object[]>}
+ */
+function readLogEntries(logPath, filters) {
+  return new Promise((resolve, reject) => {
+    if (!fs.existsSync(logPath)) return resolve([]);
+    const entries = [];
+    const rl = readline.createInterface({
+      input: fs.createReadStream(logPath, { encoding: 'utf8' }),
+      crlfDelay: Infinity,
+    });
+    rl.on('line', (line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      try {
+        const entry = JSON.parse(trimmed);
+        if (matchLogEntry(entry, filters)) {
+          entries.push(entry);
+        }
+      } catch {
+        // 跳過無法解析的行
+      }
+    });
+    rl.on('close', () => resolve(entries));
+    rl.on('error', reject);
+  });
+}
+
+/** filter 匹配邏輯（從 routes/logs.js 搬入） */
+function matchLogEntry(entry, filters) {
+  if (!filters) return true;
+  if (filters.taskId) {
+    const entryTaskId = entry.taskId || entry.data?.taskId || null;
+    if (entryTaskId !== filters.taskId) return false;
+  }
+  if (filters.event && entry.event !== filters.event) return false;
+  if (filters.user && entry.user !== filters.user) return false;
+  if (filters.from && entry.ts < filters.from) return false;
+  if (filters.to && entry.ts > filters.to) return false;
+  return true;
+}
+
+/**
+ * 讀取 JSONL archive 檔案，支援 offset/limit 分頁。
+ * @param {string} archivePath - JSONL archive 路徑
+ * @param {object} opts - { offset, limit }
+ * @returns {{ total: number, entries: object[] }}
+ */
+function readArchiveEntries(archivePath, opts) {
+  if (!fs.existsSync(archivePath)) return { total: 0, entries: [] };
+  const offset = (opts && opts.offset) || 0;
+  const limit = (opts && opts.limit) || 100;
+  const lines = fs.readFileSync(archivePath, 'utf8').split('\n').filter(Boolean);
+  const entries = [];
+  const end = Math.min(offset + limit, lines.length);
+  for (let i = offset; i < end; i++) {
+    entries.push(JSON.parse(lines[i]));
+  }
+  return { total: lines.length, entries };
+}
+
 module.exports = {
   name: 'json',
   readBoard,
   writeBoard,
   appendLog,
+  readLogEntries,
+  readArchiveEntries,
   boardExists,
   ensureLogFile,
 };

--- a/server/storage-sqlite.js
+++ b/server/storage-sqlite.js
@@ -34,11 +34,21 @@ function ensureLogFile(/* logPath */) {
   throw new Error(NOT_IMPLEMENTED);
 }
 
+function readLogEntries(/* logPath, filters */) {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+function readArchiveEntries(/* archivePath, opts */) {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
 module.exports = {
   name: 'sqlite',
   readBoard,
   writeBoard,
   appendLog,
+  readLogEntries,
+  readArchiveEntries,
   boardExists,
   ensureLogFile,
 };

--- a/server/test-storage.js
+++ b/server/test-storage.js
@@ -284,7 +284,7 @@ function test_sqliteInterfaceShape() {
 function test_factoryApiShape() {
   test('19. Default storage export provides expected API shape', () => {
     const storage = require('./storage');
-    const requiredMethods = ['readBoard', 'writeBoard', 'appendLog', 'boardExists', 'ensureLogFile'];
+    const requiredMethods = ['readBoard', 'writeBoard', 'appendLog', 'readLogEntries', 'readArchiveEntries', 'boardExists', 'ensureLogFile'];
     for (const m of requiredMethods) {
       assert.strictEqual(typeof storage[m], 'function', `storage.${m} should be a function`);
     }
@@ -378,10 +378,86 @@ function test_backwardCompatibility() {
 }
 
 // =============================================================================
+// readLogEntries tests
+// =============================================================================
+
+async function test_readLogEntries_basic() {
+  const lp = logPath('read-log.jsonl');
+  storageJson.appendLog(lp, { event: 'create', taskId: 'T1', ts: '2026-01-01T00:00:00Z' });
+  storageJson.appendLog(lp, { event: 'update', taskId: 'T2', ts: '2026-01-02T00:00:00Z' });
+  storageJson.appendLog(lp, { event: 'create', taskId: 'T3', ts: '2026-01-03T00:00:00Z' });
+
+  const all = await storageJson.readLogEntries(lp, {});
+  assert.strictEqual(all.length, 3, 'should return all 3 entries');
+
+  const filtered = await storageJson.readLogEntries(lp, { taskId: 'T2' });
+  assert.strictEqual(filtered.length, 1, 'should return 1 entry for T2');
+  assert.strictEqual(filtered[0].taskId, 'T2');
+
+  const byEvent = await storageJson.readLogEntries(lp, { event: 'create' });
+  assert.strictEqual(byEvent.length, 2, 'should return 2 create events');
+
+  console.log('  PASS  21. readLogEntries basic filtering');
+  passed++;
+}
+
+async function test_readLogEntries_time_filter() {
+  const lp = logPath('read-log-time.jsonl');
+  storageJson.appendLog(lp, { event: 'a', ts: '2026-01-01T00:00:00Z' });
+  storageJson.appendLog(lp, { event: 'b', ts: '2026-01-05T00:00:00Z' });
+  storageJson.appendLog(lp, { event: 'c', ts: '2026-01-10T00:00:00Z' });
+
+  const result = await storageJson.readLogEntries(lp, {
+    from: '2026-01-03T00:00:00Z',
+    to: '2026-01-07T00:00:00Z',
+  });
+  assert.strictEqual(result.length, 1, 'should return 1 entry in time range');
+  assert.strictEqual(result[0].event, 'b');
+
+  console.log('  PASS  22. readLogEntries time range filtering');
+  passed++;
+}
+
+async function test_readLogEntries_missing_file() {
+  const lp = logPath('nonexistent-log.jsonl');
+  const result = await storageJson.readLogEntries(lp, {});
+  assert.strictEqual(result.length, 0, 'should return empty array for missing file');
+
+  console.log('  PASS  23. readLogEntries returns empty for missing file');
+  passed++;
+}
+
+function test_readArchiveEntries_basic() {
+  test('24. readArchiveEntries basic pagination', () => {
+    const ap = logPath('archive.jsonl');
+    for (let i = 0; i < 10; i++) {
+      fs.appendFileSync(ap, JSON.stringify({ id: `sig-${i}`, ts: `2026-01-${String(i + 1).padStart(2, '0')}` }) + '\n');
+    }
+
+    const page1 = storageJson.readArchiveEntries(ap, { offset: 0, limit: 3 });
+    assert.strictEqual(page1.total, 10, 'total should be 10');
+    assert.strictEqual(page1.entries.length, 3, 'first page should have 3 entries');
+    assert.strictEqual(page1.entries[0].id, 'sig-0');
+
+    const page2 = storageJson.readArchiveEntries(ap, { offset: 8, limit: 5 });
+    assert.strictEqual(page2.entries.length, 2, 'last page should have 2 entries');
+    assert.strictEqual(page2.entries[0].id, 'sig-8');
+  });
+}
+
+function test_readArchiveEntries_missing() {
+  test('25. readArchiveEntries returns empty for missing file', () => {
+    const result = storageJson.readArchiveEntries(logPath('nonexistent-archive.jsonl'), {});
+    assert.strictEqual(result.total, 0);
+    assert.strictEqual(result.entries.length, 0);
+  });
+}
+
+// =============================================================================
 // Run all tests
 // =============================================================================
 
-function main() {
+async function main() {
   console.log('=== Storage Tests ===');
   setup();
 
@@ -409,6 +485,14 @@ function main() {
     test_versionIncrement();
     test_conflictDetection();
     test_backwardCompatibility();
+
+    // readLogEntries / readArchiveEntries tests
+    console.log('\n--- readLogEntries / readArchiveEntries ---\n');
+    await test_readLogEntries_basic();
+    await test_readLogEntries_time_filter();
+    await test_readLogEntries_missing_file();
+    test_readArchiveEntries_basic();
+    test_readArchiveEntries_missing();
 
     // storage-sqlite.js
     console.log('\n--- storage-sqlite.js ---\n');


### PR DESCRIPTION
## Summary
- Add `readLogEntries(logPath, filters)` and `readArchiveEntries(archivePath, opts)` to the storage interface (`storage-json.js`)
- Move direct `fs.createReadStream` / `fs.readFileSync` from `routes/logs.js` and `routes/evolution.js` into the storage backend
- Add corresponding stubs to `storage-sqlite.js` for interface parity
- Add 5 new tests (total 25) covering log reading, time range filtering, archive pagination, and missing file handling

All board/log data access now goes through the storage layer, enabling future backend swaps (e.g., SQLite) without touching route code.

Closes #365

## Test plan
- [x] `node --check` passes on all modified files
- [x] `node server/test-storage.js` — 25/25 tests pass (was 20)
- [x] Interface shape test verifies both backends export identical keys
- [ ] Manual: `GET /api/logs` returns same results as before
- [ ] Manual: `GET /api/signals/archive` returns same results as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)