### PR TITLE
feat(jira): @karvi mention webhook handler (GH-271)

### DIFF
--- a/server/integration-jira.js
+++ b/server/integration-jira.js
@@ -289,7 +289,7 @@ function handleMentionWebhook(board, payload, config) {
 
   // Build task from the issue context
   const task = buildTaskFromMention(issue, commentBody, parsed, config);
-  task.status = 'dispatched'; // Auto-dispatch on mention
+  // status is already 'dispatched' from buildTaskFromMention
 
   return { action: 'create_task', task, issueKey, command: parsed.command };
 }
@@ -475,19 +475,16 @@ function verifyHmacSignature(rawBody, signatureHeader, secret) {
 // ---------------------------------------------------------------------------
 
 /**
- * handleWebhook(board, payload, url)
+ * handleWebhook(board, payload)
+ *
+ * Auth is handled by the route layer before calling this function.
  *
  * @param {object} board  — current board state
  * @param {object} payload — Jira webhook JSON body
- * @param {string} url    — request URL (for token verification)
  * @returns {{ action, task?, karviStatus?, error? }}
  */
-function handleWebhook(board, payload, url) {
-  // 1. Verify token
-  if (!verifyWebhookToken(url)) {
-    return { action: 'rejected', error: 'Invalid webhook token' };
-  }
-
+function handleWebhook(board, payload) {
+  // Auth is handled by the route layer (HMAC / URL token) before calling this.
   const config = getConfig(board);
   if (!config?.enabled) {
     return { action: 'skipped', error: 'Jira integration disabled' };
@@ -875,7 +872,7 @@ if (require.main === module) {
         fields: { summary: 'New feature', priority: { name: 'Medium' } },
       },
     };
-    const result = handleWebhook(board, payload, 'http://localhost/api/webhooks/jira');
+    const result = handleWebhook(board, payload);
     if (result.action !== 'create_task') throw new Error(`action: ${result.action}`);
     if (result.task.id !== 'PROJ-1') throw new Error(`task.id: ${result.task.id}`);
     if (result.issueKey !== 'PROJ-1') throw new Error(`issueKey: ${result.issueKey}`);
@@ -895,7 +892,7 @@ if (require.main === module) {
         fields: { summary: 'Duplicate' },
       },
     };
-    const result = handleWebhook(board, payload, 'http://localhost/api/webhooks/jira');
+    const result = handleWebhook(board, payload);
     if (result.action !== 'skipped') throw new Error(`action: ${result.action}`);
     if (!result.error.includes('already exists')) throw new Error(`error: ${result.error}`);
     ok('handleWebhook: dedup → skipped');
@@ -912,7 +909,7 @@ if (require.main === module) {
       issue: { key: 'REG-1' },
       changelog: { items: [{ field: 'status', toString: 'Done' }] },
     };
-    const result = handleWebhook(board, payload, 'http://localhost/api/webhooks/jira');
+    const result = handleWebhook(board, payload);
     if (result.action !== 'status_change') throw new Error(`action: ${result.action}`);
     if (result.karviStatus !== 'completed') throw new Error(`karviStatus: ${result.karviStatus}`);
     ok('handleWebhook: issue_updated regression → status_change');
@@ -975,7 +972,7 @@ if (require.main === module) {
         ],
       },
     };
-    const result = handleWebhook(board, payload, 'http://localhost/api/webhooks/jira');
+    const result = handleWebhook(board, payload);
     if (result.action !== 'fields_updated') throw new Error(`action: ${result.action}`);
     if (result.changes.length !== 2) throw new Error(`changes: ${result.changes.length}`);
     if (result.updatedFields.title !== 'New Title') throw new Error(`title: ${result.updatedFields.title}`);
@@ -993,11 +990,11 @@ if (require.main === module) {
       issue: { key: 'DUP-1', fields: { summary: 'New' } },
       changelog: { items: [{ field: 'summary', fromString: 'Title', toString: 'New' }] },
     };
-    const r1 = handleWebhook(board, payload, 'http://localhost/api/webhooks/jira');
+    const r1 = handleWebhook(board, payload);
     if (r1.action !== 'fields_updated') throw new Error(`first call: ${r1.action}`);
     // Simulate applying the hash
     board.taskPlan.tasks[0]._lastChangeHash = r1.changeHash;
