### PR TITLE
fix(routes): add null-check for push.notifyTaskEvent (GH-470)

### DIFF
--- a/server/routes/tasks-lifecycle.js
+++ b/server/routes/tasks-lifecycle.js
@@ -459,13 +459,15 @@ function tasksLifecycleRoutes(req, res, helpers, deps, internals) {
             .catch(err => console.error('[jira] notify failed:', err.message));
         }
 
-        if (['completed', 'blocked', 'needs_revision', 'approved', 'cancelled'].includes(newStatus)) {
-          push.notifyTaskEvent(PUSH_TOKENS_PATH, task, `task.${newStatus}`)
-            .catch(err => console.error('[push] notify failed:', err.message));
-        }
-        if (allApproved) {
-          push.notifyTaskEvent(PUSH_TOKENS_PATH, task, 'all.approved')
-            .catch(err => console.error('[push] all-approved notify failed:', err.message));
+        if (push && PUSH_TOKENS_PATH) {
+          if (['completed', 'blocked', 'needs_revision', 'approved', 'cancelled'].includes(newStatus)) {
+            push.notifyTaskEvent(PUSH_TOKENS_PATH, task, `task.${newStatus}`)
+              .catch(err => console.error('[push] notify failed:', err.message));
+          }
+          if (allApproved) {
+            push.notifyTaskEvent(PUSH_TOKENS_PATH, task, 'all.approved')
+              .catch(err => console.error('[push] all-approved notify failed:', err.message));
+          }
         }
 
         if (newStatus === 'completed') {


### PR DESCRIPTION
## Summary
- `routes/tasks-lifecycle.js` L462-468 called `push.notifyTaskEvent()` without checking if `push` and `PUSH_TOKENS_PATH` exist, causing a crash when the push module is not loaded
- Added `if (push && PUSH_TOKENS_PATH)` guard to match the existing pattern at L332

## Test plan
- [x] `node --check server/server.js` passes
- [x] `npm test` (evolution loop integration test) passes
- [ ] Verify push notifications still fire when push module is loaded

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)