### PR TITLE
feat(storage): implement SQLite backend with node:sqlite (#2)

### DIFF
--- a/server/storage-sqlite.js
+++ b/server/storage-sqlite.js
@@ -104,29 +104,40 @@ function writeBoard(boardPath, board) {
   }
 
   const db = getDb(boardPath);
-  const existing = db.prepare('SELECT version FROM boards WHERE board_key = ?').get(boardPath);
-  const currentVersion = existing ? existing.version : 0;
 
-  if (existing && board._version !== currentVersion) {
-    throw new OptimisticLockError(
-      `Version conflict: expected ${currentVersion}, got ${board._version}`,
-      currentVersion,
-      board._version
-    );
-  }
+  // BEGIN IMMEDIATE 取得 write lock，防止兩個 concurrent writer
+  // 同時讀到相同 version 的 TOCTOU race
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    const existing = db.prepare('SELECT version FROM boards WHERE board_key = ?').get(boardPath);
+    const currentVersion = existing ? existing.version : 0;
 
-  board._version = currentVersion + 1;
-  const now = new Date().toISOString();
-  const data = JSON.stringify(board, null, 2);
+    if (existing && board._version !== currentVersion) {
+      throw new OptimisticLockError(
+        `Version conflict: expected ${currentVersion}, got ${board._version}`,
+        currentVersion,
+        board._version
+      );
+    }
 
-  if (existing) {
-    db.prepare(
-      'UPDATE boards SET data = ?, version = ?, updated_at = ? WHERE board_key = ?'
-    ).run(data, board._version, now, boardPath);
-  } else {
-    db.prepare(
-      'INSERT INTO boards (board_key, data, version, updated_at) VALUES (?, ?, ?, ?)'
-    ).run(boardPath, data, board._version, now);
+    board._version = currentVersion + 1;
+    const now = new Date().toISOString();
+    const data = JSON.stringify(board, null, 2);
+
+    if (existing) {
+      db.prepare(
+        'UPDATE boards SET data = ?, version = ?, updated_at = ? WHERE board_key = ?'
+      ).run(data, board._version, now, boardPath);
+    } else {
+      db.prepare(
+        'INSERT INTO boards (board_key, data, version, updated_at) VALUES (?, ?, ?, ?)'
+      ).run(boardPath, data, board._version, now);
+    }
+
+    db.exec('COMMIT');
+  } catch (e) {
+    db.exec('ROLLBACK');
+    throw e;
   }
 }
 

--- a/server/storage.js
+++ b/server/storage.js
@@ -14,7 +14,7 @@
  *
  * Environment:
  *   KARVI_STORAGE=json    (default) — JSON file backend with atomic writes
- *   KARVI_STORAGE=sqlite  (stub)    — future SQLite backend
+ *   KARVI_STORAGE=sqlite  (SQLite backend)
  */
 
 const BACKEND = (process.env.KARVI_STORAGE || 'json').toLowerCase();

--- a/server/test-storage.js
+++ b/server/test-storage.js
@@ -306,17 +306,16 @@ function test_sqliteOptimisticLock() {
   });
 }
 
-function test_sqliteAppendLog() {
-  test('22. sqlite: appendLog + ensureLogFile', () => {
-    const lp = logPath('sqlite-log.jsonl');
-    storageSqlite.ensureLogFile(lp);
-    storageSqlite.appendLog(lp, { event: 'create', taskId: 'T1', ts: '2026-01-01' });
-    storageSqlite.appendLog(lp, { event: 'update', taskId: 'T2', ts: '2026-01-05' });
-    // verify by reading back
-    storageSqlite.readLogEntries(lp, {}).then(r => {
-      assert.strictEqual(r.length, 2, 'should have 2 entries');
-    });
-  });
+async function test_sqliteAppendLog() {
+  const lp = logPath('sqlite-log.jsonl');
+  storageSqlite.ensureLogFile(lp);
+  storageSqlite.appendLog(lp, { event: 'create', taskId: 'T1', ts: '2026-01-01' });
+  storageSqlite.appendLog(lp, { event: 'update', taskId: 'T2', ts: '2026-01-05' });
+  // verify by reading back
+  const r = await storageSqlite.readLogEntries(lp, {});
+  assert.strictEqual(r.length, 2, 'should have 2 entries');
+  console.log('  PASS  22. sqlite: appendLog + ensureLogFile');
+  passed++;
 }
 
 async function test_sqliteReadLogEntries() {
@@ -583,7 +582,7 @@ async function main() {
     test_sqliteBoardExists();
     test_sqliteReadBoardMissing();
     test_sqliteOptimisticLock();
-    test_sqliteAppendLog();
+    await test_sqliteAppendLog();
     await test_sqliteReadLogEntries();
     test_sqliteReadArchiveEntries();
 


### PR DESCRIPTION
## Summary
- Implement the SQLite storage backend (`server/storage-sqlite.js`) using Node.js 22+ built-in `node:sqlite` (DatabaseSync) — **zero external dependencies**
- Full parity with JSON backend: `readBoard`, `writeBoard`, `appendLog`, `readLogEntries`, `readArchiveEntries`, `boardExists`, `ensureLogFile`
- Optimistic locking with version conflict detection (same semantics as JSON backend)
- WAL journal mode for better read/write concurrency
- DB connection caching per directory (`.karvi.db` file)
- 9 new tests in `test-storage.js` covering all SQLite operations

## Design decisions
- **Single `.karvi.db` file** per directory (derived from boardPath/logPath directory)
- **`logs` table shared** between task logs and archives (differentiated by `log_key`) — avoids redundant table since `appendLog` is the writer for both
- **Indexed columns** (`log_key`, `task_id`, `event`) for fast filtered queries
- **`closeAll()` utility** exported for test cleanup

## How to use
```bash
KARVI_STORAGE=sqlite npm start
```

## Test plan
- [x] `node --check server/storage-sqlite.js` — syntax OK
- [x] `node server/test-storage.js` — 31/31 tests pass (including 9 new SQLite tests)
- [x] `npm test` — integration tests pass
- [x] Optimistic locking conflict detection verified
- [x] readLogEntries filtering (taskId, event, time range) verified
- [x] readArchiveEntries pagination verified

Closes #2 (Stage 1: SQLite backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)