### PR TITLE
feat(cd): GitHub Actions CD pipeline with auto-deploy to VPS (GH-40)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,110 @@
+name: CD - Deploy to VPS
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script_stop: true
+          script: |
+            set -e
+            
+            PROJECT_DIR="${{ secrets.DEPLOY_DIR || '/var/www/karvi' }}"
+            HEALTH_URL="${{ secrets.HEALTH_URL || 'http://localhost:3461/api/health' }}"
+            
+            cd "$PROJECT_DIR"
+            
+            # Store current commit for rollback
+            PREV_COMMIT=$(git rev-parse HEAD)
+            echo "PREV_COMMIT=$PREV_COMMIT" >> $GITHUB_ENV
+            
+            # Pull latest changes
+            git fetch origin main
+            git reset --hard origin/main
+            
+            # Install dependencies (none, but good practice)
+            # npm install --production
+            
+            # Restart service (assumes PM2 or systemd)
+            if command -v pm2 &> /dev/null; then
+              pm2 restart karvi || pm2 start server/server.js --name karvi
+            elif systemctl is-active --quiet karvi; then
+              sudo systemctl restart karvi
+            else
+              # Fallback: kill and restart
+              pkill -f "node server/server.js" || true
+              nohup node server/server.js > /var/log/karvi/app.log 2>&1 &
+            fi
+            
+            # Wait for service to start
+            sleep 5
+
+      - name: Health check
+        id: health_check
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            HEALTH_URL="${{ secrets.HEALTH_URL || 'http://localhost:3461/api/health' }}"
+            MAX_RETRIES=10
+            RETRY_INTERVAL=3
+            
+            for i in $(seq 1 $MAX_RETRIES); do
+              RESPONSE=$(curl -sf "$HEALTH_URL" 2>/dev/null)
+              if [ $? -eq 0 ]; then
+                OK=$(echo "$RESPONSE" | grep -o '"ok"[[:space:]]*:[[:space:]]*true' || true)
+                if [ -n "$OK" ]; then
+                  echo "Health check passed: $RESPONSE"
+                  exit 0
+                fi
+              fi
+              echo "Health check attempt $i/$MAX_RETRIES failed, retrying in ${RETRY_INTERVAL}s..."
+              sleep $RETRY_INTERVAL
+            done
+            
+            echo "Health check failed after $MAX_RETRIES attempts"
+            exit 1
+
+      - name: Rollback on failure
+        if: failure()
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            set -e
+            
+            PROJECT_DIR="${{ secrets.DEPLOY_DIR || '/var/www/karvi' }}"
+            PREV_COMMIT="${{ env.PREV_COMMIT }}"
+            
+            echo "Rolling back to commit: $PREV_COMMIT"
+            
+            cd "$PROJECT_DIR"
+            
+            # Reset to previous commit
+            git reset --hard "$PREV_COMMIT"
+            
+            # Restart service
+            if command -v pm2 &> /dev/null; then
+              pm2 restart karvi
+            elif systemctl is-active --quiet karvi; then
+              sudo systemctl restart karvi
+            else
+              pkill -f "node server/server.js" || true
+              nohup node server/server.js > /var/log/karvi/app.log 2>&1 &
+            fi
+            
+            echo "Rollback complete"

--- a/server/routes/health.js
+++ b/server/routes/health.js
@@ -1,0 +1,18 @@
+/**
+ * routes/health.js — Health check endpoint for CD pipeline
+ *
+ * GET /api/health — returns { ok: true, version, uptime }
+ */
+const bb = require('../blackboard-server');
+const { json } = bb;
+
+const startTime = Date.now();
+
+module.exports = function healthRoutes(req, res, helpers, deps) {
+  if (req.method === 'GET' && req.url === '/api/health') {
+    const { version } = require('../../package.json');
+    const uptime = Math.floor((Date.now() - startTime) / 1000);
+    return json(res, 200, { ok: true, version, uptime });
+  }
+  return false;
+};

--- a/server/server.js
+++ b/server/server.js
@@ -152,6 +152,7 @@ const executionsRoutes = require('./routes/executions');
 const marketplaceRoutes = require('./routes/marketplace');
 const configRoutes = require('./routes/config');
 const reposRoutes = require('./routes/repos');
+const healthRoutes = require('./routes/health');
 
 const postmortem = require('./postmortem');
 
@@ -184,6 +185,7 @@ const routes = [
   executionsRoutes,
   configRoutes,
   reposRoutes,
+  healthRoutes,
 ];
 
 const { json } = bb;


### PR DESCRIPTION
## Summary
- Add `.github/workflows/deploy.yml` for continuous deployment on push to main
- Create `server/routes/health.js` with GET `/api/health` endpoint returning `{ ok: true, version, uptime }`
- Register health route in `server/server.js`

## Features
1. **SSH Deploy**: Uses `appleboy/ssh-action` to connect to VPS via GitHub secrets
2. **Health Check**: After deploy, verifies `/api/health` returns `{ ok: true }` (10 retries, 3s interval)
3. **Auto Rollback**: If health check fails, automatically reverts to previous commit and restarts service
4. **Service Manager Support**: Works with PM2, systemd, or bare Node.js process

## Required GitHub Secrets
- `SSH_HOST` - VPS hostname or IP
- `SSH_USER` - SSH username
- `SSH_KEY` - SSH private key
- `DEPLOY_DIR` (optional) - Project directory (default: `/var/www/karvi`)
- `HEALTH_URL` (optional) - Health check URL (default: `http://localhost:3461/api/health`)

Closes #40