### PR TITLE
fix(signal): use createSignal() in POST /api/signals route

### DIFF
--- a/server/routes/evolution.js
+++ b/server/routes/evolution.js
@@ -58,15 +58,11 @@ module.exports = function evolutionRoutes(req, res, helpers, deps) {
       }
       const board = helpers.readBoard();
       mgmt.ensureEvolutionFields(board);
-      const signal = {
-        id: helpers.uid('sig'),
-        ts: helpers.nowIso(),
-        by,
-        type,
-        content,
-      };
-      if (payload.refs) signal.refs = payload.refs;
-      if (payload.data) signal.data = payload.data;
+      const signal = createSignal({
+        by, type, content,
+        refs: payload.refs,
+        data: payload.data,
+      }, req, helpers);
       board.signals.push(signal);
       mgmt.trimSignals(board, helpers.signalArchivePath);
 


### PR DESCRIPTION
## Summary
- `POST /api/signals` in `routes/evolution.js` manually assembled signal objects, bypassing `createSignal()` and missing `_attribution` fields (`actor`, `role`)
- Replaced manual construction (lines 61-69) with `createSignal()` call, matching all other routes
- Closes #469

## Test plan
- [x] `node --check server/server.js` passes
- [x] `npm test` (evolution loop integration test) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)