### PR TITLE
fix(signal): use createSignal() in insights.js

### DIFF
--- a/server/management/insights.js
+++ b/server/management/insights.js
@@ -5,6 +5,7 @@
  */
 const bb = require('../blackboard-server');
 const { nowIso, uid } = bb;
+const { createSignal } = require('../signal');
 
 // Schema validation constants (shared with parent)
 const VALID_ACTION_TYPES = ['controls_patch', 'dispatch_hint', 'lesson_write', 'set_pipeline', 'noop'];
@@ -126,9 +127,7 @@ function autoApplyInsights(board) {
     ins.status = 'applied';
     ins.appliedAt = nowIso();
 
-    board.signals.push({
-      id: uid('sig'),
-      ts: nowIso(),
+    board.signals.push(createSignal({
       by: 'gate',
       type: 'insight_applied',
       content: `Auto-applied: ${ins.judgement}`,
@@ -139,7 +138,7 @@ function autoApplyInsights(board) {
         auto: true,
         snapshot: ins.snapshot || null,
       },
-    });
+    }, { uid, nowIso }));
 
     break; // apply one at a time
   }
@@ -200,15 +199,13 @@ function verifyAppliedInsights(board) {
         supersededBy: null,
       });
 
-      board.signals.push({
-        id: uid('sig'),
-        ts: nowIso(),
+      board.signals.push(createSignal({
         by: 'gate',
         type: 'lesson_validated',
         content: `Insight ${ins.id} verified: avg score ${avgBefore} → ${avgAfter}`,
         refs: [ins.id],
         data: { insightId: ins.id, avgBefore, avgAfter, delta },
-      });
+      }, { uid, nowIso }));
 
     } else if (delta <= -5) {
       // Degradation → rollback
@@ -227,15 +224,13 @@ function verifyAppliedInsights(board) {
 
       ins.status = 'rolled_back';
 
-      board.signals.push({
-        id: uid('sig'),
-        ts: nowIso(),
+      board.signals.push(createSignal({
         by: 'gate',
         type: 'insight_rolled_back',
         content: `Rolled back insight ${ins.id}: avg score ${avgBefore} → ${avgAfter} (${delta})`,
         refs: [ins.id],
         data: { insightId: ins.id, avgBefore, avgAfter, delta, restoredControls: ins.snapshot },
-      });
+      }, { uid, nowIso }));
 
     } else {
       // Neutral → wait more; accept after 3x reviews


### PR DESCRIPTION
## Summary
- Replace 3 manual `board.signals.push({...})` calls in `management/insights.js` with `createSignal()` from `signal.js`
- Affected locations: `autoApplyInsights` (insight_applied), `verifyAppliedInsights` (lesson_validated, insight_rolled_back)
- Ensures consistent signal schema with `_attribution` support across all signal emitters

## Test plan
- [x] `node --check server/management/insights.js` passes
- [x] `node --check server/server.js` and `node --check server/management.js` pass
- [x] `npm test` (evolution loop integration tests) passes
- [x] Verified zero remaining manual `board.signals.push({` in insights.js

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)