### PR TITLE
feat(pipeline): parallel step group support

### DIFF
--- a/server/context-compiler.js
+++ b/server/context-compiler.js
@@ -6,7 +6,7 @@
  * No dependency on conversation history — purely artifact-driven.
  */
 const path = require('path');
-const { BUDGET_DEFAULTS } = require('./route-engine');
+const { BUDGET_DEFAULTS, resolveStepGroup } = require('./route-engine');
 const { resolveCostRoutingModel } = require('./management');
 
 const STEP_OBJECTIVES = {
@@ -45,15 +45,33 @@ function buildEnvelope(decision, runState, deps) {
   const runId = targetStep.run_id;
   const stepType = targetStep.type;
 
-  // Find the preceding step's output
-  const stepTypes = steps.map(s => s.type);
-  const targetIdx = stepTypes.indexOf(stepType);
+  // Find the preceding group's output(s).
+  // For parallel groups, merge outputs from all steps in the previous group.
+  const targetGroup = resolveStepGroup(targetStep, steps);
   let previousOutput = null;
   let previousOutputRef = null;
-  if (targetIdx > 0) {
-    const prevStep = steps[targetIdx - 1];
-    previousOutput = artifactStore.readArtifact(runId, prevStep.step_id, 'output');
-    previousOutputRef = prevStep.output_ref || null;
+  const prevGroupSteps = steps.filter(s => {
+    const g = resolveStepGroup(s, steps);
+    return g < targetGroup && s.state === 'succeeded';
+  });
+  if (prevGroupSteps.length > 0) {
+    // Find steps from the closest preceding group
+    const maxPrevGroup = Math.max(...prevGroupSteps.map(s => resolveStepGroup(s, steps)));
+    const closestPrevSteps = prevGroupSteps.filter(s => resolveStepGroup(s, steps) === maxPrevGroup);
+    if (closestPrevSteps.length === 1) {
+      // Single predecessor — same as before
+      previousOutput = artifactStore.readArtifact(runId, closestPrevSteps[0].step_id, 'output');
+      previousOutputRef = closestPrevSteps[0].output_ref || null;
+    } else if (closestPrevSteps.length > 1) {
+      // Multiple predecessors (parallel group) — merge summaries and payloads
+      const outputs = closestPrevSteps.map(s => artifactStore.readArtifact(runId, s.step_id, 'output')).filter(Boolean);
+      previousOutput = {
+        status: outputs.every(o => o.status === 'succeeded') ? 'succeeded' : 'mixed',
+        summary: outputs.map(o => o.summary).filter(Boolean).join('\n---\n'),
+        payload: Object.assign({}, ...outputs.map(o => o.payload || {})),
+      };
+      previousOutputRef = closestPrevSteps.map(s => s.output_ref).filter(Boolean).join(',');
+    }
   }
 
   // Compute idempotency key from inputs

--- a/server/kernel.js
+++ b/server/kernel.js
@@ -135,9 +135,16 @@ function createKernel(deps) {
 
     // Execute decision
     switch (decision.action) {
+      case 'wait_group': {
+        // Parallel group has pending siblings — persist budget update and wait
+        console.log(`[kernel] ${taskId} parallel group pending, waiting for siblings`);
+        helpers.writeBoard(latestBoard);
+        return;
+      }
+
       case 'next_step': {
         const nextStepType = decision.next_step?.step_type;
-        
+
         // Per-step-type concurrency check
         const ctrl = mgmt.getControls(latestBoard);
         const limit = ctrl.max_concurrent_by_type?.[nextStepType];
@@ -154,7 +161,7 @@ function createKernel(deps) {
             return;
           }
         }
-        
+
         const envelope = contextCompiler.buildEnvelope(decision, runState, deps);
         if (!envelope) break;
         // Write input artifact
@@ -173,6 +180,46 @@ function createKernel(deps) {
         // Dispatch async via StepWorker (fire-and-forget, errors logged)
         deps.stepWorker.executeStep(envelope, latestBoard, helpers).catch(err =>
           console.error(`[kernel] executeStep error for ${envelope.step_id}:`, err.message));
+
+        // Dispatch parallel siblings (if any) — same group, different steps
+        if (Array.isArray(decision.parallel_siblings) && decision.parallel_siblings.length > 0) {
+          for (const sibling of decision.parallel_siblings) {
+            const sibDecision = { action: 'next_step', next_step: { step_id: sibling.step_id, step_type: sibling.step_type } };
+            const sibEnvelope = contextCompiler.buildEnvelope(sibDecision, runState, deps);
+            if (!sibEnvelope) continue;
+
+            // Check concurrency limit for sibling's type
+            const sibLimit = ctrl.max_concurrent_by_type?.[sibling.step_type];
+            if (sibLimit) {
+              let sibRunning = 0;
+              const freshBoard = helpers.readBoard();
+              for (const t of (freshBoard.taskPlan?.tasks || [])) {
+                for (const s of (t.steps || [])) {
+                  if (s.type === sibling.step_type && s.state === 'running') sibRunning++;
+                }
+              }
+              if (sibRunning >= sibLimit) {
+                console.log(`[kernel] ${sibling.step_type} concurrency limit reached for parallel sibling, skipping`);
+                continue;
+              }
+            }
+
+            artifactStore.writeArtifact(sibEnvelope.run_id, sibEnvelope.step_id, 'input', sibEnvelope);
+            const sibBoard = helpers.readBoard();
+            const sibTask = (sibBoard.taskPlan?.tasks || []).find(t => t.id === taskId);
+            const sibStep = sibTask?.steps?.find(s => s.step_id === sibling.step_id);
+            if (sibStep && sibStep.state === 'queued') {
+              stepSchema.transitionStep(sibStep, 'running', {
+                locked_by: 'kernel-parallel',
+                input_ref: artifactStore.artifactPath(sibEnvelope.run_id, sibEnvelope.step_id, 'input'),
+              });
+              helpers.writeBoard(sibBoard);
+            }
+            deps.stepWorker.executeStep(sibEnvelope, helpers.readBoard(), helpers).catch(err =>
+              console.error(`[kernel] parallel executeStep error for ${sibEnvelope.step_id}:`, err.message));
+          }
+        }
+
         return;  // writeBoard already called
       }
 

--- a/server/management/dispatch.js
+++ b/server/management/dispatch.js
@@ -564,6 +564,14 @@ const BUILT_IN_TEMPLATES = {
     { type: 'implement' },
     { type: 'review', revision_target: 'implement' },
   ],
+  'parallel-review': [
+    { type: 'plan' },
+    { type: 'implement' },
+    { parallel: [
+      { type: 'review', instruction: 'Code quality and correctness review', revision_target: 'implement' },
+      { type: 'review', instruction: 'Security and performance review', revision_target: 'implement' },
+    ]},
+  ],
   'research': [
     { type: 'plan', instruction: 'Research and analyze the problem space thoroughly' },
     { type: 'plan', instruction: 'Propose solution options with trade-offs' },
@@ -576,6 +584,12 @@ function normalizePipelineEntry(entry) {
   if (typeof entry === 'string') {
     const type = entry.trim();
     return type ? { type } : null;
+  }
+  // Parallel group: { parallel: [stepDef, stepDef, ...] }
+  if (entry && typeof entry === 'object' && Array.isArray(entry.parallel)) {
+    const children = entry.parallel.map(normalizePipelineEntry).filter(Boolean);
+    if (children.length === 0) return null;
+    return { _parallel: children };
   }
   if (entry && typeof entry === 'object' && typeof entry.type === 'string') {
     const type = entry.type.trim();
@@ -612,20 +626,49 @@ function generateStepsForTask(task, runId, pipeline, board) {
 
   const normalized = source.map(normalizePipelineEntry).filter(Boolean);
   if (normalized.length === 0) {
-    return DEFAULT_STEP_PIPELINE.map(type => stepSchema.createStep(task.id, runId, type));
+    return DEFAULT_STEP_PIPELINE.map((type, i) => stepSchema.createStep(task.id, runId, type, { group: i }));
   }
 
-  return normalized.map(stepDef => {
-    const opts = {};
-    if (stepDef.instruction) opts.instruction = stepDef.instruction;
-    if (stepDef.skill) opts.skill = stepDef.skill;
-    if (stepDef.runtime_hint) opts.runtime_hint = stepDef.runtime_hint;
-    else if (task.runtimeHint) opts.runtime_hint = task.runtimeHint;
-    if (stepDef.retry_policy) opts.retry_policy = stepDef.retry_policy;
-    if (stepDef.revision_target) opts.revision_target = stepDef.revision_target;
-    if (stepDef.max_revision_cycles != null) opts.max_revision_cycles = stepDef.max_revision_cycles;
-    return stepSchema.createStep(task.id, runId, stepDef.type, opts);
-  });
+  // Flatten parallel groups and assign group indices.
+  // Each top-level entry = one group. { _parallel: [...] } entries share the same group.
+  const steps = [];
+  let groupIdx = 0;
+  // Track how many steps of each type have been generated (for unique step_id suffixes)
+  const typeCounts = {};
+
+  for (const entry of normalized) {
+    if (entry._parallel) {
+      for (const child of entry._parallel) {
+        const step = buildStepFromDef(task, runId, child, groupIdx, typeCounts);
+        steps.push(step);
+      }
+    } else {
+      const step = buildStepFromDef(task, runId, entry, groupIdx, typeCounts);
+      steps.push(step);
+    }
+    groupIdx++;
+  }
+
+  return steps;
+}
+
+function buildStepFromDef(task, runId, stepDef, group, typeCounts) {
+  const opts = { group };
+  if (stepDef.instruction) opts.instruction = stepDef.instruction;
+  if (stepDef.skill) opts.skill = stepDef.skill;
+  if (stepDef.runtime_hint) opts.runtime_hint = stepDef.runtime_hint;
+  else if (task.runtimeHint) opts.runtime_hint = task.runtimeHint;
+  if (stepDef.retry_policy) opts.retry_policy = stepDef.retry_policy;
+  if (stepDef.revision_target) opts.revision_target = stepDef.revision_target;
+  if (stepDef.max_revision_cycles != null) opts.max_revision_cycles = stepDef.max_revision_cycles;
+
+  // Generate unique step_id: for duplicate types, append suffix (e.g. T1:review:1)
+  typeCounts[stepDef.type] = (typeCounts[stepDef.type] || 0) + 1;
+  if (typeCounts[stepDef.type] > 1) {
+    opts.stepIdSuffix = typeCounts[stepDef.type] - 1;
+  }
+
+  return stepSchema.createStep(task.id, runId, stepDef.type, opts);
 }
 
 // --- Task scheduling helpers ---

--- a/server/route-engine.js
+++ b/server/route-engine.js
@@ -175,10 +175,6 @@ function decideNext(agentOutput, runState) {
 
   // 4. Succeeded (or needs_revision — review completed but wants changes) → find next step
   if (agentOutput.status === 'succeeded' || agentOutput.status === 'needs_revision') {
-    const stepTypes = steps.map(s => s.type);
-    const currentIdx = stepTypes.indexOf(fromStep?.type);
-    const nextIdx = currentIdx + 1;
-
     // Revision cycle: if a step with revision_target found actionable findings,
     // loop back to the target step for a fix pass.
     // Guard: limit revision cycles to avoid infinite loops.
@@ -199,12 +195,36 @@ function decideNext(agentOutput, runState) {
       }
     }
 
-    // More steps in pipeline?
-    if (nextIdx < steps.length) {
-      const nextStep = steps[nextIdx];
+    // Group-aware progression: find the current step's group, check if all
+    // siblings in the group are terminal, then advance to the next group.
+    const currentGroup = resolveStepGroup(fromStep, steps);
+    const siblings = steps.filter(s => resolveStepGroup(s, steps) === currentGroup);
+    const siblingsPending = siblings.some(s =>
+      s.state !== 'succeeded' && s.state !== 'dead' && s.state !== 'cancelled'
+    );
+
+    if (siblingsPending) {
+      // Group not yet complete — wait (no action, kernel will be called again when next sibling finishes)
+      return { ...base, action: 'wait_group', rule: 'parallel_group_pending', confidence: 1.0,
+        next_step: null, retry: null, human_review: null };
+    }
+
+    // All siblings done — check if any failed fatally (dead) in this group
+    const deadSiblings = siblings.filter(s => s.state === 'dead');
+    if (deadSiblings.length > 0) {
+      return { ...base, action: 'dead_letter', rule: 'parallel_group_has_dead', confidence: 0.9,
+        next_step: null, retry: null, human_review: null };
+    }
+
+    // Find next group's first queued step
+    const nextGroupSteps = findNextGroupSteps(currentGroup, steps);
+    if (nextGroupSteps.length > 0) {
+      const nextStep = nextGroupSteps[0];
       return { ...base, action: 'next_step', rule: 'pipeline_advance', confidence: 1.0,
         retry: null, human_review: null,
-        next_step: { step_id: nextStep.step_id, step_type: nextStep.type, priority: 0 } };
+        next_step: { step_id: nextStep.step_id, step_type: nextStep.type, priority: 0 },
+        // Signal parallel siblings so kernel can dispatch them too
+        parallel_siblings: nextGroupSteps.slice(1).map(s => ({ step_id: s.step_id, step_type: s.type })) };
     }
 
     // All done
@@ -218,6 +238,32 @@ function decideNext(agentOutput, runState) {
     human_review: { reason: `Unknown output status: ${agentOutput.status}` } };
 }
 
+// --- Parallel group helpers ---
+
+/**
+ * Resolve a step's group index. If the step has no explicit group,
+ * fall back to its array position (backward compat: each step = own group).
+ */
+function resolveStepGroup(step, steps) {
+  if (step.group != null) return step.group;
+  return steps.indexOf(step);
+}
+
+/**
+ * Find all queued steps in the next group after the given group index.
+ */
+function findNextGroupSteps(currentGroup, steps) {
+  // Collect all distinct group indices > currentGroup, sorted
+  const groups = new Set();
+  for (const s of steps) {
+    const g = resolveStepGroup(s, steps);
+    if (g > currentGroup) groups.add(g);
+  }
+  if (groups.size === 0) return [];
+  const nextGroup = Math.min(...groups);
+  return steps.filter(s => resolveStepGroup(s, steps) === nextGroup && s.state === 'queued');
+}
+
 module.exports = {
   FAILURE_MODES,
   BUDGET_DEFAULTS,
@@ -228,4 +274,6 @@ module.exports = {
   isCostBudgetExceeded,
   needsRevision,
   decideNext,
+  resolveStepGroup,
+  findNextGroupSteps,
 };

--- a/server/step-schema.js
+++ b/server/step-schema.js
@@ -264,7 +264,7 @@ function computeBackoff(kindConfig, step) {
 
 
 function createStep(taskId, runId, type, opts = {}) {
-  const stepId = `${taskId}:${type}`;
+  const stepId = opts.stepIdSuffix != null ? `${taskId}:${type}:${opts.stepIdSuffix}` : `${taskId}:${type}`;
   const retry = { ...DEFAULT_RETRY_POLICY, ...(opts.retry_policy || {}) };
   return {
     step_id: stepId,
@@ -280,6 +280,9 @@ function createStep(taskId, runId, type, opts = {}) {
     idempotency_key: null,
     input_ref: null,
     output_ref: null,
+    // Parallel group index — steps with the same group run concurrently.
+    // null = auto-assigned sequential group (backward compat).
+    group: opts.group ?? null,
     // Semantic step metadata (task-specific behavior lives in data, not hard-coded maps)
     instruction: opts.instruction || null,
     skill: opts.skill || null,


### PR DESCRIPTION
## Summary

- Pipeline entries can now use `{ parallel: [stepDef, ...] }` to run steps concurrently within a group
- Steps get a `group` field; the kernel waits for all siblings in a group to complete (barrier) before advancing
- Route engine returns `wait_group` action when parallel siblings are still pending
- Context compiler merges outputs from multiple predecessor steps in a parallel group
- Added `parallel-review` built-in template (code quality + security review in parallel)
- Fully backward compatible: existing serial pipelines auto-assign sequential group indices

Closes #358

## Test plan

- [x] All syntax checks pass (`node --check` on all 7 modified/dependent files)
- [x] Evolution loop integration test (npm test) — 0 failures
- [x] Step schema tests (85 passed) — including `generateStepsForTask` with custom pipelines
- [x] Kernel integration tests (5 passed) — step advancement still works
- [x] Critical path tests (32 passed) — cancel, wave, concurrency, dead letter all unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)