### PR TITLE
test: replace false-positive warnings with strict assertions

### DIFF
--- a/server/test-evolution-loop.js
+++ b/server/test-evolution-loop.js
@@ -202,7 +202,7 @@ async function main() {
     if (anyLesson) {
       ok(`Lesson found (status: ${anyLesson.status}): "${anyLesson.rule}"`);
     } else {
-      console.log('  ⚠️ No lesson yet — verify that verifyAppliedInsights runs on review_result signals');
+      fail('Validated lesson', 'no lesson found — verifyAppliedInsights should run on review_result signals');
     }
   }
 
@@ -225,8 +225,7 @@ async function main() {
   const insights3 = await get('/api/insights');
   const badApplied = insights3.find(i => i.judgement?.includes('降到 30') && i.status === 'applied');
   if (!badApplied) {
-    console.log('  ⚠️ Bad insight not auto-applied (might be blocked by safety valve)');
-    console.log('  Skipping rollback test');
+    fail('Bad insight auto-apply', 'insight not auto-applied — expected status "applied"');
   } else {
     ok(`Applied: ${badApplied.id}, snapshot: ${JSON.stringify(badApplied.snapshot)}`);
 
@@ -247,9 +246,9 @@ async function main() {
     const insights4 = await get('/api/insights');
     const rolledBack = insights4.find(i => i.id === badApplied.id);
     if (rolledBack?.status === 'rolled_back') {
-      ok('Insight rolled back ✅');
+      ok('Insight rolled back');
     } else {
-      console.log(`  ⚠️ Status: ${rolledBack?.status} (expected: rolled_back)`);
+      fail('Insight rollback', `expected status "rolled_back", got "${rolledBack?.status}"`);
     }
 
     // 確認 controls 恢復

--- a/server/test-step-concurrency.js
+++ b/server/test-step-concurrency.js
@@ -196,10 +196,10 @@ async function runTests() {
     const res = await post('/api/tasks/T-CONC-B/steps/dispatch-batch', {});
     if (res.ok && res.results) {
       const planResult = res.results.find(r => r.step_id === 'T-CONC-B:plan');
-      if (planResult && (planResult.status === 'dispatched' || planResult.status === 'skipped')) {
-        ok('Task B plan dispatchable after A completed (status: ' + planResult.status + ')');
+      if (planResult && planResult.status === 'dispatched') {
+        ok('Task B plan dispatched after A completed');
       } else {
-        fail('Concurrency slot freed', 'unexpected plan result: ' + JSON.stringify(planResult));
+        fail('Concurrency slot freed', `expected status "dispatched", got: ${JSON.stringify(planResult)}`);
       }
     } else {
       fail('Batch dispatch after completion', 'unexpected response: ' + JSON.stringify(res).slice(0, 100));

--- a/server/test-step-endpoints.js
+++ b/server/test-step-endpoints.js
@@ -159,7 +159,9 @@ async function runTests() {
     const stepsRes = await get('/api/tasks/T-STEP-TEST/steps');
     const implementStep = (stepsRes.steps || []).find(s => s.step_id === 'T-STEP-TEST:implement');
     
-    if (implementStep && implementStep.state === 'queued') {
+    if (!implementStep) {
+      fail('Implement step exists', 'implement step not found');
+    } else if (implementStep.state === 'queued') {
       // Test invalid transition: queued → succeeded
       const res = await patch('/api/tasks/T-STEP-TEST/steps/T-STEP-TEST:implement', { state: 'succeeded' });
       if (res.status === 400 && res.body.error && res.body.error.includes('Invalid step transition')) {
@@ -168,8 +170,13 @@ async function runTests() {
         fail('PATCH invalid transition', JSON.stringify(res));
       }
     } else {
-      // Step worker already executed the step, skip this test
-      console.log('  \u26A0\uFE0F  Skipped: implement step already executed by step worker');
+      // Step worker already moved step past queued — test the transition it's in
+      const res = await patch('/api/tasks/T-STEP-TEST/steps/T-STEP-TEST:implement', { state: 'queued' });
+      if (res.status === 400 && res.body.error && res.body.error.includes('Invalid step transition')) {
+        ok(`PATCH invalid transition (${implementStep.state} \u2192 queued) returns 400`);
+      } else {
+        fail('PATCH invalid transition', `step in state ${implementStep.state}, got: ${JSON.stringify(res)}`);
+      }
     }
   }
 

--- a/server/test-step-observability.js
+++ b/server/test-step-observability.js
@@ -238,7 +238,7 @@ async function testStepProgressOnDispatch() {
     if (planStep.progress && planStep.progress.dispatched_at) {
       ok('Step progress has dispatched_at after dispatch');
     } else {
-      console.warn('  ⚠ Step transitioned but progress.dispatched_at not set (set by step-worker)');
+      fail('Step progress.dispatched_at', 'step transitioned but progress.dispatched_at not set');
     }
   } else if (planStep.state === 'queued') {
     fail('Step dispatch', 'step still queued after dispatch — expected running or beyond');
@@ -292,7 +292,7 @@ async function testDeadLetterViaStepTransition() {
   if (deadSignals.length >= 1) {
     ok('Dead letter signal emitted');
   } else {
-    console.warn('  ⚠ No step_dead signal found (emitted by step-worker, not transition API)');
+    fail('Dead letter signal', 'no step_dead signal found after step reached dead state');
   }
 }
 

--- a/server/test-wave-dispatch.js
+++ b/server/test-wave-dispatch.js
@@ -177,11 +177,11 @@ async function runTests() {
     const board = await get('/api/tasks');
     const tasks = board.tasks || board.taskPlan?.tasks || [];
     const w1 = tasks.find(t => t.id === 'T-WAVE-1');
-    // wave-1 should proceed past wave filter (may or may not fully dispatch depending on worktree setup)
-    if (w1 && (w1.status === 'in_progress' || w1.status === 'dispatched' || w1.status === 'dispatching')) {
-      ok('Wave 1 task passed wave filter (status: ' + w1.status + ')');
+    // wave-1 should proceed past wave filter — status should be dispatched after POST status
+    if (w1 && w1.status === 'dispatched') {
+      ok('Wave 1 task passed wave filter (status: dispatched)');
     } else {
-      fail('Wave 1 dispatch', `expected dispatched/in_progress, got ${w1?.status}`);
+      fail('Wave 1 dispatch', `expected status "dispatched", got "${w1?.status}"`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Convert 7 test locations across 5 files from `console.warn`/`console.log` (silent pass) to `fail()` (sets `process.exitCode = 1`)
- Tighten loose assertions that accepted multiple status values (e.g., `dispatched || skipped`) to expect the single correct outcome
- For race-condition-prone tests (step-endpoints Test 5), replace skip with an alternative assertion path that always exercises invalid-transition validation

Closes #476

## Test plan
- [x] `npm test` passes (evolution-loop integration test)
- [x] `node --check` on all 5 modified files
- [x] Verified no new warnings appear in test output — all paths now either `ok()` or `fail()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)