### PR TITLE
fix(storage): add lockfile to prevent TOCTOU race in JSON backend

### DIFF
--- a/server/storage-json.js
+++ b/server/storage-json.js
@@ -55,47 +55,104 @@ function readBoard(boardPath) {
   return board;
 }
 
+/**
+ * 取得 lockfile 以序列化 writeBoard。
+ * 使用 fs.openSync(path, 'wx') 做 atomic create — 跨 process 安全。
+ * 回傳 release function；呼叫者必須在 finally 中 release。
+ *
+ * 若 lockfile 存在超過 STALE_LOCK_MS，視為 stale（持有者 crash），自動清除重試。
+ */
+const STALE_LOCK_MS = 10_000;
+const LOCK_RETRY_MS = 5;
+const LOCK_TIMEOUT_MS = 5_000;
+
+function acquireLock(boardPath) {
+  const lockPath = boardPath + '.lock';
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+
+  while (true) {
+    try {
+      // 'wx' = O_CREAT | O_EXCL — 只在檔案不存在時建立，atomic
+      const fd = fs.openSync(lockPath, 'wx');
+      // 寫入 PID + timestamp 供 stale detection
+      fs.writeSync(fd, `${process.pid}\t${Date.now()}\n`);
+      fs.closeSync(fd);
+      return () => {
+        try { fs.unlinkSync(lockPath); } catch { /* 已被清除 */ }
+      };
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+
+      // lockfile 存在 — 檢查是否 stale
+      try {
+        const stat = fs.statSync(lockPath);
+        if (Date.now() - stat.mtimeMs > STALE_LOCK_MS) {
+          // stale lock — 清除後重試
+          try { fs.unlinkSync(lockPath); } catch { /* 另一個 process 先清了 */ }
+          continue;
+        }
+      } catch {
+        // lockfile 在 stat 前被正常 release，直接重試
+        continue;
+      }
+
+      if (Date.now() >= deadline) {
+        throw new Error(`[storage] lock timeout: could not acquire ${lockPath} within ${LOCK_TIMEOUT_MS}ms`);
+      }
+
+      // busy-wait（同步 API 限制）
+      const waitUntil = Date.now() + LOCK_RETRY_MS;
+      while (Date.now() < waitUntil) { /* spin */ }
+    }
+  }
+}
+
 function writeBoard(boardPath, board) {
   const { OptimisticLockError } = require('./errors');
-  
+
   if (typeof board._version !== 'number') {
     board._version = 0;
   }
-  
-  let currentVersion = 0;
-  let currentBoard = null;
+
+  // 取得 file lock — 確保 read-check-write 是 atomic
+  const releaseLock = acquireLock(boardPath);
   try {
-    currentBoard = JSON.parse(fs.readFileSync(boardPath, 'utf8'));
-    currentVersion = currentBoard._version || 0;
-  } catch (err) {
-    if (err.code !== 'ENOENT') {
-      console.warn('[storage] warning: could not read board for version check:', err.message);
+    let currentVersion = 0;
+    try {
+      const currentBoard = JSON.parse(fs.readFileSync(boardPath, 'utf8'));
+      currentVersion = currentBoard._version || 0;
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        console.warn('[storage] warning: could not read board for version check:', err.message);
+      }
+      currentVersion = 0;
     }
-    currentVersion = 0;
+
+    if (board._version !== currentVersion) {
+      throw new OptimisticLockError(
+        `Version conflict: expected ${currentVersion}, got ${board._version}`,
+        currentVersion,
+        board._version
+      );
+    }
+
+    board._version++;
+
+    ensureEncryptionInitialized(boardPath, board);
+
+    let dataToWrite = board;
+    if (board.meta?.encryption_enabled && enc.isEnabled() && !board.meta.encrypted_at) {
+      dataToWrite = enc.encryptBoard(board);
+    }
+
+    const dir = path.dirname(boardPath);
+    const tmpPath = path.join(dir, `.board-${process.pid}-${Date.now()}.tmp`);
+    const data = JSON.stringify(dataToWrite, null, 2);
+    fs.writeFileSync(tmpPath, data, 'utf8');
+    fs.renameSync(tmpPath, boardPath);
+  } finally {
+    releaseLock();
   }
-  
-  if (board._version !== currentVersion) {
-    throw new OptimisticLockError(
-      `Version conflict: expected ${currentVersion}, got ${board._version}`,
-      currentVersion,
-      board._version
-    );
-  }
-  
-  board._version++;
-  
-  ensureEncryptionInitialized(boardPath, board);
-  
-  let dataToWrite = board;
-  if (board.meta?.encryption_enabled && enc.isEnabled() && !board.meta.encrypted_at) {
-    dataToWrite = enc.encryptBoard(board);
-  }
-  
-  const dir = path.dirname(boardPath);
-  const tmpPath = path.join(dir, `.board-${process.pid}-${Date.now()}.tmp`);
-  const data = JSON.stringify(dataToWrite, null, 2);
-  fs.writeFileSync(tmpPath, data, 'utf8');
-  fs.renameSync(tmpPath, boardPath);
 }
 
 function appendLog(logPath, entry) {

--- a/server/test-storage.js
+++ b/server/test-storage.js
@@ -457,6 +457,47 @@ function test_backwardCompatibility() {
   console.log('✓ Backward compatibility works');
 }
 
+function test_lockfileCleanup() {
+  test('26. writeBoard lockfile is cleaned up after write', () => {
+    const bp = boardPath('lockfile-cleanup.json');
+    storageJson.writeBoard(bp, sampleBoard());
+    // lockfile 應該在 writeBoard 完成後被清除
+    assert.strictEqual(fs.existsSync(bp + '.lock'), false, 'lockfile should be cleaned up');
+  });
+}
+
+function test_lockfileCleanupOnError() {
+  test('27. writeBoard lockfile is cleaned up on version conflict', () => {
+    const bp = boardPath('lockfile-error.json');
+    storageJson.writeBoard(bp, sampleBoard());
+    const stale = { ...sampleBoard(), _version: 999 };
+    try {
+      storageJson.writeBoard(bp, stale);
+    } catch (err) {
+      assert.strictEqual(err.code, 'VERSION_CONFLICT');
+    }
+    // lockfile 應該在 error path 也被清除
+    assert.strictEqual(fs.existsSync(bp + '.lock'), false, 'lockfile should be cleaned up after error');
+  });
+}
+
+function test_staleLockRecovery() {
+  test('28. writeBoard recovers from stale lockfile', () => {
+    const bp = boardPath('stale-lock.json');
+    // 建立 stale lockfile（修改時間設為過去）
+    const lockPath = bp + '.lock';
+    fs.writeFileSync(lockPath, '99999\t0\n');
+    // 手動設定 mtime 為 30 秒前，確保超過 STALE_LOCK_MS
+    const past = new Date(Date.now() - 30_000);
+    fs.utimesSync(lockPath, past, past);
+    // writeBoard 應該能清除 stale lock 並成功寫入
+    storageJson.writeBoard(bp, sampleBoard());
+    const loaded = storageJson.readBoard(bp);
+    assert.strictEqual(loaded._version, 1);
+    assert.strictEqual(fs.existsSync(lockPath), false, 'stale lockfile should be cleaned up');
+  });
+}
+
 // =============================================================================
 // readLogEntries tests
 // =============================================================================
@@ -565,6 +606,9 @@ async function main() {
     test_versionIncrement();
     test_conflictDetection();
     test_backwardCompatibility();
+    test_lockfileCleanup();
+    test_lockfileCleanupOnError();
+    test_staleLockRecovery();
 
     // readLogEntries / readArchiveEntries tests
     console.log('\n--- readLogEntries / readArchiveEntries ---\n');


### PR DESCRIPTION
## Summary
- Fixes the TOCTOU race in `storage-json.js` `writeBoard()` where two processes could read the same `_version` and both pass the optimistic lock check
- Adds a lockfile mechanism (`boardPath + '.lock'`) using `fs.openSync` with `'wx'` (O_CREAT|O_EXCL) flag to serialize the read-check-write sequence across processes
- Includes stale lock detection (10s threshold) with automatic cleanup, and a 5s acquisition timeout
- Zero external dependencies — uses only Node.js built-in `fs` APIs

## Changes
- **`server/storage-json.js`**: Added `acquireLock()` function and wrapped `writeBoard()` internals in lock/unlock
- **`server/test-storage.js`**: Added 3 new tests — lockfile cleanup on success, cleanup on error, stale lock recovery

## Test plan
- [x] All 34 storage tests pass (31 existing + 3 new)
- [x] Full integration test suite (`npm test`) passes
- [x] Syntax checks pass for server.js and management.js

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)