### PR TITLE
feat(hooks): add lightweight hook system for server extensibility

### DIFF
--- a/server/hook-system.js
+++ b/server/hook-system.js
@@ -1,0 +1,135 @@
+/**
+ * hook-system.js — 輕量級 Hook 系統
+ *
+ * Hook 是放在 hooks/ 目錄下的 JS 檔案，匯出事件處理函數。
+ * 事件：task_created, task_completed, step_started, step_completed, dispatch_started
+ *
+ * Hook 註冊：server 啟動時掃描 hooks/ 目錄
+ * Hook 執行：fire-and-forget（非阻塞，錯誤只 log）
+ *
+ * 零外部依賴，只用 Node.js 內建模組。
+ */
+const fs = require('fs');
+const path = require('path');
+
+const SUPPORTED_EVENTS = [
+  'task_created',
+  'task_completed',
+  'step_started',
+  'step_completed',
+  'dispatch_started',
+];
+
+let registeredHooks = [];
+
+function getHooksDir(serverDir) {
+  return path.join(serverDir, 'hooks');
+}
+
+function scanHooks(hooksDir) {
+  const hooks = [];
+
+  if (!fs.existsSync(hooksDir)) {
+    return hooks;
+  }
+
+  const entries = fs.readdirSync(hooksDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.js')) continue;
+
+    const hookPath = path.join(hooksDir, entry.name);
+    const hookName = entry.name.replace(/\.js$/, '');
+
+    try {
+      const hookModule = require(hookPath);
+
+      if (typeof hookModule === 'function') {
+        hooks.push({
+          name: hookName,
+          file: entry.name,
+          events: SUPPORTED_EVENTS,
+          handler: hookModule,
+        });
+      } else if (typeof hookModule === 'object' && hookModule !== null) {
+        for (const eventName of SUPPORTED_EVENTS) {
+          const handler = hookModule[eventName];
+          if (typeof handler === 'function') {
+            hooks.push({
+              name: `${hookName}:${eventName}`,
+              file: entry.name,
+              events: [eventName],
+              handler,
+            });
+          }
+        }
+      }
+    } catch (err) {
+      console.error(`[hook-system] 載入 hook 失敗 ${entry.name}: ${err.message}`);
+    }
+  }
+
+  return hooks;
+}
+
+function init(hooksDir) {
+  registeredHooks = scanHooks(hooksDir);
+
+  if (registeredHooks.length > 0) {
+    const eventCounts = {};
+    for (const h of registeredHooks) {
+      for (const ev of h.events) {
+        eventCounts[ev] = (eventCounts[ev] || 0) + 1;
+      }
+    }
+    const summary = SUPPORTED_EVENTS.map(ev => `${ev}:${eventCounts[ev] || 0}`).join(', ');
+    console.log(`[hook-system] 註冊 ${registeredHooks.length} 個 hook（${summary}）`);
+  }
+
+  return registeredHooks;
+}
+
+function emit(eventName, data) {
+  if (!SUPPORTED_EVENTS.includes(eventName)) {
+    console.warn(`[hook-system] 未知事件: ${eventName}`);
+    return;
+  }
+
+  for (const hook of registeredHooks) {
+    if (!hook.events.includes(eventName)) continue;
+
+    setImmediate(() => {
+      try {
+        const result = hook.handler(eventName, data);
+        if (result && typeof result.catch === 'function') {
+          result.catch(err => {
+            console.error(`[hook-system] hook ${hook.name} 錯誤 (${eventName}): ${err.message}`);
+          });
+        }
+      } catch (err) {
+        console.error(`[hook-system] hook ${hook.name} 錯誤 (${eventName}): ${err.message}`);
+      }
+    });
+  }
+}
+
+function listHooks() {
+  return registeredHooks.map(h => ({
+    name: h.name,
+    file: h.file,
+    events: h.events,
+  }));
+}
+
+function getSupportedEvents() {
+  return [...SUPPORTED_EVENTS];
+}
+
+module.exports = {
+  init,
+  emit,
+  listHooks,
+  getSupportedEvents,
+  getHooksDir,
+  SUPPORTED_EVENTS,
+};