-    const r2 = handleWebhook(board, payload, 'http://localhost/api/webhooks/jira');
+    const r2 = handleWebhook(board, payload);
     if (r2.action !== 'skipped') throw new Error(`second call: ${r2.action}`);
     ok('handleWebhook: dedup via change hash');
   } catch (e) { fail('handleWebhook: dedup via change hash', e.message); }
@@ -1016,7 +1013,7 @@ if (require.main === module) {
         { field: 'Sprint', fromString: 'Sprint 1', toString: 'Sprint 2' },
       ]},
     };
-    const result = handleWebhook(board, payload, 'http://localhost/api/webhooks/jira');
+    const result = handleWebhook(board, payload);
     if (result.action !== 'skipped') throw new Error(`action: ${result.action}`);
     ok('handleWebhook: ignores non-substantive fields');
   } catch (e) { fail('handleWebhook: ignores non-substantive', e.message); }

--- a/server/routes/jira.js
+++ b/server/routes/jira.js
@@ -91,7 +91,18 @@ module.exports = function jiraRoutes(req, res, helpers, deps) {
             board.taskPlan = board.taskPlan || { tasks: [] };
             board.taskPlan.tasks = board.taskPlan.tasks || [];
             board.taskPlan.tasks.push(result.task);
+
+            // Emit signal before writeBoard so both task + signal are persisted atomically
+            mgmt.ensureEvolutionFields(board);
+            board.signals.push(createSignal({
+              by: 'jira-mention', type: 'mention_task_created',
+              content: `@karvi mention → ${result.task.id} created from Jira ${result.issueKey}`,
+              refs: [result.task.id],
+              data: { taskId: result.task.id, jiraKey: result.issueKey, command: result.command },
+            }, req, helpers));
+            mgmt.trimSignals(board, helpers.signalArchivePath);
             helpers.writeBoard(board);
+
             helpers.appendLog({
               ts: helpers.nowIso(),
               event: 'jira_mention_task_created',
@@ -113,17 +124,6 @@ module.exports = function jiraRoutes(req, res, helpers, deps) {
               : `Task **${result.task.id}** created (status: ${result.task.status}).`;
             replyOnIssue(result.issueKey, replyBody);
 
-            // Emit signal
-            mgmt.ensureEvolutionFields(board);
-            board.signals.push(createSignal({
-              by: 'jira-mention', type: 'mention_task_created',
-              content: `@karvi mention → ${result.task.id} created from Jira ${result.issueKey}`,
-              refs: [result.task.id],
-              data: { taskId: result.task.id, jiraKey: result.issueKey, command: result.command },
-            }, req, helpers));
-            mgmt.trimSignals(board, helpers.signalArchivePath);
-            helpers.writeBoard(board);
-
             json(res, 201, { ok: true, action: 'create_task', taskId: result.task.id, jiraKey: result.issueKey });
             return;
           }
@@ -133,7 +133,7 @@ module.exports = function jiraRoutes(req, res, helpers, deps) {
         }
 
         // --- issue_created / issue_updated events: existing behavior ---
-        const result = jiraIntegration.handleWebhook(board, payload, req.url);
+        const result = jiraIntegration.handleWebhook(board, payload);
 
         if (result.action === 'rejected') {
           json(res, 401, { error: result.error });


### PR DESCRIPTION
## Summary

- Add Jira webhook handler for `comment_created` events with `@karvi` mentions
- Implement HMAC-SHA256 signature verification for webhook security
- Parse mention commands: `@karvi fix`, `@karvi implement`, `@karvi status`, `@karvi plan`
- Create and auto-dispatch tasks from Jira issues when mentioned
- Reply to Jira issues with task status updates

## Changes

### `server/integration-jira.js`
- Added `verifyHmacSignature()` for HMAC-SHA256 webhook verification
- Added `parseMentionCommand()` to extract commands from `@karvi` mentions
- Added `handleMentionWebhook()` to process comment_created events
- Added `buildTaskFromMention()` to create tasks from mention context
- Added comprehensive self-tests for all new functions

### `server/routes/jira.js`
- Updated webhook handler to support HMAC verification (with URL token fallback)
- Added routing for `comment_created` webhook events
- Integrated with Jira API to reply on issues with task status

## Testing

All 21 self-tests pass:
- `verifyHmacSignature`: valid/invalid/missing cases
- `parseMentionCommand`: fix, implement, status, plan, bare mention, no mention
- `handleMentionWebhook`: create_task, status_reply, already_exists, skipped cases

Closes #271