--- a/server/hooks/example-logger.js
+++ b/server/hooks/example-logger.js
@@ -1,0 +1,42 @@
+/**
+ * 範例 Hook：記錄所有事件到 console
+ *
+ * Hook 檔案放在 server/hooks/ 目錄下，必須是 .js 檔案。
+ *
+ * 匯出方式：
+ * 1. 匯出函數：處理所有事件
+ *    module.exports = (eventName, data) => { ... }
+ *
+ * 2. 匯出物件：只處理特定事件
+ *    module.exports = {
+ *      task_created: (eventName, data) => { ... },
+ *      step_completed: (eventName, data) => { ... },
+ *    }
+ *
+ * 支援的事件：
+ *   - task_created: 新任務建立
+ *   - task_completed: 任務完成（approved）
+ *   - step_started: 步驟開始執行
+ *   - step_completed: 步驟完成（成功或失敗）
+ *   - dispatch_started: 任務派發開始
+ *
+ * Hook 是 fire-and-forget：
+ *   - 非阻塞，不會影響主流程
+ *   - 錯誤只會 log，不會中斷
+ *   - 可以是 async function
+ */
+
+function logHook(eventName, data) {
+  const ts = new Date().toISOString();
+  const taskId = data?.taskId || data?.task?.id || '-';
+  const stepId = data?.stepId || '-';
+  console.log(`[${ts}] [hook] ${eventName} task=${taskId} step=${stepId}`);
+}
+
+module.exports = {
+  task_created: logHook,
+  task_completed: logHook,
+  step_started: logHook,
+  step_completed: logHook,
+  dispatch_started: logHook,
+};

--- a/server/kernel.js
+++ b/server/kernel.js
@@ -460,6 +460,11 @@ function createKernel(deps) {
 
         helpers.writeBoard(latestBoard);
 
+        // Hook system: emit task_completed
+        if (deps.hookSystem) {
+          deps.hookSystem.emit('task_completed', { taskId, task: latestTask });
+        }
+
         if (push && PUSH_TOKENS_PATH && latestTask) {
           push.notifyTaskEvent(PUSH_TOKENS_PATH, latestTask, 'task.completed')
             .catch(async err => {

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -161,6 +161,11 @@ function dispatchTask(task, board, deps, helpers, opts = {}) {
   }
   _dispatchLocks.set(taskId, helpers.nowIso());
 
+  // Hook system: emit dispatch_started
+  if (deps.hookSystem) {
+    deps.hookSystem.emit('dispatch_started', { taskId, source, mode });
+  }
+
   const assignee = participantById(board, task.assignee);
   if (!assignee || assignee.type !== 'agent') {
     _dispatchLocks.delete(taskId);
@@ -638,6 +643,11 @@ module.exports = function tasksRoutes(req, res, helpers, deps) {
           };
           if (t.scope) newTask.scope = t.scope;
           board.taskPlan.tasks.push(newTask);
+
+          // Hook system: emit task_created
+          if (deps.hookSystem) {
+            deps.hookSystem.emit('task_created', { taskId: newTask.id, task: newTask });
+          }
         }
 
         helpers.writeBoard(board);

--- a/server/server.js
+++ b/server/server.js
@@ -21,6 +21,7 @@ const usage = require('./usage');
 const { createServiceManager } = require('./service-manager');
 
 const vault = require('./vault').createVault({ vaultDir: path.join(__dirname, 'vaults') });
+const hookSystem = require('./hook-system');
 
 const opt = loadModules([
   { name: 'runtimeCodex',     path: './runtime-codex',       optional: true },
@@ -199,6 +200,14 @@ const server = bb.createServer(ctx, (req, res, helpers) => {
     return json(res, 200, serviceManager.status());
   }
 
+  // GET /api/hooks — list registered hooks
+  if (req.method === 'GET' && req.url === '/api/hooks') {
+    return json(res, 200, {
+      supportedEvents: hookSystem.getSupportedEvents(),
+      hooks: hookSystem.listHooks(),
+    });
+  }
+
   // POST /api/shutdown — graceful shutdown (critical for Windows where SIGTERM kills immediately)
   if (req.method === 'POST' && req.url === '/api/shutdown') {
     // Admin-only: shutdown requires highest privilege
@@ -272,6 +281,11 @@ if (migrationResult.applied.length > 0) {
 if (migrationResult.dirty) {
   writeBoard(initBoard);
 }
+
+// --- Hook System: 初始化輕量級 hook 系統 ---
+const hooksDir = hookSystem.getHooksDir(DIR);
+hookSystem.init(hooksDir);
+deps.hookSystem = hookSystem;
 
 // --- Service Manager: 統一管理所有 background services ---
 const serviceManager = createServiceManager();

--- a/server/step-worker.js
+++ b/server/step-worker.js
@@ -197,6 +197,11 @@ function createStepWorker(deps) {
 
     emitWebhookEvent(board, 'step_started', { taskId: envelope.task_id, stepId: envelope.step_id, stepType: envelope.step_type });
 
+    // Hook system: emit step_started
+    if (deps.hookSystem) {
+      deps.hookSystem.emit('step_started', { taskId: envelope.task_id, stepId: envelope.step_id, stepType: envelope.step_type });
+    }
+
     // 3. Per-step runtime selection (envelope.runtime_hint takes precedence)
     //    With fallback chain: on PROVIDER errors, try next runtime in chain
     const step = task.steps?.find(s => s.step_id === envelope.step_id);
@@ -752,6 +757,11 @@ function createStepWorker(deps) {
       helpers.writeBoard(latestBoard);
       helpers.appendLog({ ts: helpers.nowIso(), event: signalType, taskId: envelope.task_id, stepId: envelope.step_id, from: 'running', to: latestStep.state });
       emitWebhookEvent(latestBoard, signalType, { taskId: envelope.task_id, stepId: envelope.step_id, state: latestStep.state });
+
+      // Hook system: emit step_completed
+      if (deps.hookSystem && signalType === 'step_completed') {
+        deps.hookSystem.emit('step_completed', { taskId: envelope.task_id, stepId: envelope.step_id, state: latestStep.state });
+      }
 
       // 8. Trigger kernel for terminal states (via setImmediate to avoid deep recursion)
       const newSignal = {

--- a/server/test-hook-system.js
+++ b/server/test-hook-system.js
@@ -1,0 +1,120 @@
+/**
+ * test-hook-system.js — Hook 系統單元測試
+ */
+const assert = require('assert');
+const path = require('path');
+const hookSystem = require('./hook-system');
+
+const originalConsoleLog = console.log;
+const originalConsoleError = console.error;
+
+function mockConsole() {
+  const logs = [];
+  console.log = (...args) => logs.push(['log', ...args]);
+  console.warn = (...args) => logs.push(['warn', ...args]);
+  console.error = (...args) => logs.push(['error', ...args]);
+  return logs;
+}
+
+function restoreConsole() {
+  console.log = originalConsoleLog;
+  console.error = originalConsoleError;
+}
+
+async function testGetSupportedEvents() {
+  const events = hookSystem.getSupportedEvents();
+  assert.deepStrictEqual(events, [
+    'task_created',
+    'task_completed',
+    'step_started',
+    'step_completed',
+    'dispatch_started',
+  ]);
+  console.log('  ✓ getSupportedEvents() 返回正確的事件列表');
+}
+
+async function testListHooksEmpty() {
+  const hooks = hookSystem.listHooks();
+  assert.ok(Array.isArray(hooks));
+  console.log(`  ✓ listHooks() 返回陣列 (${hooks.length} 個 hook)`);
+}
+
+async function testEmitUnknownEvent() {
+  const logs = mockConsole();
+  hookSystem.emit('unknown_event', {});
+  restoreConsole();
+  const warnLog = logs.find(l => l[0] === 'warn' && l[1].includes('未知事件'));
+  assert.ok(warnLog, '應該 log 警告訊息');
+  console.log('  ✓ emit() 對未知事件發出警告');
+}
+
+async function testInitWithNonexistentDir() {
+  const logs = mockConsole();
+  const hooks = hookSystem.init('/nonexistent/path');
+  restoreConsole();
+  assert.deepStrictEqual(hooks, []);
+  console.log('  ✓ init() 對不存在的目錄返回空陣列');
+}
+
+async function testHookFiresAndForgets() {
+  let hookCalled = false;
+  let receivedEvent = null;
+  let receivedData = null;
+
+  const testHandler = (event, data) => {
+    hookCalled = true;
+    receivedEvent = event;
+    receivedData = data;
+  };
+
+  const testHooksDir = path.join(__dirname, 'hooks');
+  const fs = require('fs');
+  const testHookPath = path.join(testHooksDir, 'test-hook.js');
+
+  fs.writeFileSync(testHookPath, `
+module.exports = {
+  task_created: (event, data) => {
+    global.__testHookCalled = true;
+    global.__testHookEvent = event;
+    global.__testHookData = data;
+  }
+};
+`);
+
+  const logs = mockConsole();
+  hookSystem.init(testHooksDir);
+  hookSystem.emit('task_created', { taskId: 'TEST-123' });
+  restoreConsole();
+
+  await new Promise(resolve => setTimeout(resolve, 50));
+
+  fs.unlinkSync(testHookPath);
+
+  assert.ok(global.__testHookCalled, 'Hook 應該被調用');
+  assert.strictEqual(global.__testHookEvent, 'task_created');
+  assert.deepStrictEqual(global.__testHookData, { taskId: 'TEST-123' });
+
+  delete global.__testHookCalled;
+  delete global.__testHookEvent;
+  delete global.__testHookData;
+
+  console.log('  ✓ emit() 觸發 hook 並正確傳遞參數');
+}
+
+async function runTests() {
+  console.log('\n=== Hook System 測試 ===\n');
+
+  await testGetSupportedEvents();
+  await testListHooksEmpty();
+  await testEmitUnknownEvent();
+  await testInitWithNonexistentDir();
+  await testHookFiresAndForgets();
+
+  console.log('\n=== 所有測試通過 ===\n');
+}
+
+runTests().catch(err => {
+  restoreConsole();
+  console.error('測試失敗:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Closes #364

實作輕量級 Hook 系統，讓 Karvi server 可以透過 JS 檔案擴充功能。

### 功能

- **Hook 註冊**：server 啟動時掃描 `server/hooks/` 目錄
- **支援的事件**：
  - `task_created` — 新任務建立
  - `task_completed` — 任務完成（approved）
  - `step_started` — 步驟開始執行
  - `step_completed` — 步驟完成
  - `dispatch_started` — 任務派發開始
- **Fire-and-forget**：非阻塞，錯誤只 log 不影響主流程
- **零外部依賴**：只用 Node.js 內建模組

### 新增 API

- `GET /api/hooks` — 列出已註冊的 hooks

### 使用方式

在 `server/hooks/` 目錄下建立 JS 檔案：

```js
// 方式 1：處理所有事件
module.exports = (eventName, data) => {
  console.log(`[${eventName}]`, data);
};

// 方式 2：只處理特定事件
module.exports = {
  task_created: (eventName, data) => {
    console.log('New task:', data.taskId);
  },
  task_completed: (eventName, data) => {
    console.log('Task done:', data.taskId);
  },
};
```

### 檔案變更

- `server/hook-system.js` — Hook 系統核心模組
- `server/hooks/example-logger.js` — 範例 hook
- `server/server.js` — 初始化 hook 系統 + /api/hooks endpoint
- `server/kernel.js` — 發出 task_completed 事件
- `server/step-worker.js` — 發出 step_started, step_completed 事件
- `server/routes/tasks.js` — 發出 task_created, dispatch_started 事件
- `server/test-hook-system.js` — 單元測試

## Test Plan

- [x] `node -c` 驗證所有修改檔案的語法
- [x] `node server/test-hook-system.js` 單元測試通過